### PR TITLE
feat(legend): Implement legend.contents

### DIFF
--- a/spec/assets/util.js
+++ b/spec/assets/util.js
@@ -37,7 +37,7 @@ const generate = args => {
 			args.bindto = "#chart";
 		}
 
-		initDom(args);
+		initDom(args.bindto);
 
 		// when touch param is set, make to be 'touch' input mode
 		if (args.interaction && args.interaction.inputType && args.interaction.inputType.touch) {

--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -297,20 +297,21 @@ describe("LEGEND", () => {
 					}
 				},
 				legend: {
-					template: {
+					contents: {
 						bindto: "#legend",
-						html: "<li style='background-color:{=COLOR}'>{=NAME}</li>"
+						template: "<li style='background-color:{=COLOR}'>{=NAME}</li>"
 					}
 				}
 			};
 		});
 
-		it("check for legend template setting", () => {
+		it("check for legend template setting with template string", () => {
 			const legend = d3.select("#legend");
+			const items = legend.selectAll(`.${CLASS.legendItem}`);
 
 			expect(legend.html()).not.to.be.null;
 
-			legend.selectAll(`.${CLASS.legendItem}`).each(function(v) {
+			items.each(function(v) {
 				const item = d3.select(this);
 
 				expect(item.html()).to.be.equal(v);
@@ -319,6 +320,35 @@ describe("LEGEND", () => {
 				// check for event bind
 				expect(item.on("click")).not.be.null;
 			});
+
+			expect(items.size()).to.be.equal(2);
+		});
+
+		it("set options legend.content.template as function", () => {
+			args.legend.contents.template = function(name, color) {
+				if (name !== "data1") {
+					return `<li style='background-color:${color}'>${name}</li>`;
+				}
+			}
+		});
+
+		it("check for legend template setting with template function callback", () => {
+			const legend = d3.select("#legend");
+			const items = legend.selectAll(`.${CLASS.legendItem}`);
+
+			expect(legend.html()).not.to.be.null;
+
+			items.each(function(v) {
+				const item = d3.select(this);
+
+				expect(item.html()).to.be.equal(v);
+				expect(item.style("background-color")).to.be.equal(chart.color(v));
+
+				// check for event bind
+				expect(item.on("click")).not.be.null;
+			});
+
+			expect(items.size()).to.be.equal(1);
 		});
 	});
 });

--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -5,6 +5,7 @@
 /* eslint-disable */
 /* global describe, beforeEach, it, expect */
 import util from "./assets/util";
+import CLASS from "../src/config/classes";
 
 describe("LEGEND", () => {
 	let chart;
@@ -230,7 +231,7 @@ describe("LEGEND", () => {
 		});
 	});
 
-	describe("custom legend size", () => {
+	describe("custom legend settings", () => {
 		before(() => {
 			args = {
 				data: {
@@ -259,20 +260,10 @@ describe("LEGEND", () => {
 				expect(tileWidth).to.be.equal(args.legend.item.tile.width);
 			});
 		});
-	});
 
-	describe("custom legend padding", () => {
-		before(() => {
-			args = {
-				data: {
-					columns: [
-						["padded1", 30, 200, 100, 400, 150, 250],
-						["padded2", 130, 100, 200, 100, 250, 150]
-					]
-				},
-				legend: {
-					padding: 10
-				}
+		it("set options legend.padding=10", () => {
+			args.legend = {
+				padding: 10
 			};
 		});
 
@@ -287,6 +278,47 @@ describe("LEGEND", () => {
 
 					expect(itemWidth).to.be.equal(expectedWidth);
 				});
+		});
+	});
+
+	describe("set legend using template", () => {
+		before(() => {
+			sandbox("legend-wrapper").innerHTML = "<ul id='legend'></ul>";
+
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 130, 100, 200, 100, 250, 150]
+					],
+					colors: {
+						data1: "rgb(42, 208, 255)",
+						data2: "rgb(250, 113, 113)"
+					}
+				},
+				legend: {
+					template: {
+						bindto: "#legend",
+						html: "<li style='background-color:{=COLOR}'>{=NAME}</li>"
+					}
+				}
+			};
+		});
+
+		it("check for legend template setting", () => {
+			const legend = d3.select("#legend");
+
+			expect(legend.html()).not.to.be.null;
+
+			legend.selectAll(`.${CLASS.legendItem}`).each(function(v) {
+				const item = d3.select(this);
+
+				expect(item.html()).to.be.equal(v);
+				expect(item.style("background-color")).to.be.equal(chart.color(v));
+
+				// check for event bind
+				expect(item.on("click")).not.be.null;
+			});
 		});
 	});
 });

--- a/spec/legend-spec.js
+++ b/spec/legend-spec.js
@@ -299,7 +299,7 @@ describe("LEGEND", () => {
 				legend: {
 					contents: {
 						bindto: "#legend",
-						template: "<li style='background-color:{=COLOR}'>{=NAME}</li>"
+						template: "<li style='background-color:{=COLOR}'>{=TITLE}</li>"
 					}
 				}
 			};
@@ -325,9 +325,9 @@ describe("LEGEND", () => {
 		});
 
 		it("set options legend.content.template as function", () => {
-			args.legend.contents.template = function(name, color) {
-				if (name !== "data1") {
-					return `<li style='background-color:${color}'>${name}</li>`;
+			args.legend.contents.template = function(title, color) {
+				if (title !== "data1") {
+					return `<li style='background-color:${color}'>${title}</li>`;
 				}
 			}
 		});

--- a/src/api/api.show.js
+++ b/src/api/api.show.js
@@ -59,8 +59,7 @@ extend(Chart.prototype, {
 				targets.style("opacity", null).style("opacity", "0");
 			});
 
-		options.withLegend &&
-		$$.hideLegend(targetIds);
+		options.withLegend && $$.hideLegend(targetIds);
 
 		$$.redraw({
 			withUpdateOrgXDomain: true,

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -970,11 +970,11 @@ export default class Options {
 			 * @property {Boolean} [legend.show=true] Show or hide legend.
 			 * @property {Boolean} [legend.hide=false] Hide legend
 			 *  If true given, all legend will be hidden. If string or array given, only the legend that has the id will be hidden.
-			 * @property {String|HTMLElement} [legend.contents.bindto=undefined] Template element to bind to.
-			 * @property {String|Function} [legend.contents.template=undefined] Template html string.<br>
-			 *      If set as string, within template string the 'color' and 'data name' can be placed using template-like syntax string:
+			 * @property {String|HTMLElement} [legend.contents.bindto=undefined] Set CSS selector or element reference to bind legend items.
+			 * @property {String|Function} [legend.contents.template=undefined] Set item's template.<br>
+			 *      If set string value, within template the 'color' and 'title' can be replaced using template-like syntax string:
 			 *      - {=COLOR}: data color value
-			 *      - {=NAME}: data name value
+			 *      - {=TITLE}: data title value
 			 * @property {String} [legend.position=bottom] Change the position of legend.<br>
 			 *  Available values are: `bottom`, `right` and `inset` are supported.
 			 * @property {Object} [legend.inset={anchor: 'top-left',x: 10,y: 0,step: undefined}] Change inset legend attributes.<br>
@@ -1003,13 +1003,13 @@ export default class Options {
 			 *          bindto: "#legend",   // <ul id='legend'></ul>
 			 *
 			 *          // will be as: <li style='background-color:#1f77b4'>data1</li>
-			 *          template: "<li style='background-color:{=COLOR}'>{=NAME}</li>"
+			 *          template: "<li style='background-color:{=COLOR}'>{=TITLE}</li>"
 			 *
 			 *          // or using function
-			 *          template: function(name, color) {
+			 *          template: function(title, color) {
 			 *               // if you want omit some legend, return falsy value
-			 *               if (name !== "data1") {
-			 *                    return "<li style='background-color:"+ color +">"+ name +"</li>";
+			 *               if (title !== "data1") {
+			 *                    return "<li style='background-color:"+ color +">"+ title +"</li>";
 			 *               }
 			 *          }
 			 *      },

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -970,9 +970,9 @@ export default class Options {
 			 * @property {Boolean} [legend.show=true] Show or hide legend.
 			 * @property {Boolean} [legend.hide=false] Hide legend
 			 *  If true given, all legend will be hidden. If string or array given, only the legend that has the id will be hidden.
-			 * @property {String|HTMLElement} [legend.template.bindto=undefined] Template element to bind to.
-			 * @property {String} [legend.template.html=undefined] Template html string.<br>
-			 *      Inside of template string, the 'color' and 'data name' can be placed using template-like syntax string:
+			 * @property {String|HTMLElement} [legend.contents.bindto=undefined] Template element to bind to.
+			 * @property {String|Function} [legend.contents.template=undefined] Template html string.<br>
+			 *      If set as string, within template string the 'color' and 'data name' can be placed using template-like syntax string:
 			 *      - {=COLOR}: data color value
 			 *      - {=NAME}: data name value
 			 * @property {String} [legend.position=bottom] Change the position of legend.<br>
@@ -999,9 +999,19 @@ export default class Options {
 			 *      hide: true,
 			 *      //or hide: "data1"
              *      //or hide: ["data1", "data2"]
-			 *      template: {
+			 *      contents: {
 			 *          bindto: "#legend",   // <ul id='legend'></ul>
-			 *          template: "<li style='background-color:{=COLOR}'>{=NAME}</li>"  // will be as: <li style='background-color:#1f77b4'>data1</li>
+			 *
+			 *          // will be as: <li style='background-color:#1f77b4'>data1</li>
+			 *          template: "<li style='background-color:{=COLOR}'>{=NAME}</li>"
+			 *
+			 *          // or using function
+			 *          template: function(name, color) {
+			 *               // if you want omit some legend, return falsy value
+			 *               if (name !== "data1") {
+			 *                    return "<li style='background-color:"+ color +">"+ name +"</li>";
+			 *               }
+			 *          }
 			 *      },
              *      position: "bottom",  // bottom, right, inset
 			 *      inset: {
@@ -1027,6 +1037,8 @@ export default class Options {
 			 */
 			legend_show: true,
 			legend_hide: false,
+			legend_contents_bindto: undefined,
+			legend_contents_template: undefined,
 			legend_position: "bottom",
 			legend_inset_anchor: "top-left",
 			legend_inset_x: 10,

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -970,6 +970,11 @@ export default class Options {
 			 * @property {Boolean} [legend.show=true] Show or hide legend.
 			 * @property {Boolean} [legend.hide=false] Hide legend
 			 *  If true given, all legend will be hidden. If string or array given, only the legend that has the id will be hidden.
+			 * @property {String|HTMLElement} [legend.template.bindto=undefined] Template element to bind to.
+			 * @property {String} [legend.template.html=undefined] Template html string.<br>
+			 *      Inside of template string, the 'color' and 'data name' can be placed using template-like syntax string:
+			 *      - {=COLOR}: data color value
+			 *      - {=NAME}: data name value
 			 * @property {String} [legend.position=bottom] Change the position of legend.<br>
 			 *  Available values are: `bottom`, `right` and `inset` are supported.
 			 * @property {Object} [legend.inset={anchor: 'top-left',x: 10,y: 0,step: undefined}] Change inset legend attributes.<br>
@@ -997,13 +1002,21 @@ export default class Options {
 			 *          y: 10,
 			 *          step: 2
 			 *      },
-			 *      onclick: function(id) { ... },
-			 *      onover: function(id) { ... },
-			 *      onout: function(id) { ... }
+			 *      item: {
+			 *          onclick: function(id) { ... },
+			 *          onover: function(id) { ... },
+			 *          onout: function(id) { ... }
+			 *      },
+			 *      template: {
+			 *          bindto: "#legend",   // <ul id='legend'></ul>
+			 *          template: "<li style='background-color:{=COLOR}'>{=NAME}</li>"  // will be as: <li style='background-color:#1f77b4'>data1</li>
+			 *      }
 			 *  }
 			 */
 			legend_show: true,
 			legend_hide: false,
+			legend_template_bindto: undefined,
+			legend_template_html: undefined,
 			legend_position: "bottom",
 			legend_inset_anchor: "top-left",
 			legend_inset_x: 10,
@@ -1012,6 +1025,8 @@ export default class Options {
 			legend_item_onclick: undefined,
 			legend_item_onover: undefined,
 			legend_item_onout: undefined,
+
+			// @TODO add api doc
 			legend_equally: false,
 			legend_padding: 0,
 			legend_item_tile_width: 10,

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -553,7 +553,7 @@ export default class ChartInternal {
 		$$.inputType === "touch" && $$.hideTooltip();
 
 		// update legend and transform each g
-		if (withLegend && config.legend_show) {
+		if (withLegend && config.legend_show && !config.legend_template_bindto) {
 			$$.updateLegend($$.mapToIds($$.data.targets), options, transitions);
 		} else if (withDimension) {
 			// need to update dimension (e.g. axis.y.tick.values) because y tick values should change

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -553,7 +553,7 @@ export default class ChartInternal {
 		$$.inputType === "touch" && $$.hideTooltip();
 
 		// update legend and transform each g
-		if (withLegend && config.legend_show && !config.legend_template_bindto) {
+		if (withLegend && config.legend_show && !config.legend_contents_bindto) {
 			$$.updateLegend($$.mapToIds($$.data.targets), options, transitions);
 		} else if (withDimension) {
 			// need to update dimension (e.g. axis.y.tick.values) because y tick values should change

--- a/src/internals/legend.js
+++ b/src/internals/legend.js
@@ -41,6 +41,7 @@ extend(ChartInternal.prototype, {
 
 	/**
 	 * Update legend using template option
+	 * @private
 	 */
 	updateLegendTemplate() {
 		const $$ = this;

--- a/src/internals/legend.js
+++ b/src/internals/legend.js
@@ -59,7 +59,7 @@ extend(ChartInternal.prototype, {
 					template.call($$, v, $$.color(v)) :
 					template
 						.replace(/{=COLOR}/g, $$.color(v))
-						.replace(/{=NAME}/g, v);
+						.replace(/{=TITLE}/g, v);
 
 				if (content) {
 					ids.push(v);

--- a/src/internals/legend.js
+++ b/src/internals/legend.js
@@ -24,7 +24,7 @@ extend(ChartInternal.prototype, {
 		$$.legend = $$.svg.append("g");
 
 		if (config.legend_show) {
-			if (config.legend_template_bindto && config.legend_template_html) {
+			if (config.legend_contents_bindto && config.legend_contents_template) {
 				$$.updateLegendTemplate();
 			} else {
 				$$.legend.attr("transform", $$.getTranslate("legend"));
@@ -45,22 +45,30 @@ extend(ChartInternal.prototype, {
 	updateLegendTemplate() {
 		const $$ = this;
 		const config = $$.config;
-		const wrapper = d3Select(config.legend_template_bindto);
-		const template = config.legend_template_html;
+		const wrapper = d3Select(config.legend_contents_bindto);
+		const template = config.legend_contents_template;
 
 		if (!wrapper.empty()) {
 			const targets = $$.mapToIds($$.data.targets);
+			const ids = [];
 			let html = "";
 
 			targets.forEach(v => {
-				html += template
-					.replace(/{=COLOR}/g, $$.color(v))
-					.replace(/{=NAME}/g, v);
+				const content = isFunction(template) ?
+					template.call($$, v, $$.color(v)) :
+					template
+						.replace(/{=COLOR}/g, $$.color(v))
+						.replace(/{=NAME}/g, v);
+
+				if (content) {
+					ids.push(v);
+					html += content;
+				}
 			});
 
 			const legendItem = wrapper.html(html)
 				.selectAll(function() { return this.childNodes; })
-				.data(targets);
+				.data(ids);
 
 			$$.setLegendItem(legendItem);
 		}


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#58

## Details
<!-- Detailed description of the change/feature -->
- Added updateLegendTemplate() to handle template option
- Split legend item setting to setLegendItem()
- Fixed wrong param call on test helper

```js
legend: {
    template: {
        bindto: "#legend",
        html: "<li style='background-color:{=COLOR}'>{=NAME}</li>"
    }
}
```
with above option, will get the result as:
```html
<ul id="legend">
	<li style="background-color: rgb(42, 208, 255);" class="bb-legend-item bb-legend-item-data1">data1</li>
	...
</ul>
```