### PR TITLE
fix(arc,api): Correct on data representation and handling

### DIFF
--- a/spec/api/api.data-spec.js
+++ b/spec/api/api.data-spec.js
@@ -90,13 +90,27 @@ describe("API data", function() {
 
 	describe("data.values()", () => {
 		it("should return values for specified target", () => {
-			const values = chart.data.values("data1");
-			const expectedValues = [30, 200, 100, 400, 150, 250];
+			const expectedValues1 = [30, 200, 100, 400, 150, 250];
+			const expectedValues2 = [5000, 2000, 1000, 4000, 1500, 2500];
 
-			expect(values.length).to.be.equal(6);
+			// retrieve one data value
+			let values = chart.data.values("data1");
+
+			expect(values.length).to.be.equal(expectedValues1.length);
 
 			values.forEach((v, i) => {
-				expect(v).to.be.equal(expectedValues[i]);
+				expect(v).to.be.equal(expectedValues1[i]);
+			});
+
+			// retrieve two data values
+			values = chart.data.values(["data1", "data2"]);
+
+			expect(values.length).to.be.equal(expectedValues1.length + expectedValues2.length);
+
+			values.forEach((v, i) => {
+				const expected = expectedValues1.concat(expectedValues2);
+
+				expect(v).to.be.equal(expected[i]);
 			});
 		});
 

--- a/spec/internals/arc-spec.js
+++ b/spec/internals/arc-spec.js
@@ -116,6 +116,12 @@ describe("ARC", () => {
 
 			expect(chart.internal.pie.padAngle()()).to.be.equal(value);
 			expect(chart.internal.main.selectAll(`text.${CLASS.chartArcsTitle} tspan`).size()).to.be.equal(3);
+
+			d3.selectAll(`.${CLASS.chartArc} text`).each(function(d) {
+				const value = parseInt(this.textContent);
+
+				expect(value).to.be.equal(d.value);
+			});
 		});
 
 		it("check for padding and innerRadius", () => {
@@ -138,6 +144,12 @@ describe("ARC", () => {
 
 			expect(internal.pie.padAngle()()).to.be.equal(padding * 0.01);
 			expect(internal.innerRadius).to.be.equal(innerRadius);
+
+			d3.selectAll(`.${CLASS.chartArc} text`).each(function(d) {
+				const value = parseInt(this.textContent);
+
+				expect(value).to.be.equal(d.value);
+			});
 		});
 	});
 

--- a/src/api/api.data.js
+++ b/src/api/api.data.js
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import Chart from "../internals/Chart";
-import {extend, isUndefined} from "../internals/util";
+import {extend, isUndefined, isArray} from "../internals/util";
 
 /**
  * Get data loaded in the chart.
@@ -65,8 +65,12 @@ extend(data, {
 		if (targetId) {
 			const targets = this.data(targetId);
 
-			if (targets && targets[0]) {
-				values = targets[0].values.map(d => d.value);
+			if (targets && isArray(targets)) {
+				values = [];
+
+				targets.forEach(v => {
+					values = values.concat(v.values.map(d => d.value));
+				});
 			}
 		}
 

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -5,7 +5,8 @@
 import {
 	min as d3Min,
 	max as d3Max,
-	merge as d3Merge
+	merge as d3Merge,
+	sum as d3Sum
 } from "d3-array";
 import {set as d3Set} from "d3-collection";
 import CLASS from "../config/classes";
@@ -244,6 +245,28 @@ extend(ChartInternal.prototype, {
 		}
 
 		return $$.cache.$minMaxData;
+	},
+
+	/**
+	 * Get total data sum
+	 * @private
+	 * @return {Number}
+	 */
+	getTotalDataSum() {
+		const $$ = this;
+
+		if (!$$.cache.$totalDataSum) {
+			let total = 0;
+
+			$$.data.targets.map(t => t.values)
+				.forEach(v => {
+					total += d3Sum(v, t => t.value);
+				});
+
+			$$.cache.$totalDataSum = total;
+		}
+
+		return $$.cache.$totalDataSum;
 	},
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
 #303, #331

## Details
<!-- Detailed description of the change/feature -->
- Fix % value for pie when uses with `padAngle` or `padding` options
  - When above options are used, make the ratio calculation to be based on the value not from the rendered angle value.
- Fix to return multiple data values as indicated
