### PR TITLE
fix(all): Re-organize import from d3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 cache:
   yarn: true
   directories:
-    - "node_modules"
+    - $HOME/.npm
 before_script:
   - greenkeeper-lockfile-update
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
 before_script:
   - greenkeeper-lockfile-update
   - npm run lint
+  - ls /home/travis/build/naver/billboard.js/node_modules
 script:
   - npm run coverage
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false  # no need for virtualization.
 before_install:
   - npm install -g npm@5
   - npm install -g greenkeeper-lockfile@1
-  - npm clear cache --force
+  - npm cache clear --force
 install:
   - npm install
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,12 @@ sudo: false  # no need for virtualization.
 before_install:
   - npm install -g npm@5
   - npm install -g greenkeeper-lockfile@1
-  - npm cache clear --force
 install:
   - npm install
+  - npm i d3-dsv d3-request d3-scale d3-time-format d3-zoom
 sudo: required
 addons:
   chrome: stable # install chrome stable.
-cache:
-  yarn: true
-  directories:
-    - $HOME/.npm
 before_script:
   - greenkeeper-lockfile-update
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false  # no need for virtualization.
 before_install:
   - npm install -g npm@5
   - npm install -g greenkeeper-lockfile@1
+  - npm clear cache --force
 install:
   - npm install
 sudo: required

--- a/README.md
+++ b/README.md
@@ -117,7 +117,11 @@ Load billboard.js after D3.js.
 or use importing ESM.
 
 ```js
+// as named import
 import {bb} from "billboard.js";
+
+// or as importing default
+import bb from "billboard.js";
 ```
 
 > **Note**  

--- a/config/uglify.js
+++ b/config/uglify.js
@@ -8,7 +8,9 @@ module.exports = {
 			comments: false
 		},
 		keep_fnames: true,
-		warnings: false
+		warnings: false,
+		dead_code: true,
+		unused: true
 	},
 	sourceMap: true
 };

--- a/config/webpack.config.packaged.js
+++ b/config/webpack.config.packaged.js
@@ -11,14 +11,15 @@ const config = {
 	},
 	devtool: false,
 	module: {
-		rules: [{
-			test: /\.scss$/,
-			use: [{
-				loader: "css-loader"
-			}, {
-				loader: "sass-loader"
-			}]
-		}],
+		rules: [
+			{
+				test: /\.scss$/,
+				use: [
+					{loader: "css-loader"},
+					{loader: "sass-loader"}
+				],
+			}
+		],
 	},
 	plugins: [
 		new UglifyJSPlugin(uglifyConfig),

--- a/config/webpack.config.production.js
+++ b/config/webpack.config.production.js
@@ -7,14 +7,13 @@ const uglifyConfig = require("./uglify");
 const banner = require("./banner");
 const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
+
 const config = {
 	entry: {
 		"billboard": "./src/core.js",
 		"billboard.min": "./src/core.js",
 	},
-	externals: [{
-		"d3": "d3"
-	}],
+	externals: /^d3-[a-z-]+$/i,
 	module: {
 		rules: [
 			{

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,8 +28,7 @@ module.exports = function(config) {
 								[
 									"env",
 									{
-										"loose": true,
-										"modules": false
+										"loose": true
 									}
 								]
 							],

--- a/package-lock.json
+++ b/package-lock.json
@@ -474,6 +474,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "atob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
+      "dev": true
+    },
     "autoprefixer": {
       "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
@@ -2638,6 +2644,23 @@
         "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
       }
     },
+    "clean-css": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
+      "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
     "clean-webpack-plugin": {
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-0.1.16.tgz",
@@ -3572,6 +3595,35 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
+        }
+      }
+    },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -13844,6 +13896,12 @@
         "mimic-fn": "1.1.0"
       }
     },
+    "opener": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "dev": true
+    },
     "opn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
