### PR TITLE
fix(shape, api.zoom): fix zoom for barchart

### DIFF
--- a/spec/api.zoom-spec.js
+++ b/spec/api.zoom-spec.js
@@ -13,7 +13,7 @@ describe("API zoom", function() {
 		chart = util.initChart(chart, args, done);
 	});
 
-	describe("zoom", () => {
+	describe("zoom line chart", () => {
 
 		it("should update args", () => {
 			args = {
@@ -107,6 +107,39 @@ describe("API zoom", function() {
 		});
 
 	});
+
+	describe("zoom bar chart", () => {
+
+		it("should update args", () => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 50, 20, 10, 40, 15, 25],
+						["data3", 150, 120, 110, 140, 115, 125]
+					],
+					type: "bar"
+				},
+				zoom: {
+					enabled: true
+				},
+			};
+
+			expect(true).to.be.ok;
+		});
+
+		it("should be zoomed properly", (done) => {
+			const target = [3, 5];
+			const bars = d3.select(".bb-chart-bars").node();
+			const orgWidth = bars.getBoundingClientRect().width;
+			chart.zoom(target);
+			setTimeout(() => {
+				expect(bars.getBoundingClientRect().width/orgWidth).to.be.above(2.5);
+				done();
+			}, 500)
+		});
+	});
+
 
 	describe("unzoom", () => {
 		it("should load indexed data", () => {

--- a/src/api/api.zoom.js
+++ b/src/api/api.zoom.js
@@ -52,7 +52,8 @@ const zoom = function(domainValue) {
 
 		$$.redraw({
 			withTransition: true,
-			withY: $$.config.zoom_rescale
+			withY: $$.config.zoom_rescale,
+			withDimension: false
 		});
 
 		$$.config.zoom_onzoom.call(this, $$.x.orgDomain());

--- a/src/internals/shape.js
+++ b/src/internals/shape.js
@@ -53,7 +53,7 @@ extend(ChartInternal.prototype, {
 
 	getShapeX(offset, targetsNum, indices, isSub) {
 		const $$ = this;
-		const scale = isSub ? $$.subX : $$.x;
+		const scale = isSub ? $$.subX : ($$.zoomScale ? $$.zoomScale : $$.x);
 
 		return d => {
 			const index = d.id in indices ? indices[d.id] : 0;


### PR DESCRIPTION
## Issue
#16

## Details
chart which is bar type didn't zoom because `zoomScale` is not applied.

## Preferred reviewers
@netil 