### PR TITLE
docs(demo): Updated JSON key without quotes in demo

### DIFF
--- a/demo/chart.js
+++ b/demo/chart.js
@@ -165,8 +165,8 @@ var billboardDemo = {
 						.replace(/\[\[/g, "[\r\n\t[")
 						.replace(/\]\]/g, "]\r\n    ]")
 						.replace(/(],)/g, "$1\r\n\t")
-						.replace(/(\"|\d),/g, "$1, ")
-						.replace(/"([^(")"]+)":/g,"$1:");
+						.replace(/(\"|\d),/g, "$1, ");
+						
 						
 					return key === "json" ?
 						str.replace(/{/, "{\r\n\t").replace(/}/, "\r\n    }") : str;
@@ -181,6 +181,7 @@ var billboardDemo = {
 			.replace(/\\t/g, "\t")
 			.replace(/\t{5}/g,"")
 			.replace(/\\r/g, "\r")
+			.replace(/"(\w+)":/g,"$1:")
 			.replace(/\\n(?!T)/g, "\n") +");";
 
 		// markup

--- a/demo/chart.js
+++ b/demo/chart.js
@@ -165,8 +165,9 @@ var billboardDemo = {
 						.replace(/\[\[/g, "[\r\n\t[")
 						.replace(/\]\]/g, "]\r\n    ]")
 						.replace(/(],)/g, "$1\r\n\t")
-						.replace(/(\"|\d),/g, "$1, ");
-
+						.replace(/(\"|\d),/g, "$1, ")
+						.replace(/"([^(")"]+)":/g,"$1:");
+						
 					return key === "json" ?
 						str.replace(/{/, "{\r\n\t").replace(/}/, "\r\n    }") : str;
 				}


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
None

## Details
<!-- Detailed description of the change/feature -->
In the example of the demo page(https://naver.github.io/billboard.js/demo/), I think that double quotes in the key part of JSON hurt readability.
I added <code>.replace(/\"([^(\")"]+)\":/g,"$1:")</code> to JSON.stringify()
This regular expression changes the "key" : "value" to key : "value"