### PR TITLE
fix(zoom): Correct zoom in rendering on 0 coordinates.

### DIFF
--- a/spec/api.zoom-spec.js
+++ b/spec/api.zoom-spec.js
@@ -45,6 +45,23 @@ describe("API zoom", function() {
 			expect(Math.round(domain[0])).to.be.equal(target[0]);
 			expect(Math.round(domain[1])).to.be.equal(target[1]);
 		});
+
+		it("should be zoomed and showing focus grid properly when target contained minus value", () => {
+			const target = [-2, 3]; // zoom in cotaining minus value
+
+			chart.zoom(target);
+
+			const zoomScale = chart.internal.zoomScale;
+			
+			// If target contained minus value should not be null
+			expect(zoomScale).to.not.be.null;
+
+			const domain = chart.internal.zoomScale.domain();
+
+			// domain value must be above than target
+			expect(Math.round(domain[0])).to.be.above(target[0]);
+			expect(Math.round(domain[1])).to.be.above(target[1]);
+		});
 	});
 
 	describe("zoom line chart #2", () => {

--- a/src/interactions/zoom.js
+++ b/src/interactions/zoom.js
@@ -103,14 +103,20 @@ extend(ChartInternal.prototype, {
 		// 	.on("dblclick.zoom", null);
 
 		if ($$.zoomScale) {
-			const range1 = $$.zoomScale.domain()[0];
-			const range2 = $$.x.domain()[0];
+			const zoomLeftDomain = $$.zoomScale.domain()[0];
+			const leftDomain = $$.x.domain()[0];
+			const zoomRightDomain = $$.zoomScale.domain()[1];
+			const rightDomain = $$.x.domain()[1];
 			const delta = 0.015;
 
+			// check the zoomed chart is shown between leftDomain(x) and rightDomain(x).
+			const initLeft = zoomLeftDomain <= leftDomain || (zoomLeftDomain - delta) <= leftDomain;
+			const initRight = rightDomain <= zoomRightDomain || rightDomain <= (zoomRightDomain - delta);
+
 			// reset scale when zoom is out as initial
-			if (range1 <= range2 || (range1 - delta) <= range2) {
-				$$.zoomScale = null;
+			if (initLeft && initRight) {
 				$$.xAxis.scale($$.x);
+				$$.zoomScale = null;
 			}
 		}
 


### PR DESCRIPTION
When mouse over the coordinates after zooming in, the guide line has
incorrect coordinates.

## Issue
#169

## Details
```
// reset scale when zoom is out as initial
			if (range1 <= range2 || (range1 - delta) <= range2) {
				$$.zoomScale = null;
				$$.xAxis.scale($$.x);
			}
```
I think there is a problem in this code. 

1, zoom in
2. scroll to 0 (range1 and range2 are same, and zoomScale will be null)
3. mouse over to each coordinate.
4. When axis rendered, zoomScale has already been reset. (I guessed)

I think it's very simple issue, but i didn't understand about that comment (reset scale when zoom is out as initial). If it has some problem about this, please give some more information.

