### PR TITLE
fix(zoom): Correct not to re-scale while zoom is disabled

### DIFF
--- a/spec/api/api.zoom-spec.js
+++ b/spec/api/api.zoom-spec.js
@@ -4,6 +4,7 @@
  */
 /* eslint-disable */
 import util from "../assets/util";
+import CLASS from "../../src/config/classes";
 
 describe("API zoom", function() {
 	let chart;
@@ -144,9 +145,9 @@ describe("API zoom", function() {
 
 		it("should be zoomed properly", done => {
 			const target = [3, 5];
-			const bars = d3.select(".bb-chart-bars").node();
-			const rects = d3.select(".bb-event-rects").node();
-			const rectlist = d3.selectAll(".bb-event-rect").nodes();
+			const bars = d3.select(`.${CLASS.chartBars}`).node();
+			const rects = d3.select(`.${CLASS.eventRects}`).node();
+			const rectlist = d3.selectAll(`.${CLASS.eventRect}`).nodes();
 			const orgWidth = bars.getBoundingClientRect().width;
 			const rectWidth = chart.internal.getEventRectWidth();
 
@@ -197,5 +198,55 @@ describe("API zoom", function() {
 		});
 	});
 
-	// @TODO zoom.enable / max/min/range
+	describe("zoom.enable()", () => {
+		chart = util.generate({
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400, 150, 250]
+				]
+			},
+			zoom: {
+				enabled: true
+			}
+		});
+
+		it("should be disabled & enabled zoom", () => {
+			const main = chart.internal.main;
+			const domain = [1, 2];
+
+			// when disable zoom
+			chart.zoom.enable(false);
+
+			const selector = `.${CLASS.eventRect}-1`;
+			const xValue = +main.select(selector).attr("x");
+			const tickTransform = [];
+
+			main.selectAll(`.${CLASS.axisX} .tick`).each(function() {
+				tickTransform.push(this.getAttribute("transform"));
+			});
+
+			// check the returned domain value
+			chart.zoom(domain).forEach((v, i) => {
+				expect(Math.round(v)).to.not.equal(domain[i]);
+			});
+
+			expect(+main.select(selector).attr("x")).to.be.equal(xValue);
+
+			// check x Axis to not be zoomed
+			main.selectAll(`.${CLASS.axisX} .tick`).each(function(i) {
+				expect(this.getAttribute("transform")).to.be.equal(tickTransform[i]);
+			});
+
+			// when enable zoom
+			chart.zoom.enable(true);
+
+			chart.zoom(domain).forEach((v, i) => {
+				expect(Math.round(v)).to.equal(domain[i]);
+			});
+
+			expect(+main.select(selector).attr("x")).to.below(xValue);
+		});
+	});
+
+	// @TODO zoom.max/min/range
 });

--- a/spec/interactions/zoom-spec.js
+++ b/spec/interactions/zoom-spec.js
@@ -30,7 +30,7 @@ describe("ZOOM", function() {
 					}
 				},
 				zoom: {
-					enable: true
+					enabled: true
 				},
 				subchart: {
 					show: true
@@ -83,7 +83,7 @@ describe("ZOOM", function() {
 					]
 				},
 				zoom: {
-					enable: true
+					enabled: true
 				}
 			};
 		});

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -131,6 +131,8 @@ export default class Options {
 			 * @property {Boolean} [zoom.rescale=false] Enable to rescale after zooming.<br>
 			 *  If true set, y domain will be updated according to the zoomed region.
 			 * @property {Array} [zoom.extent=[1, 10]] Change zoom extent.
+			 * @property {Number} [zoom.x.min] Set x Axis minimum zoom range
+			 * @property {Number} [zoom.x.max] Set x Axis maximum zoom range
 			 * @property {Function} [zoom.onzoom=function(){}] Set callback that is called when the chart is zooming.<br>
 			 *  Specified function receives the zoomed domain.
 			 * @property {Function} [zoom.onzoomstart=function(){}] Set callback that is called when zooming starts.<br>
@@ -142,6 +144,10 @@ export default class Options {
 			 *      enabled: true,
 			 *      rescale: true,
 			 *      extent: [1, 100]  // enable more zooming
+			 *      x: {
+			 *          min: -1,  // set min range
+			 *          max: 10  // set max range
+			 *      },
 			 *      onzoom: function(domain) { ... },
 			 *      onzoomstart: function(event) { ... },
 			 *      onzoomend: function(domain) { ... }


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#272

## Details
<!-- Detailed description of the change/feature -->
- Fix the x Axis re-scaling
- Reinforce zoom APIs and options description
- Updated to return when param is not given for `.zoom.max()`, `.zoom.min()` and `.zoom.range()`