@@ -15146,6 +15204,109 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
+    "purify-css": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/purify-css/-/purify-css-1.2.6.tgz",
+      "integrity": "sha512-FuK4G3s98k+nHJGgheSL6/4gbvc5DeM7IyxI0lW+jvAd6pRRAM5etRtBlPrrPdbJt2iO9kLt/+AGoJ6foJM23A==",
+      "dev": true,
+      "requires": {
+        "clean-css": "4.1.9",
+        "glob": "7.1.2",
+        "rework": "1.0.1",
+        "uglify-js": "3.3.10",
+        "yargs": "8.0.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        }
+      }
+    },
     "q": {
       "version": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
@@ -15587,6 +15748,12 @@
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -15601,6 +15768,24 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true
+        }
+      }
+    },
+    "rework": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
+      "integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "0.3.5",
+        "css": "2.2.1"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
           "dev": true
         }
       }
@@ -16939,6 +17124,18 @@
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
       "dev": true
     },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+      "dev": true,
+      "requires": {
+        "atob": "1.1.3",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.3.0",
+        "urix": "0.1.0"
+      }
+    },
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
@@ -16955,6 +17152,12 @@
           "dev": true
         }
       }
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -18350,6 +18553,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url": {
@@ -20402,6 +20611,208 @@
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
+    "webpack-monitor": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/webpack-monitor/-/webpack-monitor-1.0.14.tgz",
+      "integrity": "sha512-FzydIARAepBv9CXVzJcOU51LQOb9jDGNqYT8ZpoQ3PETIvBoGq3r8nuJJEAgD/E9S6jDwgnSJY+kjkeHw91eLQ==",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "colors": "1.1.2",
+        "express": "4.16.2",
+        "opener": "1.4.3",
+        "purify-css": "1.2.6"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+          "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+          "dev": true,
+          "requires": {
+            "mime-types": "2.1.17",
+            "negotiator": "0.6.1"
+          }
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "etag": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+          "dev": true
+        },
+        "express": {
+          "version": "4.16.2",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+          "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+          "dev": true,
+          "requires": {
+            "accepts": "1.3.4",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
+            "content-type": "1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "finalhandler": "1.1.0",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "2.0.3",
+            "qs": "6.5.1",
+            "range-parser": "1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.1",
+            "serve-static": "1.13.1",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.3.1",
+            "type-is": "1.6.15",
+            "utils-merge": "1.0.1",
+            "vary": "1.1.2"
+          }
+        },
+        "finalhandler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+          "dev": true
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+          "dev": true
+        },
+        "ipaddr.js": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+          "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
+        "proxy-addr": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+          "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+          "dev": true,
+          "requires": {
+            "forwarded": "0.1.2",
+            "ipaddr.js": "1.6.0"
+          }
+        },
+        "send": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          }
+        },
+        "serve-static": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+          "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+          "dev": true,
+          "requires": {
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
+            "send": "0.16.1"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        },
+        "vary": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "main": "dist/billboard.js",
   "scripts": {
     "start": "webpack-dev-server --open",
-    "build": "webpack --env production && webpack --env packaged",
+    "build": "npm run build:production && npm run build:packaged",
+    "build:production": "webpack --env.mode=production",
+    "build:packaged": "webpack --env.mode=packaged",
+    "build:production:monitor": "npm run build:production -- --env.monitor=true",
+    "build:packaged:monitor": "npm run build:packaged -- --env.monitor=true",
     "deploy": "bash ./config/deploy.sh",
     "lint": "eslint src",
     "test": "node --max-old-space-size=2048 ./node_modules/karma/bin/karma start",
@@ -94,6 +98,7 @@
     "webpack-common-shake": "^1.5.3",
     "webpack-dev-server": "^2.7.1",
     "webpack-merge": "^4.1.0",
+    "webpack-monitor": "^1.0.14",
     "webpack-stylish": "^0.1.5",
     "write-file-webpack-plugin": "^4.1.0",
     "xml2js": "^0.4.18"

--- a/src/api/api.export.js
+++ b/src/api/api.export.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {namespaces as d3Namespaces} from "d3";
+import {namespaces as d3Namespaces} from "d3-selection";
 import Chart from "../internals/Chart";
 import {extend, isFunction, toArray, getCssRules} from "../internals/util";
 

--- a/src/api/api.flow.js
+++ b/src/api/api.flow.js
@@ -2,11 +2,9 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {
-	easeLinear as d3EaseLinear,
-	transition as d3Transition,
-	selectAll as d3SelectAll
-} from "d3";
+import {selectAll as d3SelectAll} from "d3-selection";
+import {easeLinear as d3EaseLinear} from "d3-ease";
+import {transition as d3Transition} from "d3-transition";
 import Chart from "../internals/Chart";
 import ChartInternal from "../internals/ChartInternal";
 import {isDefined, isValue, diffDomain, extend} from "../internals/util";

--- a/src/api/api.focus.js
+++ b/src/api/api.focus.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {select as d3Select} from "d3";
+import {select as d3Select} from "d3-selection";
 import Chart from "../internals/Chart";
 import CLASS from "../config/classes";
 import {extend} from "../internals/util";

--- a/src/api/api.selection.js
+++ b/src/api/api.selection.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {select as d3Select} from "d3";
+import {select as d3Select} from "d3-selection";
 import Chart from "../internals/Chart";
 import {isDefined, extend} from "../internals/util";
 import CLASS from "../config/classes";

--- a/src/api/api.zoom.js
+++ b/src/api/api.zoom.js
@@ -4,9 +4,9 @@
  */
 import {
 	min as d3Min,
-	max as d3Max,
-	zoomIdentity as d3ZoomIdentity,
-} from "d3";
+	max as d3Max
+} from "d3-array";
+import {zoomIdentity as d3ZoomIdentity} from "d3-zoom";
 import Chart from "../internals/Chart";
 import {isDefined, isObject, extend} from "../internals/util";
 

