### PR TITLE
fix(internal): Correct evaluating inputType condition

### DIFF
--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -21,10 +21,12 @@ describe("Interface & initialization", () => {
 				]
 			}
 		});
+		const internal = chart.internal;
 
 		expect(chart).not.to.be.null;
 		expect(d3.select(chart.element).classed("bb")).to.be.true;
-		expect(chart.internal.svg.node().tagName).to.be.equal("svg");
+		expect(internal.svg.node().tagName).to.be.equal("svg");
+		expect(internal.convertInputType()).to.be.equal(internal.inputType);
 	});
 
 	it("should resize correctly in flex container", done => {

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -1261,9 +1261,10 @@ export default class ChartInternal {
 		const hasMouse = config.interaction_inputType_mouse ? ("onmouseover" in window) : false;
 		let hasTouch = false;
 
-		if (config.interaction_inputType_touch) {
+		if (notEmpty(config.interaction_inputType_touch)) {
 			// Ref: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/touchevents.js
-			hasTouch = ("ontouchstart" in window) || (window.DocumentTouch && document instanceof window.DocumentTouch);
+			// On IE11 with IE9 emulation mode, ('ontouchstart' in window) is returning true
+			hasTouch = ("ontouchmove" in window) || (window.DocumentTouch && document instanceof window.DocumentTouch);
 		}
 
 		return (hasTouch && "touch") || (hasMouse && "mouse") || null;


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#92

## Details
<!-- Detailed description of the change/feature -->
On IE11 with IE9 emulation mode, ('ontouchstart' in window) is returning true.
Evaluate inputType.touch to not be empty and change condition as ('ontouchmove' in window)
