### PR TITLE
fix(axis): improve tick label size calculation (Ref #323)

### DIFF
--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -255,7 +255,7 @@ describe("AXIS", function() {
 
 				it("should split x axis tick text to multiple lines", () => {
 					const ticks = chart.internal.main.select(`.${CLASS.axisX}`).selectAll("g.tick");
-					const expectedTexts = ["very long tick text", "on x axis"];
+					const expectedTexts = ["very long tick", "text on x axis"];
 					const expectedX = "0";
 
 					expect(ticks.size()).to.be.equal(6);
@@ -529,7 +529,8 @@ describe("AXIS", function() {
 					const tspans = tick.selectAll("tspan");
 					const expectedTickTexts = [
 							"this is a very",
-							"long tick text on",
+							"long tick text",
+							"on",
 							"category axis"
 						];
 					const expectedX = "-9";

--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -530,8 +530,8 @@ describe("AXIS", function() {
 					const expectedTickTexts = [
 							"this is a very",
 							"long tick text",
-							"on",
-							"category axis"
+							"on category",
+							"axis"
 						];
 					const expectedX = "-9";
 

--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -535,7 +535,7 @@ describe("AXIS", function() {
 						];
 					const expectedX = "-9";
 
-					expect(tspans.size()).to.be.equal(3);
+					expect(tspans.size()).to.be.equal(4);
 
 					tspans.each(function(d, i) {
 						const tspan = d3.select(this);

--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -462,7 +462,8 @@ describe("AXIS", function() {
 					const expectedTickTexts = [
 							"this is a very",
 							"long tick text",
-							"on category axis"
+							"on category",
+							"axis"
 						];
 					const expectedX = "0";
 

--- a/src/axis/bb.axis.js
+++ b/src/axis/bb.axis.js
@@ -104,7 +104,7 @@ export default function(params = {}) {
 			.text(textFormatted)
 			.each(function(d) {
 				const box = this.getBBox();
-				const text = textFormatted(d);
+				const text = textFormatted(d).toString();
 				const h = box.height;
 				const w = text ? (box.width / text.length) : undefined;
 
@@ -225,7 +225,7 @@ export default function(params = {}) {
 						subtext = text.substr(0, i + 1);
 						textWidth = sizeFor1Char.w * subtext.length;
 
-						// if text width gets over tick width, split by space index or crrent index
+						// if text width gets over tick width, split by space index or current index
 						if (maxWidth < textWidth) {
 							return split(
 								splitted.concat(text.substr(0, spaceIndex || i)),


### PR DESCRIPTION
## Issue
#323 

## Details
Current labels
<img width="863" alt="bildschirmfoto 2018-03-07 um 15 55 54" src="https://user-images.githubusercontent.com/6169269/37100197-a1ace3ae-2222-11e8-8f03-9fd3962e2354.png">


Tick labels after changes
<img width="877" alt="bildschirmfoto 2018-03-07 um 15 56 33" src="https://user-images.githubusercontent.com/6169269/37100181-9984a20c-2222-11e8-814b-2c98b69ccfd1.png">