--- a/src/axis/Axis.js
+++ b/src/axis/Axis.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {select as d3Select} from "d3";
+import {select as d3Select} from "d3-selection";
 import {isFunction, isString, isValue, isEmpty, isNumber, isObjectType} from "../internals/util";
 import bbAxis from "./bb.axis";
 import CLASS from "../config/classes";

--- a/src/axis/bb.axis.js
+++ b/src/axis/bb.axis.js
@@ -2,10 +2,8 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {
-	scaleLinear as d3ScaleLinear,
-	select as d3Select
-} from "d3";
+import {scaleLinear as d3ScaleLinear} from "d3-scale";
+import {select as d3Select} from "d3-selection";
 import {isArray, toArray, isDefined, isFunction} from "../internals/util";
 
 // Features:

--- a/src/core.js
+++ b/src/core.js
@@ -2,7 +2,6 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import * as d3 from "d3";
 import Chart from "./internals/Chart";
 import ChartInternal from "./internals/ChartInternal";
 import Axis from "./axis/Axis";
@@ -119,4 +118,5 @@ require("./axis/bb.axis.js");
 require("./internals/ua.js");
 require("./api/api.export.js");
 
-export {bb, d3};
+export {bb};
+export default bb;

--- a/src/data/data.convert.js
+++ b/src/data/data.convert.js
@@ -3,13 +3,13 @@
  * billboard.js project is licensed under the MIT license
  */
 import {
-	request as d3Request,
-	keys as d3Keys,
 	csvParse as d3CsvParse,
 	tsvParse as d3TsvParse,
 	csvParseRows as d3CsvParseRows,
 	tsvParseRows as d3TsvParseRows,
-} from "d3";
+} from "d3-dsv";
+import {keys as d3Keys} from "d3-collection";
+import {request as d3Request} from "d3-request";
 import ChartInternal from "../internals/ChartInternal";
 import {isUndefined, isDefined, isValue, notEmpty, extend, isArray} from "../internals/util";
 

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -3,11 +3,11 @@
  * billboard.js project is licensed under the MIT license
  */
 import {
-	set as d3Set,
 	min as d3Min,
 	max as d3Max,
 	merge as d3Merge
-} from "d3";
+} from "d3-array";
+import {set as d3Set} from "d3-collection";
 import CLASS from "../config/classes";
 import ChartInternal from "../internals/ChartInternal";
 import {

--- a/src/interactions/drag.js
+++ b/src/interactions/drag.js
@@ -2,9 +2,7 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {
-	select as d3Select,
-} from "d3"; // interpolate
+import {select as d3Select} from "d3-selection";
 import ChartInternal from "../internals/ChartInternal";
 import CLASS from "../config/classes";
 import {extend, getPathBox} from "../internals/util";

--- a/src/interactions/interaction.js
+++ b/src/interactions/interaction.js
@@ -3,11 +3,11 @@
  * billboard.js project is licensed under the MIT license
  */
 import {
-	drag as d3Drag,
 	mouse as d3Mouse,
 	select as d3Select,
 	event as d3Event
-} from "d3";
+} from "d3-selection";
+import {drag as d3Drag} from "d3-drag";
 import ChartInternal from "../internals/ChartInternal";
 import CLASS from "../config/classes";
 import {extend, isBoolean} from "../internals/util";

