### PR TITLE
Avoid unnecessary getBoundingClientRect() calls

### DIFF
--- a/src/internals/text.js
+++ b/src/internals/text.js
@@ -215,7 +215,8 @@ extend(ChartInternal.prototype, {
 		}
 		// show labels regardless of the domain if value is null
 		if (d.value === null && !$$.config.axis_rotated) {
-			let boxHeight = textElement.getBoundingClientRect().height;
+			const boxHeight = textElement.getBoundingClientRect().height;
+
 			if (yPos < boxHeight) {
 				yPos = boxHeight;
 			} else if (yPos > this.height) {

--- a/src/internals/text.js
+++ b/src/internals/text.js
@@ -166,7 +166,6 @@ extend(ChartInternal.prototype, {
 	 */
 	getXForText(points, d, textElement) {
 		const $$ = this;
-		const box = textElement.getBoundingClientRect();
 		let xPos;
 		let padding;
 
@@ -179,7 +178,7 @@ extend(ChartInternal.prototype, {
 		// show labels regardless of the domain if value is null
 		if (d.value === null) {
 			if (xPos > $$.width) {
-				xPos = $$.width - box.width;
+				xPos = $$.width - textElement.getBoundingClientRect().width;
 			} else if (xPos < 0) {
 				xPos = 4;
 			}
@@ -197,15 +196,14 @@ extend(ChartInternal.prototype, {
 	 */
 	getYForText(points, d, textElement) {
 		const $$ = this;
-		const box = textElement.getBoundingClientRect();
 		let yPos;
 
 		if ($$.config.axis_rotated) {
-			yPos = (points[0][0] + points[2][0] + box.height * 0.6) / 2;
+			yPos = (points[0][0] + points[2][0] + textElement.getBoundingClientRect().height * 0.6) / 2;
 		} else {
 			yPos = points[2][1];
 			if (d.value < 0 || (d.value === 0 && !$$.hasPositiveValue)) {
-				yPos += box.height;
+				yPos += textElement.getBoundingClientRect().height;
 				if ($$.isBarType(d) && $$.isSafari()) {
 					yPos -= 3;
 				} else if (!$$.isBarType(d) && $$.isChrome()) {
@@ -217,8 +215,9 @@ extend(ChartInternal.prototype, {
 		}
 		// show labels regardless of the domain if value is null
 		if (d.value === null && !$$.config.axis_rotated) {
-			if (yPos < box.height) {
-				yPos = box.height;
+			let boxHeight = textElement.getBoundingClientRect().height;
+			if (yPos < boxHeight) {
+				yPos = boxHeight;
 			} else if (yPos > this.height) {
 				yPos = this.height - 4;
 			}


### PR DESCRIPTION
May seem like useless micro optimization, but just with this simple change my sizable graph redraw went from 6s to 3s.
Each call to getBoundingClientRect() causes forced layout, avoiding when possible can make big difference.


## Details
Avoids getBoundingClientRect() call until actually needed - paths that don't need it will not call this function