--- a/src/interactions/subchart.js
+++ b/src/interactions/subchart.js
@@ -4,10 +4,12 @@
  */
 import {
 	select as d3Select,
-	brushX as d3BrushX,
-	brushY as d3BrushY,
 	event as d3Event
-} from "d3";
+} from "d3-selection";
+import {
+	brushX as d3BrushX,
+	brushY as d3BrushY
+} from "d3-brush";
 import ChartInternal from "../internals/ChartInternal";
 import CLASS from "../config/classes";
 import {extend, isFunction} from "../internals/util";

--- a/src/interactions/zoom.js
+++ b/src/interactions/zoom.js
@@ -3,11 +3,11 @@
  * billboard.js project is licensed under the MIT license
  */
 import {
-	event as d3Event,
-	zoom as d3Zoom,
 	min as d3Min,
 	max as d3Max
-} from "d3";
+} from "d3-array";
+import {event as d3Event} from "d3-selection";
+import {zoom as d3Zoom} from "d3-zoom";
 import ChartInternal from "../internals/ChartInternal";
 import CLASS from "../config/classes";
 import {extend, diffDomain, isFunction} from "../internals/util";

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -6,12 +6,15 @@ import {
 	timeParse as d3TimeParse,
 	timeFormat as d3TimeFormat,
 	utcParse as d3UtcParse,
-	utcFormat as d3UtcFormat,
+	utcFormat as d3UtcFormat
+} from "d3-time-format";
+import {
 	select as d3Select,
-	selectAll as d3SelectAll,
-	extent as d3Extent,
-	transition as d3Transition
-} from "d3";
+	selectAll as d3SelectAll
+} from "d3-selection";
+import {extent as d3Extent} from "d3-array";
+import {transition as d3Transition} from "d3-transition";
+
 import Axis from "../axis/Axis";
 import CLASS from "../config/classes";
 import {addEvent, notEmpty, asHalfPixel, isValue, getOption, isFunction, isDefined, isUndefined, isString, isNumber, isObject} from "./util";

--- a/src/internals/color.js
+++ b/src/internals/color.js
@@ -2,11 +2,11 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
+import {select as d3Select} from "d3-selection";
 import {
-	select as d3Select,
 	scaleOrdinal as d3ScaleOrdinal,
 	schemeCategory10 as d3SchemeCategory10
-} from "d3";
+} from "d3-scale";
 import ChartInternal from "./ChartInternal";
 import {notEmpty, extend, isFunction} from "./util";
 

--- a/src/internals/domain.js
+++ b/src/internals/domain.js
@@ -6,10 +6,9 @@ import {
 	min as d3Min,
 	max as d3Max,
 	extent as d3Extent
-} from "d3"; // selection
+} from "d3-array"; // selection
 import ChartInternal from "./ChartInternal";
 import {extend, isDefined, notEmpty, isValue, isObject, isNumber, diffDomain} from "./util";
-
 
 extend(ChartInternal.prototype, {
 	getYDomainMinMax(targets, type) {

--- a/src/internals/grid.js
+++ b/src/internals/grid.js
@@ -5,7 +5,7 @@
 import {
 	select as d3Select,
 	selectAll as d3SelectAll
-} from "d3";
+} from "d3-selection";
 import ChartInternal from "./ChartInternal";
 import CLASS from "../config/classes";
 import {extend, isArray, isValue} from "./util";

--- a/src/internals/legend.js
+++ b/src/internals/legend.js
@@ -6,7 +6,7 @@ import {
 	select as d3Select,
 	event as d3Event,
 	namespaces as d3Namespaces
-} from "d3";
+} from "d3-selection";
 import ChartInternal from "./ChartInternal";
 import CLASS from "../config/classes";
 import {extend, isDefined, getOption, isEmpty, isFunction, notEmpty} from "./util";

--- a/src/internals/region.js
+++ b/src/internals/region.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {select as d3Select} from "d3"; // selection
+import {select as d3Select} from "d3-selection"; // selection
 import ChartInternal from "./ChartInternal";
 import CLASS from "../config/classes";
 import {isValue, extend} from "./util";

--- a/src/internals/scale.js
+++ b/src/internals/scale.js
@@ -5,7 +5,7 @@
 import {
 	scaleTime as d3ScaleTime,
 	scaleLinear as d3ScaleLinear
-} from "d3";
+} from "d3-scale";
 import ChartInternal from "./ChartInternal";
 import {extend} from "./util";
 

--- a/src/internals/selection.js
+++ b/src/internals/selection.js
@@ -2,10 +2,8 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {
-	select as d3Select,
-	rgb as d3Rgb
-} from "d3";
+import {select as d3Select} from "d3-selection";
+import {rgb as d3Rgb} from "d3-color";
 import ChartInternal from "./ChartInternal";
 import CLASS from "../config/classes";
 import {extend} from "./util";

--- a/src/internals/text.js
+++ b/src/internals/text.js
@@ -5,7 +5,7 @@
 import {
 	select as d3Select,
 	selectAll as d3SelectAll
-} from "d3";
+} from "d3-selection";
 import ChartInternal from "./ChartInternal";
 import CLASS from "../config/classes";
 import {extend} from "./util";

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {mouse as d3Mouse} from "d3";
+import {mouse as d3Mouse} from "d3-selection";
 import ChartInternal from "./ChartInternal";
 import CLASS from "../config/classes";
 import {extend, isValue, sanitise, isString, isFunction} from "./util";

--- a/src/internals/util.js
+++ b/src/internals/util.js
@@ -2,10 +2,8 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {
-	event as d3Event,
-	brushSelection as d3BrushSelection
-} from "d3";
+import {event as d3Event} from "d3-selection";
+import {brushSelection as d3BrushSelection} from "d3-brush";
 import CLASS from "../config/classes";
 
 const isValue = v => v || v === 0;

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -4,11 +4,13 @@
  */
 import {
 	select as d3Select,
+	event as d3Event
+} from "d3-selection";
+import {
 	arc as d3Arc,
-	pie as d3Pie,
-	event as d3Event,
-	interpolate as d3Interpolate
-} from "d3";
+	pie as d3Pie
+} from "d3-shape";
+import {interpolate as d3Interpolate} from "d3-interpolate";
 import ChartInternal from "../internals/ChartInternal";
 import CLASS from "../config/classes";
 import {extend, isFunction} from "../internals/util";

--- a/src/shape/bar.js
+++ b/src/shape/bar.js
@@ -2,9 +2,7 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {
-	mouse as d3Mouse
-} from "d3";
+import {mouse as d3Mouse} from "d3-selection";
 import CLASS from "../config/classes";
 import ChartInternal from "../internals/ChartInternal";
 import {extend, isValue, isNumber, getRectSegList} from "../internals/util";

--- a/src/shape/bubble.js
+++ b/src/shape/bubble.js
@@ -5,7 +5,7 @@
 import {
 	min as d3Min,
 	max as d3Max
-} from "d3";
+} from "d3-array";
 import ChartInternal from "../internals/ChartInternal";
 import {extend, isFunction, isNumber} from "../internals/util";
 

--- a/src/shape/line.js
+++ b/src/shape/line.js
@@ -2,7 +2,14 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {area as d3Area, line as d3Line, mouse as d3Mouse, select as d3Select} from "d3";
+import {
+	area as d3Area,
+	line as d3Line
+} from "d3-shape";
+import {
+	mouse as d3Mouse,
+	select as d3Select
+} from "d3-selection";
 import CLASS from "../config/classes";
 import ChartInternal from "../internals/ChartInternal";
 import {extend, isDefined, isFunction, isUndefined, isValue} from "../internals/util";

--- a/src/shape/point.js
+++ b/src/shape/point.js
@@ -5,7 +5,7 @@
 import {
 	namespaces as d3Namespaces,
 	select as d3Select
-} from "d3";
+} from "d3-selection";
 import ChartInternal from "../internals/ChartInternal";
 import {isFunction, isObjectType, extend, notEmpty} from "../internals/util";
 

--- a/src/shape/shape.js
+++ b/src/shape/shape.js
@@ -20,10 +20,9 @@ import {
 	curveMonotoneX as d3CurveMonotoneX,
 	curveMonotoneY as d3CurveMonotoneY,
 	curveNatural as d3CurveNatural,
-	curveStep as d3CurveStep,
-	select as d3Select
-} from "d3";
-
+	curveStep as d3CurveStep
+} from "d3-shape";
+import {select as d3Select} from "d3-selection";
 import CLASS from "../config/classes";
 import ChartInternal from "../internals/ChartInternal";
 import {isUndefined, extend} from "../internals/util";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,10 +3,11 @@ const path = require("path");
 const webpack = require("webpack");
 const StringReplacePlugin = require("string-replace-webpack-plugin");
 const Stylish = require("webpack-stylish");
+const WebpackMonitor = require("webpack-monitor");
 
 const config = {
 	entry: {
-		"billboard": "./src/core.js",
+		billboard: "./src/core.js",
 	},
 	output: {
 		path: path.resolve(__dirname, "dist"),
@@ -41,5 +42,12 @@ const config = {
 	stats: "minimal"
 };
 
-module.exports = env =>
-	require(`./config/webpack.config.${env || "development"}.js`)(config);
+module.exports = env => {
+	env.monitor && config.plugins.push(
+		new WebpackMonitor({
+			launch: true
+		})
+	);
+
+	return require(`./config/webpack.config.${env.mode || "development"}.js`)(config);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,6 +375,10 @@ atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
+atob@~1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
+
 autoprefixer@^6.3.1:
   version "6.7.7"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
@@ -1569,6 +1573,12 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+clean-css@^4.0.12:
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
+  dependencies:
+    source-map "0.5.x"
+
 clean-webpack-plugin@^0.1.16:
   version "0.1.18"
   resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.18.tgz#2e2173897c76646031bff047c14b9c22c80d8c4a"
@@ -1678,7 +1688,7 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@^1.1.0, colors@~1.1.2:
+colors@^1.1.0, colors@^1.1.2, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -1826,6 +1836,10 @@ content-disposition@0.5.2:
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+
+convert-source-map@^0.3.3:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
 
 convert-source-map@^1.5.0:
   version "1.5.1"
@@ -1990,6 +2004,15 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.1.tgz#73a4c81de85db664d4ee674f7d47085e3b2d55dc"
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.3.0"
+    urix "^0.1.0"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -2986,7 +3009,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-express@^4.16.2:
+express@^4.15.5, express@^4.16.2:
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"
   dependencies:
@@ -5523,6 +5546,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+opener@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
+
 opn@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.2.0.tgz#71fdf934d6827d676cecbea1531f95d354641225"
@@ -6200,6 +6227,16 @@ punycode@1.4.1, punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
+purify-css@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/purify-css/-/purify-css-1.2.6.tgz#56c2b58e4e1134247c6fdc20ba443b51b45e8b2f"
+  dependencies:
+    clean-css "^4.0.12"
+    glob "^7.1.1"
+    rework "^1.0.1"
+    uglify-js "^3.0.6"
+    yargs "^8.0.1"
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -6670,7 +6707,7 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
-resolve-url@^0.2.1:
+resolve-url@^0.2.1, resolve-url@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
@@ -6696,6 +6733,13 @@ resumer@~0.0.0:
   resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
   dependencies:
     through "~2.3.4"
+
+rework@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/rework/-/rework-1.0.1.tgz#30806a841342b54510aa4110850cd48534144aa7"
+  dependencies:
+    convert-source-map "^0.3.3"
+    css "^2.0.0"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -7127,6 +7171,15 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
+source-map-resolve@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.3.1.tgz#610f6122a445b8dd51535a2a71b783dfc1248761"
+  dependencies:
+    atob "~1.1.0"
+    resolve-url "~0.2.1"
+    source-map-url "~0.3.0"
+    urix "~0.1.0"
+
 source-map-resolve@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
@@ -7147,25 +7200,29 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
+source-map-url@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
+
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.1.38, source-map@~0.1.38:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
+
 source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
 source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
-source-map@~0.1.38:
-  version "0.1.43"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
-  dependencies:
-    amdefine ">=0.0.4"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -7689,6 +7746,13 @@ uglify-js@^2.6, uglify-js@^2.8.29:
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
 
+uglify-js@^3.0.6:
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.12.tgz#efd87c16a1f4c674a8a5ede571001ef634dcc883"
+  dependencies:
+    commander "~2.14.1"
+    source-map "~0.6.1"
+
 uglify-js@^3.3.10:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.10.tgz#8e47821d4cf28e14c1826a0078ba0825ed094da8"
@@ -7808,7 +7872,7 @@ upath@1.0.0:
     lodash "3.x"
     underscore.string "2.3.x"
 
-urix@^0.1.0:
+urix@^0.1.0, urix@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
@@ -7979,6 +8043,16 @@ webpack-merge@^4.1.0:
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.1.tgz#f1197a0a973e69c6fbeeb6d658219aa8c0c13555"
   dependencies:
     lodash "^4.17.4"
+
+webpack-monitor@^1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/webpack-monitor/-/webpack-monitor-1.0.14.tgz#dc690810ffc17578097392b820e6b8cb35dcc3c9"
+  dependencies:
+    babel-core "^6.26.0"
+    colors "^1.1.2"
+    express "^4.15.5"
+    opener "^1.4.3"
+    purify-css "^1.2.6"
 
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"
@@ -8217,7 +8291,7 @@ yargs@^7.0.0:
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
 
-yargs@^8.0.2:
+yargs@^8.0.1, yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#285

## Details
<!-- Detailed description of the change/feature -->
- Updated module importing to be from specific module
- Removed exporting d3
- Added webpack-monitor

From this changes, the size of `packaged.min` build was decreased from:
- 390kb to `329kb`