### PR TITLE
Tooltip extensions (onShown,onHidden, linked) and reference to all chart instances 

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -12,6 +12,6 @@ Julien Castelain <jcastelain@gmail.com>
 Kim Jong Hyen <fussaep@gmail.com>
 dtc03012 <dtc03012@naver.com>
 Kim Dong Min <dkrahd12@gmail.com>
-Russell Shingleton <russellshomes@aol.com>
+Russell Shingleton <reshingleton@gmail.com>
 Matthias Komarek <matthias@mkomarek.de>
 Tony Quetano <tony.quetano@planttheidea.com>

--- a/demo/chart.js
+++ b/demo/chart.js
@@ -3,7 +3,7 @@ var billboardDemo = {
 	/**
 	 * Initializer
 	 */
-	init: function() {
+	init: function () {
 		this.$wrapper = document.getElementById("wrapper");
 		this.$chartArea = document.querySelector(".chart_area");
 		this.$list = document.querySelector(".sidebar-nav");
@@ -21,12 +21,12 @@ var billboardDemo = {
 		location.href.indexOf("#") > -1 && this.clickHandler(location.href);
 	},
 
-	_bindEvents: function() {
+	_bindEvents: function () {
 		var $list = this.$list;
 		var $wrapper = this.$wrapper;
 		var WIDTH = this.WIDTH;
 
-		var clickHandler = (function(e) {
+		var clickHandler = (function (e) {
 			e.target.tagName === "A" && this.clickHandler(e.target.href)
 		}).bind(this);
 
@@ -34,12 +34,12 @@ var billboardDemo = {
 		$list.addEventListener("click", clickHandler, false);
 		document.querySelector(".chart_area ul").addEventListener("click", clickHandler, false);
 
-		document.getElementById("menu-toggle").addEventListener("click", function(e) {
+		document.getElementById("menu-toggle").addEventListener("click", function (e) {
 			$wrapper.className = $wrapper.className ? "" : "toggled";
 			e.preventDefault();
 		}, false);
 
-		window.addEventListener("resize", function() {
+		window.addEventListener("resize", function () {
 			if (window.innerWidth > WIDTH) {
 				$wrapper && ($wrapper.className = "");
 			}
@@ -51,13 +51,13 @@ var billboardDemo = {
 	 * Create left menu list
 	 * @private
 	 */
-	_createList: function() {
+	_createList: function () {
 		var html = [];
 
-		Object.keys(demos).forEach(function(key) {
+		Object.keys(demos).forEach(function (key) {
 			html.push("<li><h4>" + key + "</h4>");
 
-			Object.keys(demos[key]).forEach(function(v, i) {
+			Object.keys(demos[key]).forEach(function (v, i) {
 				i === 0 && html.push("<ul>");
 				html.push("<li><a href='#" + [key, v].join(".") + "'>" + v + "</a></li>");
 			});
@@ -73,7 +73,7 @@ var billboardDemo = {
 	 * Click handler
 	 * @param {String} type
 	 */
-	clickHandler: function(type) {
+	clickHandler: function (type) {
 		// remove legend
 		var $legend = document.querySelector(".legend");
 		$legend && $legend.parentNode.removeChild($legend);
@@ -113,15 +113,15 @@ var billboardDemo = {
 	 * @param {String} key
 	 * @returns {boolean}
 	 */
-	generate: function(type, key) {
+	generate: function (type, key) {
 		var chartInst = this.chartInst;
 		var typeData = demos[type][key];
 
 		var isArray = Array.isArray(typeData);
 
 		chartInst.length &&
-		chartInst.forEach(function(c, i, array) {
-			c.timer && c.timer.forEach(function(v) {
+		chartInst.forEach(function (c, i, array) {
+			c.timer && c.timer.forEach(function (v) {
 				clearTimeout(v);
 			});
 
@@ -141,7 +141,7 @@ var billboardDemo = {
 		if (isArray) {
 			typeData.forEach((t, i) => {this._addChartInstance(t, key, i + 1, code)})
 		} else {
-			this._addChartInstance(typeData, key)
+			this._addChartInstance(typeData, key, undefined, code)
 		}
 		this.$code.innerHTML = "";
 		code.markup.forEach(t => {this.$code.innerHTML += t})
@@ -150,7 +150,7 @@ var billboardDemo = {
 		hljs.highlightBlock(this.$code);
 		return false;
 	},
-	_addChartInstance: function(type, key, index, code) {
+	_addChartInstance: function (type, key, index, code) {
 
 		if (index) {
 			key += `_${index}`
@@ -187,7 +187,7 @@ var billboardDemo = {
 		this.chartInst.push(inst);
 
 		var codeStr = "var chart = bb.generate(" +
-			JSON.stringify(options, function(k, v) {
+			JSON.stringify(options, function (k, v) {
 				if (typeof v === "function") {
 					return v.toString();
 				} else if (/(columns|rows|json)/.test(k)) {

--- a/demo/chart.js
+++ b/demo/chart.js
@@ -133,17 +133,24 @@ let billboardDemo = {
 		});
 		this.chartInst = [];
 
+		let code = {
+			markup: [],
+			data: []
+		};
 		// generate chart
 		if (isArray) {
-			typeData.forEach((t, i) => {this._addChartInstance(t, key, i + 1, typeData.length)})
+			typeData.forEach((t, i) => {this._addChartInstance(t, key, i + 1, code)})
 		} else {
 			this._addChartInstance(typeData, key)
 		}
-
-
+		this.$code.innerHTML = "";
+		code.markup.forEach(t => {this.$code.innerHTML += t})
+		code.data.forEach(t => {this.$code.innerHTML += t});
+		this.$code.scrollTop = 0;
+		hljs.highlightBlock(this.$code);
 		return false;
 	},
-	_addChartInstance: function(type, key, index, items) {
+	_addChartInstance: function(type, key, index, code) {
 
 		if (index) {
 			key += `_${index}`
@@ -207,21 +214,27 @@ let billboardDemo = {
 				.replace(/\\n(?!T)/g, "\n") + ");";
 
 		// markup
-		this.$code.innerHTML = "&lt;!-- Markup -->\r\n&lt;div id=\"" + key + "\">&lt;/div>\r\n" + (legend ? legend + "\r\n" : "") + "\r\n";
+		if ((index && index === 1) || !index) {
+			code.markup.push("&lt;!-- Markup -->\r\n&lt;div id=\"" + key + "\">&lt;/div>\r\n" + (legend ? legend + "\r\n" : "") + "\r\n");
+		} else if (index && index > 1) {
+			code.markup.push("&lt;div id=\"" + key + "\">&lt;/div>\r\n" + (legend ? legend + "\r\n" : "") + "\r\n");
+		}
 
-		// script
-		this.$code.innerHTML += "// Script\r\n" + codeStr.replace(/"(\[|{)/, "$1").replace(/(\]|})"/, "$1");
-		this.$code.scrollTop = 0;
+		if (index && index > 1) {
+			code.data.push("\r\n\r\n");
+		}
+		// script this.$code.innerHTML
+		code.data.push("// Script\r\n" + codeStr.replace(/"(\[|{)/, "$1").replace(/(\]|})"/, "$1"));
 
 		try {
 			if (func) {
-				this.$code.innerHTML += "\r\n\r\n" + func.toString()
+				code.data.push("\r\n\r\n" + func.toString()
 					.replace(/[\t\s]*function \(chart\) \{[\r\n\t\s]*/, "")
 					.replace(/}$/, "")
 					.replace(/chart.timer = \[[\r\n\t\s]*/, "")
 					.replace(/\t{5}/g, "")
 					.replace(/[\r\n\t\s]*\];?[\r\n\t\s]*$/, "")
-					.replace(/(\d)\),?/g, "$1);");
+					.replace(/(\d)\),?/g, "$1);"));
 
 				func(inst);
 			}
@@ -229,9 +242,8 @@ let billboardDemo = {
 
 		// style
 		if (style) {
-			this.$code.innerHTML += "\r\n\r\n/* Style */\r\n" + style.join("\r\n");
+			code.data.push("\r\n\r\n/* Style */\r\n" + style.join("\r\n"));
 		}
 
-		hljs.highlightBlock(this.$code);
 	}
 };

--- a/demo/chart.js
+++ b/demo/chart.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-let billboardDemo = {
+var billboardDemo = {
 	/**
 	 * Initializer
 	 */
@@ -22,11 +22,11 @@ let billboardDemo = {
 	},
 
 	_bindEvents: function() {
-		let $list = this.$list;
-		let $wrapper = this.$wrapper;
-		let WIDTH = this.WIDTH;
+		var $list = this.$list;
+		var $wrapper = this.$wrapper;
+		var WIDTH = this.WIDTH;
 
-		let clickHandler = (function(e) {
+		var clickHandler = (function(e) {
 			e.target.tagName === "A" && this.clickHandler(e.target.href)
 		}).bind(this);
 
@@ -52,7 +52,7 @@ let billboardDemo = {
 	 * @private
 	 */
 	_createList: function() {
-		let html = [];
+		var html = [];
 
 		Object.keys(demos).forEach(function(key) {
 			html.push("<li><h4>" + key + "</h4>");
@@ -75,7 +75,7 @@ let billboardDemo = {
 	 */
 	clickHandler: function(type) {
 		// remove legend
-		let $legend = document.querySelector(".legend");
+		var $legend = document.querySelector(".legend");
 		$legend && $legend.parentNode.removeChild($legend);
 
 		if (window.innerWidth <= this.WIDTH) {
@@ -97,7 +97,7 @@ let billboardDemo = {
 		this.$codeArea.style.display = "block";
 
 		// remove selected class
-		let $selected = this.$list.querySelector("[class=" + this.selectedClass + "]");
+		var $selected = this.$list.querySelector("[class=" + this.selectedClass + "]");
 		$selected && ($selected.className = $selected.className.replace(this.selectedClass, ""));
 
 		// add selected class
@@ -114,10 +114,10 @@ let billboardDemo = {
 	 * @returns {boolean}
 	 */
 	generate: function(type, key) {
-		let chartInst = this.chartInst;
-		let typeData = demos[type][key];
+		var chartInst = this.chartInst;
+		var typeData = demos[type][key];
 
-		let isArray = Array.isArray(typeData);
+		var isArray = Array.isArray(typeData);
 
 		chartInst.length &&
 		chartInst.forEach(function(c, i, array) {
@@ -133,7 +133,7 @@ let billboardDemo = {
 		});
 		this.chartInst = [];
 
-		let code = {
+		var code = {
 			markup: [],
 			data: []
 		};
@@ -156,8 +156,8 @@ let billboardDemo = {
 			key += `_${index}`
 		}
 
-		let $el = document.getElementById(key);
-		let legend;
+		var $el = document.getElementById(key);
+		var legend;
 		if (!$el) {
 			$el = document.createElement("div");
 			$el.id = key;
@@ -177,21 +177,21 @@ let billboardDemo = {
 			}
 		}
 
-		let func = type.func;
-		let style = type.style;
-		let options = type.options;
+		var func = type.func;
+		var style = type.style;
+		var options = type.options;
 		options.bindto = "#" + key;
 
-		let inst = bb.generate(options);
+		var inst = bb.generate(options);
 		inst.timer = [];
 		this.chartInst.push(inst);
 
-		let codeStr = "let chart = bb.generate(" +
+		var codeStr = "var chart = bb.generate(" +
 			JSON.stringify(options, function(k, v) {
 				if (typeof v === "function") {
 					return v.toString();
 				} else if (/(columns|rows|json)/.test(k)) {
-					let str = JSON.stringify(v)
+					var str = JSON.stringify(v)
 						.replace(/\[\[/g, "[\r\n\t[")
 						.replace(/\]\]/g, "]\r\n    ]")
 						.replace(/(],)/g, "$1\r\n\t")

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -387,16 +387,16 @@ var demos = {
 						['data1', 30],
 						['data2', 120],
 					],
-					type : 'pie',
+					type: 'pie',
 					onclick: function(d, i) {
 						console.log("onclick", d, i);
-					    },
+					},
 					onover: function(d, i) {
 						console.log("onover", d, i);
-					    },
+					},
 					onout: function(d, i) {
 						console.log("onout", d, i);
-					    }
+					}
 				}
 			},
 			func: function(chart) {
@@ -432,13 +432,13 @@ var demos = {
 					type: 'donut',
 					onclick: function(d, i) {
 						console.log("onclick", d, i);
-					    },
+					},
 					onover: function(d, i) {
 						console.log("onover", d, i);
-					    },
+					},
 					onout: function(d, i) {
 						console.log("onout", d, i);
-					    }
+					}
 				},
 				donut: {
 					title: "Iris Petal Width"
@@ -476,10 +476,10 @@ var demos = {
 					type: 'gauge',
 					onclick: function(d, i) {
 						console.log("onclick", d, i);
-					    },
+					},
 					onover: function(d, i) {
 						console.log("onover", d, i);
-					    },
+					},
 					onout: function(d, i) {
 						console.log("onout", d, i);
 					}
@@ -1911,7 +1911,65 @@ var demos = {
 					order: "desc"
 				}
 			}
-		}
+		},
+		LinkedTooltips: [
+			{
+				options: {
+					data: {
+						x: 'x',
+						columns: [
+							['x', '2013-01-01', '2013-01-02', '2013-01-03', '2013-01-04', '2013-01-05', '2013-01-06'],
+							['data', 20, 30, 10, 10, 30, 40],
+						],
+					},
+					axis: {
+						x: {
+							type: 'timeseries',
+							tick: {
+								format: '%Y-%m-%d'
+							}
+						}
+					},
+					tooltip: {
+						linked: true,
+						onShown: function() {
+							alertify.notify('Graph 1 tooltip onShown', 'success', 2);
+						},
+						onHidden: function() {
+							alertify.notify('Graph 1 tooltip onHidden', 'warning', 2);
+						}
+					}
+				}
+			},
+			{
+				options: {
+					data: {
+						x: 'x',
+						columns: [
+							['x', '2013-01-01', '2013-01-02', '2013-01-03', '2013-01-04', '2013-01-05', '2013-01-06'],
+							['data', 10, 50, 100, 50, 50, 50],
+						],
+					},
+					axis: {
+						x: {
+							type: 'timeseries',
+							tick: {
+								format: '%Y-%m-%d'
+							}
+						}
+					},
+					tooltip: {
+						linked: true,
+						onShown: function() {
+							alertify.notify('Graph 2 tooltip onShown', 'success', 2);
+						},
+						onHidden: function() {
+							alertify.notify('Graph 2 tooltip onHidden', 'warning', 2);
+						}
+					}
+				}
+			}
+		]
 	},
 	ChartOptions: {
 		ChartSize: {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1932,11 +1932,17 @@ var demos = {
 					},
 					tooltip: {
 						linked: true,
-						onShown: function() {
-							alertify.notify('Graph 1 tooltip onShown', 'success', 2);
+						onshow: function() {
+							alertify.notify('Graph 1 tooltip BEFORE show', 'warning', 2);
 						},
-						onHidden: function() {
-							alertify.notify('Graph 1 tooltip onHidden', 'warning', 2);
+						onhide: function() {
+							alertify.notify('Graph 1 tooltip BEFORE hide', 'warning', 2);
+						},
+						onshown: function() {
+							alertify.notify('Graph 1 tooltip AFTER show', 'success', 2);
+						},
+						onhidden: function() {
+							alertify.notify('Graph 1 tooltip AFTER hide', 'error', 2);
 						}
 					}
 				}
@@ -1960,11 +1966,17 @@ var demos = {
 					},
 					tooltip: {
 						linked: true,
-						onShown: function() {
-							alertify.notify('Graph 2 tooltip onShown', 'success', 2);
+						onshow: function() {
+							alertify.notify('Graph 2 tooltip BEFORE show', 'warning', 2);
 						},
-						onHidden: function() {
-							alertify.notify('Graph 2 tooltip onHidden', 'warning', 2);
+						onhide: function() {
+							alertify.notify('Graph 2 tooltip BEFORE hide', 'warning', 2);
+						},
+						onshown: function() {
+							alertify.notify('Graph 2 tooltip AFTER show', 'success', 2);
+						},
+						onhidden: function() {
+							alertify.notify('Graph 2 tooltip AFTER hide', 'error', 2);
 						}
 					}
 				}

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,9 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fallback/1.1.8/fallback.min.js"></script>
 
+    <!--Alertify is an unobtrusive customizable JavaScript notification system.-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/AlertifyJS/1.11.0/alertify.min.js"></script>
+
     <!-- jQuery -->
     <script src="//code.jquery.com/jquery-1.12.4.min.js"></script>
 
@@ -20,6 +23,7 @@
     <!-- Bootstrap Core CSS -->
     <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
 
+
     <!-- Custom CSS -->
     <link href="./simple-sidebar.css" rel="stylesheet">
 
@@ -27,7 +31,7 @@
     <link rel="stylesheet" type="text/css" href="./tomorrow.css" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/languages/javascript.min.js"></script>
-
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/AlertifyJS/1.11.0/css/alertify.min.css" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/d3/4.9.0/d3.js"></script>
     <script>
         !function() {

--- a/demo/linked-tooltips.html
+++ b/demo/linked-tooltips.html
@@ -53,7 +53,6 @@
         bindto: '#bbChart1',
         data: {
             x: 'x',
-            //  xFormat: '%Y%m%d', // 'xFormat' can be used as custom format of 'x'
             columns: [
                 ['x', '2013-01-01', '2013-01-02', '2013-01-03', '2013-01-04', '2013-01-05', '2013-01-06'],
                 ['data', 10, 50, 100, 50, 50, 50],
@@ -82,7 +81,6 @@
         bindto: '#bbChart2',
         data: {
             x: 'x',
-            //  xFormat: '%Y%m%d', // 'xFormat' can be used as custom format of 'x'
             columns: [
                 ['x', '2013-01-01', '2013-01-02', '2013-01-03', '2013-01-04', '2013-01-05', '2013-01-06'],
                 ['data', 20, 30, 10, 10, 30, 40],
@@ -95,7 +93,8 @@
                 tick: {
                     format: '%Y-%m-%d'
                 }
-            }
+            },
+            rotated: true
         },
         tooltip: {
             linked:true,

--- a/demo/linked-tooltips.html
+++ b/demo/linked-tooltips.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport"
+          content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no">
+    <meta name="description"
+          content="Examples of billboard.js. billboard.js is a re-usable easy interface JavaScript chart library, based on D3 v4+.">
+    <meta name="author" content="NAVER Corp.">
+    <title>billboard.js - examples</title>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fallback/1.1.8/fallback.min.js"></script>
+
+    <!-- jQuery -->
+    <script src="//code.jquery.com/jquery-1.12.4.min.js"></script>
+
+    <!-- Bootstrap Core JavaScript -->
+    <script src="//cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+
+    <!-- Bootstrap Core CSS -->
+    <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link href="./simple-sidebar.css" rel="stylesheet">
+
+    <link rel="stylesheet" type="text/css"
+          href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/default.min.css"/>
+    <link rel="stylesheet" type="text/css" href="./tomorrow.css"/>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/languages/javascript.min.js"></script>
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3/4.9.0/d3.js"></script>
+
+    <link href="../dist/billboard.css" rel="stylesheet">
+    <script src="../dist/billboard.js"></script>
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+    <script src="//oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+    <script src="//oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+    <![endif]-->
+</head>
+<body>
+
+<div id="bbChart1" style="width: 80%; margin: 0 auto;margin-top: 20px;"></div>
+<div id="bbChart2" style="width: 80%; margin: 0 auto;margin-top: 20px;"></div>
+
+<script>
+    var chart1 = bb.generate({
+        bindto: '#bbChart1',
+        data: {
+            x: 'x',
+            //  xFormat: '%Y%m%d', // 'xFormat' can be used as custom format of 'x'
+            columns: [
+                ['x', '2013-01-01', '2013-01-02', '2013-01-03', '2013-01-04', '2013-01-05', '2013-01-06'],
+                ['data', 10, 50, 100, 50, 50, 50],
+            ],
+        },
+
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%Y-%m-%d'
+                }
+            }
+        },
+        tooltip: {
+            linked:true,
+            onShown: function() {
+                console.log('shown')
+            },
+            onHidden: function() {
+                console.log('hidden')
+            }
+        }
+    });
+    var chart2 = bb.generate({
+        bindto: '#bbChart2',
+        data: {
+            x: 'x',
+            //  xFormat: '%Y%m%d', // 'xFormat' can be used as custom format of 'x'
+            columns: [
+                ['x', '2013-01-01', '2013-01-02', '2013-01-03', '2013-01-04', '2013-01-05', '2013-01-06'],
+                ['data', 20, 30, 10, 10, 30, 40],
+            ],
+        },
+
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%Y-%m-%d'
+                }
+            }
+        },
+        tooltip: {
+            linked:true,
+            onShown: function() {
+                console.log('shown')
+            },
+            onHidden: function() {
+                console.log('hidden')
+            }
+        }
+    })
+
+</script>
+</body>
+</html>

--- a/demo/linked-tooltips.html
+++ b/demo/linked-tooltips.html
@@ -100,7 +100,7 @@
         tooltip: {
             linked:true,
             onShown: function() {
-                console.log('shown')
+                console.log('shown', this.x, this.position)
             },
             onHidden: function() {
                 console.log('hidden')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "billboard.js",
-  "version": "1.2.0-snapshot",
+  "version": "1.3.0-snapshot",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2029,6 +2029,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2052,7 +2053,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -3918,7 +3919,7 @@
     "eslint-module-utils": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -4596,6 +4597,910 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
@@ -5063,7 +5968,7 @@
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -5299,7 +6204,7 @@
     "husky": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
       "dev": true,
       "requires": {
         "is-ci": "1.1.0",
@@ -6077,7 +6982,7 @@
     "istanbul-instrumenter-loader": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-3.0.0.tgz",
-      "integrity": "sha512-alLSEFX06ApU75sm5oWcaVNaiss/bgMRiWTct3g0P0ZZTKjR+6QiCcuVOKDI1kWJgwHEnIXsv/dWm783kPpmtw==",
+      "integrity": "sha1-n1U5I7IjYLrJXmF6q6Aa3R99sLI=",
       "dev": true,
       "requires": {
         "convert-source-map": "1.5.1",
@@ -6384,7 +7289,7 @@
     "karma-chrome-launcher": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
-      "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
+      "integrity": "sha1-zxudBxNswY/iOTJ9JGVMPbw2is8=",
       "dev": true,
       "requires": {
         "fs-access": "1.0.1",
@@ -8202,6 +9107,3937 @@
         "prepend-http": "1.0.4",
         "query-string": "4.3.4",
         "sort-keys": "1.1.2"
+      }
+    },
+    "npm": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-5.7.1.tgz",
+      "integrity": "sha512-r1grvv6mcEt+nlMzMWPc5n/z5q8NNuBWj0TGFp1PBSFCl6ubnAoUGBsucYsnZYT7MOJn0ha1ptEjmdBoAdJ+SA==",
+      "requires": {
+        "JSONStream": "1.3.2",
+        "abbrev": "1.1.1",
+        "ansi-regex": "3.0.0",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.0",
+        "bluebird": "3.5.1",
+        "cacache": "10.0.4",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cli-table2": "0.2.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.5.0",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.1",
+        "is-cidr": "1.0.0",
+        "lazy-property": "1.0.0",
+        "libcipm": "1.3.3",
+        "libnpx": "9.7.1",
+        "lockfile": "1.0.3",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.1",
+        "meant": "1.0.1",
+        "mississippi": "2.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.0.0",
+        "npm-package-arg": "6.0.0",
+        "npm-packlist": "1.1.10",
+        "npm-profile": "3.0.1",
+        "npm-registry-client": "8.5.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.5",
+        "pacote": "7.3.3",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.11.0",
+        "query-string": "5.1.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.12",
+        "read-package-tree": "5.1.6",
+        "readable-stream": "2.3.4",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.83.0",
+        "retry": "0.10.1",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.1",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "5.2.4",
+        "strip-ansi": "4.0.0",
+        "tar": "4.3.3",
+        "text-table": "0.2.0",
+        "uid-number": "0.0.6",
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.3.0",
+        "uuid": "3.2.1",
+        "validate-npm-package-license": "3.0.1",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.0",
+        "worker-farm": "1.5.2",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.1.0"
+      },
+      "dependencies": {
+        "JSONStream": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansicolors": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "ansistyles": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bin-links": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "fs-write-stream-atomic": "1.0.10",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "slide": "1.1.6"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "cacache": {
+          "version": "10.0.4",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.1",
+            "mississippi": "2.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "5.2.4",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "call-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "cli-table2": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "colors": "1.1.2",
+            "lodash": "3.10.1",
+            "string-width": "1.0.2"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cmd-shim": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "columnify": {
+          "version": "1.5.4",
+          "bundled": true,
+          "requires": {
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                }
+              }
+            },
+            "wcwidth": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "defaults": "1.0.3"
+              },
+              "dependencies": {
+                "defaults": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "clone": "1.0.2"
+                  },
+                  "dependencies": {
+                    "clone": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "config-chain": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
+          },
+          "dependencies": {
+            "proto-list": {
+              "version": "1.2.4",
+              "bundled": true
+            }
+          }
+        },
+        "debuglog": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "asap": "2.0.5",
+            "wrappy": "1.0.2"
+          },
+          "dependencies": {
+            "asap": {
+              "version": "2.0.5",
+              "bundled": true
+            }
+          }
+        },
+        "editor": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "find-npm-prefix": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "fs-vacuum": {
+          "version": "1.2.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.4"
+          }
+        },
+        "gentle-fs": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true
+        },
+        "iferr": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "init-package-json": {
+          "version": "1.10.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "npm-package-arg": "5.1.2",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.12",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.1",
+            "validate-npm-package-name": "3.0.0"
+          },
+          "dependencies": {
+            "npm-package-arg": {
+              "version": "5.1.2",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.5",
+                "semver": "5.5.0",
+                "validate-npm-package-name": "3.0.0"
+              }
+            },
+            "promzard": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "read": "1.0.7"
+              }
+            }
+          }
+        },
+        "is-cidr": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "cidr-regex": "1.0.6"
+          },
+          "dependencies": {
+            "cidr-regex": {
+              "version": "1.0.6",
+              "bundled": true
+            }
+          }
+        },
+        "lazy-property": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "libcipm": {
+          "version": "1.3.3",
+          "bundled": true,
+          "requires": {
+            "bin-links": "1.1.0",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.0",
+            "npm-lifecycle": "2.0.0",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.0.0",
+            "pacote": "7.3.3",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.12",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.5.2"
+          },
+          "dependencies": {
+            "find-npm-prefix": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "lock-verify": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "npm-package-arg": "5.1.2",
+                "semver": "5.5.0"
+              },
+              "dependencies": {
+                "npm-package-arg": {
+                  "version": "5.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "hosted-git-info": "2.5.0",
+                    "osenv": "0.1.5",
+                    "semver": "5.5.0",
+                    "validate-npm-package-name": "3.0.0"
+                  }
+                }
+              }
+            },
+            "npm-logical-tree": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "protoduck": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
+              "dependencies": {
+                "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "worker-farm": {
+              "version": "1.5.2",
+              "bundled": true,
+              "requires": {
+                "errno": "0.1.7",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "errno": {
+                  "version": "0.1.7",
+                  "bundled": true,
+                  "requires": {
+                    "prr": "1.0.1"
+                  },
+                  "dependencies": {
+                    "prr": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "libnpx": {
+          "version": "9.7.1",
+          "bundled": true,
+          "requires": {
+            "dotenv": "4.0.0",
+            "npm-package-arg": "5.1.2",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.1",
+            "update-notifier": "2.3.0",
+            "which": "1.3.0",
+            "y18n": "3.2.1",
+            "yargs": "8.0.2"
+          },
+          "dependencies": {
+            "dotenv": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "npm-package-arg": {
+              "version": "5.1.2",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.5",
+                "semver": "5.5.0",
+                "validate-npm-package-name": "3.0.0"
+              }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "8.0.2",
+              "bundled": true,
+              "requires": {
+                "camelcase": "4.1.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "read-pkg-up": "2.0.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "7.0.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wrap-ansi": "2.1.0"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "wrap-ansi": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
+                      }
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "get-caller-file": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "os-locale": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.7.0",
+                    "lcid": "1.0.0",
+                    "mem": "1.1.0"
+                  },
+                  "dependencies": {
+                    "execa": {
+                      "version": "0.7.0",
+                      "bundled": true,
+                      "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                      },
+                      "dependencies": {
+                        "cross-spawn": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.1.1",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "npm-run-path": {
+                          "version": "2.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "p-finally": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true
+                        },
+                        "strip-eof": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "lcid": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "invert-kv": "1.0.0"
+                      },
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "mem": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "mimic-fn": "1.1.0"
+                      },
+                      "dependencies": {
+                        "mimic-fn": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "2.1.0",
+                    "read-pkg": "2.0.0"
+                  },
+                  "dependencies": {
+                    "find-up": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "locate-path": "2.0.0"
+                      },
+                      "dependencies": {
+                        "locate-path": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "p-locate": "2.0.0",
+                            "path-exists": "3.0.0"
+                          },
+                          "dependencies": {
+                            "p-locate": {
+                              "version": "2.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "p-limit": "1.1.0"
+                              },
+                              "dependencies": {
+                                "p-limit": {
+                                  "version": "1.1.0",
+                                  "bundled": true
+                                }
+                              }
+                            },
+                            "path-exists": {
+                              "version": "3.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "read-pkg": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
+                      },
+                      "dependencies": {
+                        "load-json-file": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "graceful-fs": "4.1.11",
+                            "parse-json": "2.2.0",
+                            "pify": "2.3.0",
+                            "strip-bom": "3.0.0"
+                          },
+                          "dependencies": {
+                            "parse-json": {
+                              "version": "2.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "error-ex": "1.3.1"
+                              },
+                              "dependencies": {
+                                "error-ex": {
+                                  "version": "1.3.1",
+                                  "bundled": true,
+                                  "requires": {
+                                    "is-arrayish": "0.2.1"
+                                  },
+                                  "dependencies": {
+                                    "is-arrayish": {
+                                      "version": "0.2.1",
+                                      "bundled": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "bundled": true
+                            },
+                            "strip-bom": {
+                              "version": "3.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "path-type": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "pify": "2.3.0"
+                          },
+                          "dependencies": {
+                            "pify": {
+                              "version": "2.3.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-directory": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "which-module": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "yargs-parser": {
+                  "version": "7.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "4.1.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "lockfile": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "lodash._baseindexof": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "lodash._baseuniq": {
+          "version": "4.6.0",
+          "bundled": true,
+          "requires": {
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
+          },
+          "dependencies": {
+            "lodash._createset": {
+              "version": "4.0.3",
+              "bundled": true
+            },
+            "lodash._root": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash._cacheindexof": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "lodash._createcache": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "3.9.1"
+          }
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "bundled": true
+        },
+        "lodash.union": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.without": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          },
+          "dependencies": {
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            }
+          }
+        },
+        "meant": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "mississippi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "duplexify": "3.5.3",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "2.0.1",
+            "pumpify": "1.4.0",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "duplexify": {
+              "version": "3.5.3",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "end-of-stream": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0"
+              }
+            },
+            "flush-write-stream": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4"
+              }
+            },
+            "from2": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4"
+              }
+            },
+            "parallel-transform": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4"
+              },
+              "dependencies": {
+                "cyclist": {
+                  "version": "0.2.2",
+                  "bundled": true
+                }
+              }
+            },
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            },
+            "pumpify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "duplexify": "3.5.3",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
+              }
+            },
+            "stream-each": {
+              "version": "1.2.2",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "through2": {
+              "version": "2.0.3",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.4",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
+          },
+          "dependencies": {
+            "copy-concurrently": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
+              }
+            },
+            "run-queue": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0"
+              }
+            }
+          }
+        },
+        "node-gyp": {
+          "version": "3.6.2",
+          "bundled": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.5",
+            "request": "2.83.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.1"
+              }
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              },
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.1"
+          },
+          "dependencies": {
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              },
+              "dependencies": {
+                "builtin-modules": {
+                  "version": "1.1.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "npm-cache-filename": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "npm-install-checks": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "semver": "5.5.0"
+          }
+        },
+        "npm-lifecycle": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.6.2",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
+            "uid-number": "0.0.6",
+            "umask": "1.1.0",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "byline": {
+              "version": "5.0.0",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "npm-package-arg": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
+          }
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          },
+          "dependencies": {
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "minimatch": "3.0.4"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "npm-profile": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "make-fetch-happen": "2.6.0"
+          },
+          "dependencies": {
+            "make-fetch-happen": {
+              "version": "2.6.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.3.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.0.0",
+                "https-proxy-agent": "2.1.1",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.2.4"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "2.6.9"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "2.6.9",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "mississippi": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "concat-stream": "1.6.0",
+                    "duplexify": "3.5.3",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
+                  },
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.6.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4",
+                        "typedarray": "0.0.6"
+                      },
+                      "dependencies": {
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "duplexify": {
+                      "version": "3.5.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "end-of-stream": {
+                      "version": "1.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
+                    },
+                    "flush-write-stream": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4"
+                      }
+                    },
+                    "from2": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4"
+                      }
+                    },
+                    "parallel-transform": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4"
+                      },
+                      "dependencies": {
+                        "cyclist": {
+                          "version": "0.2.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "pump": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                      }
+                    },
+                    "pumpify": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "duplexify": "3.5.3",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
+                      },
+                      "dependencies": {
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        }
+                      }
+                    },
+                    "stream-each": {
+                      "version": "1.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "2.3.4",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "xtend": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.1"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.19"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.19",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "json-parse-better-errors": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "npm-registry-client": {
+          "version": "8.5.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "5.1.2",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.83.0",
+            "retry": "0.10.1",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "4.1.6"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "npm-package-arg": {
+              "version": "5.1.2",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.5",
+                "semver": "5.5.0",
+                "validate-npm-package-name": "3.0.0"
+              }
+            },
+            "ssri": {
+              "version": "4.1.6",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            }
+          }
+        },
+        "npm-user-validate": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          },
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.4"
+              },
+              "dependencies": {
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              },
+              "dependencies": {
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                }
+              }
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "opener": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          },
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "pacote": {
+          "version": "7.3.3",
+          "bundled": true,
+          "requires": {
+            "bluebird": "3.5.1",
+            "cacache": "10.0.4",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.1",
+            "make-fetch-happen": "2.6.0",
+            "minimatch": "3.0.4",
+            "mississippi": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.0.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "safe-buffer": "5.1.1",
+            "semver": "5.5.0",
+            "ssri": "5.2.4",
+            "tar": "4.3.3",
+            "unique-filename": "1.1.0",
+            "which": "1.3.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "make-fetch-happen": {
+              "version": "2.6.0",
+              "bundled": true,
+              "requires": {
+                "agentkeepalive": "3.3.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.0.0",
+                "https-proxy-agent": "2.1.1",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.2.4"
+              },
+              "dependencies": {
+                "agentkeepalive": {
+                  "version": "3.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "humanize-ms": "1.2.1"
+                  },
+                  "dependencies": {
+                    "humanize-ms": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-cache-semantics": {
+                  "version": "3.8.1",
+                  "bundled": true
+                },
+                "http-proxy-agent": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "2.6.9"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "2.6.9",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "https-proxy-agent": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "mississippi": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "concat-stream": "1.6.0",
+                    "duplexify": "3.5.3",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
+                  },
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.6.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4",
+                        "typedarray": "0.0.6"
+                      },
+                      "dependencies": {
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "duplexify": {
+                      "version": "3.5.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "end-of-stream": {
+                      "version": "1.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
+                    },
+                    "flush-write-stream": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4"
+                      }
+                    },
+                    "from2": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4"
+                      }
+                    },
+                    "parallel-transform": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.4"
+                      },
+                      "dependencies": {
+                        "cyclist": {
+                          "version": "0.2.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "pump": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
+                      }
+                    },
+                    "pumpify": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "duplexify": "3.5.3",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
+                      },
+                      "dependencies": {
+                        "pump": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
+                          }
+                        }
+                      }
+                    },
+                    "stream-each": {
+                      "version": "1.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
+                      },
+                      "dependencies": {
+                        "stream-shift": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "2.3.4",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "xtend": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-fetch-npm": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.1"
+                  },
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "bundled": true,
+                      "requires": {
+                        "iconv-lite": "0.4.19"
+                      },
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.19",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "json-parse-better-errors": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "socks-proxy-agent": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
+                  },
+                  "dependencies": {
+                    "agent-base": {
+                      "version": "4.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "es6-promisify": "5.0.0"
+                      },
+                      "dependencies": {
+                        "es6-promisify": {
+                          "version": "5.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promise": "4.2.4"
+                          },
+                          "dependencies": {
+                            "es6-promise": {
+                              "version": "4.2.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks": {
+                      "version": "1.1.10",
+                      "bundled": true,
+                      "requires": {
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
+                      },
+                      "dependencies": {
+                        "ip": {
+                          "version": "1.1.5",
+                          "bundled": true
+                        },
+                        "smart-buffer": {
+                          "version": "1.1.15",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "mississippi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "concat-stream": "1.6.0",
+                "duplexify": "3.5.3",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.2",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "2.0.1",
+                "pumpify": "1.4.0",
+                "stream-each": "1.2.2",
+                "through2": "2.0.3"
+              },
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.4",
+                    "typedarray": "0.0.6"
+                  },
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "bundled": true
+                    }
+                  }
+                },
+                "duplexify": {
+                  "version": "3.5.3",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.4",
+                    "stream-shift": "1.0.0"
+                  },
+                  "dependencies": {
+                    "stream-shift": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "end-of-stream": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.4.0"
+                  }
+                },
+                "flush-write-stream": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.4"
+                  }
+                },
+                "from2": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.4"
+                  }
+                },
+                "parallel-transform": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "cyclist": "0.2.2",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.4"
+                  },
+                  "dependencies": {
+                    "cyclist": {
+                      "version": "0.2.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "pump": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
+                  }
+                },
+                "pumpify": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "duplexify": "3.5.3",
+                    "inherits": "2.0.3",
+                    "pump": "2.0.1"
+                  }
+                },
+                "stream-each": {
+                  "version": "1.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.1",
+                    "stream-shift": "1.0.0"
+                  },
+                  "dependencies": {
+                    "stream-shift": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "2.3.4",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "xtend": {
+                      "version": "4.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "npm-pick-manifest": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "npm-package-arg": "6.0.0",
+                "semver": "5.5.0"
+              }
+            },
+            "promise-retry": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "err-code": "1.1.2",
+                "retry": "0.10.1"
+              },
+              "dependencies": {
+                "err-code": {
+                  "version": "1.1.2",
+                  "bundled": true
+                }
+              }
+            },
+            "protoduck": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "genfun": "4.0.1"
+              },
+              "dependencies": {
+                "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "qrcode-terminal": {
+          "version": "0.11.0",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "0.2.0",
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          },
+          "dependencies": {
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "strict-uri-encode": {
+              "version": "1.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "qw": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "read": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "mute-stream": "0.0.7"
+          },
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            }
+          }
+        },
+        "read-cmd-shim": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "read-installed": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.12",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
+          },
+          "dependencies": {
+            "util-extend": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "2.0.12",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.1",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
+          },
+          "dependencies": {
+            "json-parse-better-errors": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "slash": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "read-package-tree": {
+          "version": "5.1.6",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.12",
+            "readdir-scoped-modules": "1.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.4",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
+          }
+        },
+        "request": {
+          "version": "2.83.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              },
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "bundled": true
+                }
+              }
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.2.3",
+                "har-schema": "2.0.0"
+              },
+              "dependencies": {
+                "ajv": {
+                  "version": "5.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "fast-deep-equal": "1.0.0",
+                    "json-schema-traverse": "0.3.1",
+                    "json-stable-stringify": "1.0.1"
+                  },
+                  "dependencies": {
+                    "co": {
+                      "version": "4.6.0",
+                      "bundled": true
+                    },
+                    "fast-deep-equal": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "json-schema-traverse": {
+                      "version": "0.3.1",
+                      "bundled": true
+                    },
+                    "json-stable-stringify": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "jsonify": "0.0.0"
+                      },
+                      "dependencies": {
+                        "jsonify": {
+                          "version": "0.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.0.2"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "4.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.0"
+                  }
+                },
+                "cryptiles": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "5.2.0"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "5.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "4.2.0"
+                      }
+                    }
+                  }
+                },
+                "hoek": {
+                  "version": "4.2.0",
+                  "bundled": true
+                },
+                "sntp": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.0"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "jsprim": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.3.0",
+                    "json-schema": "0.2.3",
+                    "verror": "1.10.0"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.3.0",
+                      "bundled": true
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "bundled": true
+                    },
+                    "verror": {
+                      "version": "1.10.0",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.13.1",
+                  "bundled": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "bundled": true
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.5"
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.30.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.30.0",
+                  "bundled": true
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            }
+          }
+        },
+        "retry": {
+          "version": "0.10.1",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "sha": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.4"
+          }
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "sorted-object": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "sorted-union-stream": {
+          "version": "2.1.3",
+          "bundled": true,
+          "requires": {
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
+          },
+          "dependencies": {
+            "from2": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.14",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "stream-iterate": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.3.4",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "ssri": {
+          "version": "5.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "tar": {
+          "version": "4.3.3",
+          "bundled": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.1",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "yallist": "3.0.2"
+          },
+          "dependencies": {
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.2.1"
+              }
+            },
+            "minipass": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "yallist": "3.0.2"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.2.1"
+              }
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "umask": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "unique-filename": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "unique-slug": "2.0.0"
+          },
+          "dependencies": {
+            "unique-slug": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "imurmurhash": "0.1.4"
+              }
+            }
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "1.2.1",
+            "chalk": "2.1.0",
+            "configstore": "3.1.1",
+            "import-lazy": "2.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          },
+          "dependencies": {
+            "boxen": {
+              "version": "1.2.1",
+              "bundled": true,
+              "requires": {
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "2.1.0",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "1.0.0"
+              },
+              "dependencies": {
+                "ansi-align": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "2.1.1"
+                  }
+                },
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cli-boxes": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "term-size": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.7.0"
+                  },
+                  "dependencies": {
+                    "execa": {
+                      "version": "0.7.0",
+                      "bundled": true,
+                      "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                      },
+                      "dependencies": {
+                        "cross-spawn": {
+                          "version": "5.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.1.1",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
+                          },
+                          "dependencies": {
+                            "shebang-command": {
+                              "version": "1.2.0",
+                              "bundled": true,
+                              "requires": {
+                                "shebang-regex": "1.0.0"
+                              },
+                              "dependencies": {
+                                "shebang-regex": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "npm-run-path": {
+                          "version": "2.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-key": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "p-finally": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "signal-exit": {
+                          "version": "3.0.2",
+                          "bundled": true
+                        },
+                        "strip-eof": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "widest-line": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.1.1"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "4.4.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  },
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "1.9.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-name": "1.1.3"
+                      },
+                      "dependencies": {
+                        "color-name": {
+                          "version": "1.1.3",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "4.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "configstore": {
+              "version": "3.1.1",
+              "bundled": true,
+              "requires": {
+                "dot-prop": "4.2.0",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.0.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.1.0",
+                "xdg-basedir": "3.0.0"
+              },
+              "dependencies": {
+                "dot-prop": {
+                  "version": "4.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-obj": "1.0.1"
+                  },
+                  "dependencies": {
+                    "is-obj": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "make-dir": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "pify": "2.3.0"
+                  },
+                  "dependencies": {
+                    "pify": {
+                      "version": "2.3.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "unique-string": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "crypto-random-string": "1.0.0"
+                  },
+                  "dependencies": {
+                    "crypto-random-string": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "import-lazy": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "is-installed-globally": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "global-dirs": "0.1.0",
+                "is-path-inside": "1.0.0"
+              },
+              "dependencies": {
+                "global-dirs": {
+                  "version": "0.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "ini": "1.3.5"
+                  }
+                },
+                "is-path-inside": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "path-is-inside": "1.0.2"
+                  }
+                }
+              }
+            },
+            "is-npm": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "latest-version": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "package-json": "4.0.1"
+              },
+              "dependencies": {
+                "package-json": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "got": "6.7.1",
+                    "registry-auth-token": "3.3.1",
+                    "registry-url": "3.1.0",
+                    "semver": "5.5.0"
+                  },
+                  "dependencies": {
+                    "got": {
+                      "version": "6.7.1",
+                      "bundled": true,
+                      "requires": {
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.0",
+                        "safe-buffer": "5.1.1",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
+                      },
+                      "dependencies": {
+                        "create-error-class": {
+                          "version": "3.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "capture-stack-trace": "1.0.0"
+                          },
+                          "dependencies": {
+                            "capture-stack-trace": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexer3": {
+                          "version": "0.1.4",
+                          "bundled": true
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-redirect": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "is-retry-allowed": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "timed-out": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        },
+                        "unzip-response": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "url-parse-lax": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "prepend-http": "1.0.4"
+                          },
+                          "dependencies": {
+                            "prepend-http": {
+                              "version": "1.0.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-auth-token": {
+                      "version": "3.3.1",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.2.1",
+                        "safe-buffer": "5.1.1"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.2",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.4.2",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.2.1"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.2",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.4.2",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "semver": "5.5.0"
+              }
+            },
+            "xdg-basedir": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          },
+          "dependencies": {
+            "spdx-correct": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "spdx-license-ids": "1.2.2"
+              },
+              "dependencies": {
+                "spdx-license-ids": {
+                  "version": "1.2.2",
+                  "bundled": true
+                }
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "1.0.4",
+              "bundled": true
+            }
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "builtins": "1.0.3"
+          },
+          "dependencies": {
+            "builtins": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          },
+          "dependencies": {
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "worker-farm": {
+          "version": "1.5.2",
+          "bundled": true,
+          "requires": {
+            "errno": "0.1.7",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "errno": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "prr": "1.0.1"
+              },
+              "dependencies": {
+                "prr": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write-file-atomic": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -10478,7 +15314,7 @@
     "sass-loader": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
-      "integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
+      "integrity": "sha1-6dXmwfFV+qMqSybXqbcQfCJeQPk=",
       "dev": true,
       "requires": {
         "async": "2.6.0",
@@ -12702,7 +17538,7 @@
     "webpack-common-shake": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/webpack-common-shake/-/webpack-common-shake-1.5.3.tgz",
-      "integrity": "sha512-TsOcSYbE6eSmVudGvlo4LRTggJ26Q/U0jEA0yaRP+L4nKknAjCq2Ps5A6me2pcWvKgronALMcEkAcKQNbRCy2w==",
+      "integrity": "sha1-0jkyGnGi1RKOX7hxYWzjQNtym7s=",
       "dev": true,
       "requires": {
         "acorn": "5.5.0",
@@ -12836,6 +17672,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.1",
+            "fsevents": "1.1.3",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -13475,7 +18312,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "d3": "^4.13.0"
+    "d3": "^4.13.0",
+    "npm": "^5.7.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/spec/internals/tooltip-spec.js
+++ b/spec/internals/tooltip-spec.js
@@ -6,8 +6,9 @@
 import util from "../assets/util";
 import CLASS from "../../src/config/classes";
 
-describe("TOOLTIP", function () {
+describe("TOOLTIP", function() {
 	let chart;
+	let chart2;
 	let args = {
 		data: {
 			columns: [
@@ -18,6 +19,17 @@ describe("TOOLTIP", function () {
 		},
 		tooltip: {}
 	};
+	let args2 = {
+		data: {
+			columns: [
+				["data1-2", 30, 200, 100, 400, 150, 250],
+				["data2-2", 50, 20, 10, 40, 15, 25],
+				["data3-2", 150, 120, 110, 140, 115, 125]
+			]
+		},
+		tooltip: {}
+	};
+
 
 	// check for the tooltip's ordering
 	const checkTooltip = (chart, expected) => {
@@ -42,9 +54,76 @@ describe("TOOLTIP", function () {
 
 	};
 
+	// check for the tooltip's ordering
+	const checkLinkedTooltip = (hoverChart, checkChart, expected) => {
+		const eventRect = hoverChart.internal.main
+			.select(`.${CLASS.eventRect}-2`)
+			.node();
+
+		util.fireEvent(eventRect, "mousemove", {
+			clientX: 100,
+			clientY: 100
+		}, hoverChart);
+
+		const tooltips = d3.select(checkChart.element)
+			.selectAll(`.${CLASS.tooltip} tr`)
+			.nodes();
+
+		if (expected) {
+			for (let i = 1, el; (el = tooltips[i]); i++) {
+				expect(el.className).to.be.equal(expected[i - 1]);
+			}
+		}
+	};
+
+
+	const checkCallback = (chart, callback, expected) => {
+		let test = 0;
+
+		args.tooltip[callback] = function() {
+			test++;
+			expect(test).to.be.equal(expected);
+		};
+
+		const eventRect = chart.internal.main
+			.select(`.${CLASS.eventRect}-2`)
+			.node();
+
+		util.fireEvent(eventRect, "mousemove", {
+			clientX: 100,
+			clientY: 100
+		}, chart);
+	};
 
 	beforeEach(() => {
 		chart = util.generate(args);
+	});
+
+	describe("Tooltip callbacks", () => {
+		after(() => {
+			args.tooltip.onshow = () => {};
+			args.tooltip.onshown = () => {};
+			args.tooltip.onhide = () => {};
+			args.tooltip.onhidden = () => {};
+		});
+
+		it("chart tooltip.onhide function should be called", () => {
+			checkCallback(chart, 'onhide', 3);
+		});
+
+		it("chart tooltip.onhidden function should be called", () => {
+			checkCallback(chart, 'onhidden', 4);
+		});
+
+		it("chart tooltip.onshow function should be called", () => {
+			checkCallback(chart, 'onshow', 1);
+		});
+
+		it("chart tooltip.onshown function should be called", () => {
+			checkCallback(chart, 'onshown', 2);
+		});
+
+
 	});
 
 	describe("tooltip position", () => {
@@ -138,6 +217,19 @@ describe("TOOLTIP", function () {
 	});
 
 	describe("tooltip order", () => {
+		after(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 50, 20, 10, 40, 15, 25],
+						["data3", 150, 120, 110, 140, 115, 125]
+					]
+				},
+				tooltip: {}
+			};
+		});
+
 		it("should sort values in data display order", () => {
 			checkTooltip(chart, [
 				"bb-tooltip-name-data1",
@@ -210,7 +302,7 @@ describe("TOOLTIP", function () {
 		});
 
 		it("set options tooltip.order=function", () => {
-			args.tooltip.order = sinon.spy(function (a, b) {
+			args.tooltip.order = sinon.spy(function(a, b) {
 				return a.value - b.value;
 			});
 		});
@@ -218,6 +310,229 @@ describe("TOOLTIP", function () {
 		it("data.order function should be called", () => {
 			checkTooltip(chart);
 			expect(args.tooltip.order.called).to.be.true;
+		});
+	});
+
+	describe("linked tooltip positionFunction", () => {
+		const topExpected = 37;
+		const leftExpected = 79;
+
+		const topExpected2 = 37;
+		const leftExpected2 = 79;
+
+		before(() => {
+			chart2 = util.generate(args2);
+
+			args.tooltip = {
+				position: (data, width, height, element) => {
+					expect(data.length).to.be.equal(args.data.columns.length);
+					expect(data[0].index).to.be.equal(2);
+					expect(data[0].value).to.be.equal(100);
+					expect(data[0].id).to.be.equal("data1");
+					expect(width).to.be.above(0);
+					expect(height).to.be.above(0);
+					expect(element).to.be.equal(chart.internal.main.select(`.${CLASS.eventRect}-2`).node());
+
+					return {
+						top: topExpected,
+						left: leftExpected
+					};
+				}
+			};
+
+			args2.tooltip = {
+				position: (data, width, height, element) => {
+					expect(data.length).to.be.equal(args.data.columns.length);
+					expect(data[0].index).to.be.equal(2);
+					expect(data[0].value).to.be.equal(100);
+					expect(data[0].id).to.be.equal("data1");
+					expect(width).to.be.above(0);
+					expect(height).to.be.above(0);
+					expect(element).to.be.equal(chart.internal.main.select(`.${CLASS.eventRect}-2`).node());
+
+					return {
+						top: topExpected2,
+						left: leftExpected2
+					};
+				}
+			};
+		});
+
+		it("linked tooltips should be set to the coordinate where the function returned", () => {
+			const eventRect = chart.internal.main.select(`.${CLASS.eventRect}-2`).node();
+			// const eventRect2 = chart2.internal.main.select(`.${CLASS.eventRect}-2`).node();
+
+			util.fireEvent(eventRect, "mousemove", {
+				clientX: 100,
+				clientY: 100
+			}, chart);
+			const tooltipContainer1 = d3.select(chart.element).select(`.${CLASS.tooltipContainer}`);
+			const top1 = Math.floor(+tooltipContainer1.style("top").replace(/px/, ""));
+			const left1 = Math.floor(+tooltipContainer1.style("left").replace(/px/, ""));
+
+			expect(top1).to.be.equal(topExpected);
+			expect(left1).to.be.equal(leftExpected);
+
+			const tooltipContainer2 = d3.select(chart2.element).select(`.${CLASS.tooltipContainer}`);
+			const top2 = Math.floor(+tooltipContainer2.style("top").replace(/px/, ""));
+			const left2 = Math.floor(+tooltipContainer2.style("left").replace(/px/, ""));
+
+			expect(top2).to.be.equal(topExpected2);
+			expect(left2).to.be.equal(leftExpected2);
+
+			expect(top2).to.be.equal(topExpected);
+			expect(left2).to.be.equal(leftExpected);
+		});
+	});
+
+	describe("linked tooltip order", () => {
+		before(() => {
+
+		});
+
+		it("chart 1 should sort values in data display order", () => {
+			checkLinkedTooltip(chart, chart2, [
+				"bb-tooltip-name-data1",
+				"bb-tooltip-name-data2",
+				"bb-tooltip-name-data3"
+			]);
+		});
+
+		it("chart 2 should sort values in data display order", () => {
+			checkLinkedTooltip(chart2, chart, [
+				"bb-tooltip-name-data1-2",
+				"bb-tooltip-name-data2-2",
+				"bb-tooltip-name-data3-2"
+			]);
+		});
+
+		it("linked charts set options tooltip.order=asc", () => {
+			args.tooltip.order = "asc";
+			args2.tooltip.order = args.tooltip.order;
+		});
+
+		it("chart 1 should sort values ascending order", () => {
+			checkLinkedTooltip(chart, chart2, [
+				"bb-tooltip-name-data2",
+				"bb-tooltip-name-data1",
+				"bb-tooltip-name-data3"
+			]);
+		});
+
+		it("chart 2 should sort values ascending order", () => {
+			checkLinkedTooltip(chart2, chart, [
+				"bb-tooltip-name-data2-2",
+				"bb-tooltip-name-data1-2",
+				"bb-tooltip-name-data3-2"
+			]);
+		});
+
+		it("linked charts set options tooltip.order=desc", () => {
+			args.tooltip.order = "desc";
+			args2.tooltip.order = args.tooltip.order;
+		});
+
+		it("chart 1 set options tooltip.order=desc", () => {
+			checkLinkedTooltip(chart, chart2, [
+				"bb-tooltip-name-data3",
+				"bb-tooltip-name-data1",
+				"bb-tooltip-name-data2"
+			]);
+		});
+
+		it("chart 2 set options tooltip.order=desc", () => {
+			checkLinkedTooltip(chart2, chart, [
+				"bb-tooltip-name-data3-2",
+				"bb-tooltip-name-data1-2",
+				"bb-tooltip-name-data2-2"
+			]);
+		});
+
+		// check for stacking bar
+		it("linked charts  set options data.groups", () => {
+			args.data.type = "bar";
+			args.data.groups = [["data1", "data2", "data3"]];
+			args.tooltip.order = args.data.order = "desc";
+
+			args2.data.type = args.data.type;
+			args2.data.groups = args.data.groups;
+			args2.tooltip.order = args.tooltip.order;
+
+		});
+
+		it("chart 1 stacked bar: should sort values in descending order", () => {
+			checkLinkedTooltip(chart, chart2, [
+				"bb-tooltip-name-data3",
+				"bb-tooltip-name-data1",
+				"bb-tooltip-name-data2"
+			]);
+		})
+
+		it("chart 2 stacked bar: should sort values in descending order", () => {
+			checkLinkedTooltip(chart2, chart, [
+				"bb-tooltip-name-data3-2",
+				"bb-tooltip-name-data1-2",
+				"bb-tooltip-name-data2-2"
+			]);
+		});
+
+		it("linked charts  set options tooltip.order=asc", () => {
+			args.tooltip.order = args.data.order = "asc";
+			args2.tooltip.order = args2.data.order = args.tooltip.order;
+		});
+
+		it("chart 1 stacked bar: should sort values in ascending order", () => {
+			checkLinkedTooltip(chart, chart2, [
+				"bb-tooltip-name-data2",
+				"bb-tooltip-name-data1",
+				"bb-tooltip-name-data3"
+			]);
+		});
+
+		it("chart 2 stacked bar: should sort values in ascending order", () => {
+			checkLinkedTooltip(chart2, chart, [
+				"bb-tooltip-name-data2-2",
+				"bb-tooltip-name-data1-2",
+				"bb-tooltip-name-data3-2"
+			]);
+		});
+
+		it("linked charts set options tooltip.order=null", () => {
+			args.tooltip.order = args.data.order = null;
+			args2.tooltip.order = args2.data.order = args.tooltip.order;
+		});
+
+		it("chart 1 stacked bar: should be ordered in data input order", () => {
+			checkLinkedTooltip(chart, chart2, [
+				"bb-tooltip-name-data3",
+				"bb-tooltip-name-data2",
+				"bb-tooltip-name-data1"
+			]);
+		});
+
+		it("chart 2 stacked bar: should be ordered in data input order", () => {
+			checkLinkedTooltip(chart2, chart, [
+				"bb-tooltip-name-data3-2",
+				"bb-tooltip-name-data2-2",
+				"bb-tooltip-name-data1-2"
+			]);
+		});
+
+		it("linked charts set options tooltip.order=function", () => {
+			args.tooltip.order = sinon.spy(function(a, b) {
+				return a.value - b.value;
+			});
+			args2.tooltip.order = args.tooltip.order;
+		});
+
+		it("chart 1 data.order function should be called", () => {
+			checkLinkedTooltip(chart, chart2);
+			expect(args.tooltip.order.called).to.be.true;
+		});
+
+		it("chart 2 data.order function should be called", () => {
+			checkLinkedTooltip(chart2, chart);
+			expect(args2.tooltip.order.called).to.be.true;
 		});
 	});
 });

--- a/spec/internals/tooltip-spec.js
+++ b/spec/internals/tooltip-spec.js
@@ -6,7 +6,7 @@
 import util from "../assets/util";
 import CLASS from "../../src/config/classes";
 
-describe("TOOLTIP", function() {
+describe("TOOLTIP", function () {
 	let chart;
 	let args = {
 		data: {
@@ -30,7 +30,7 @@ describe("TOOLTIP", function() {
 			clientY: 100
 		}, chart);
 
-		const tooltips =  d3.select(chart.element)
+		const tooltips = d3.select(chart.element)
 			.selectAll(`.${CLASS.tooltip} tr`)
 			.nodes();
 
@@ -39,6 +39,7 @@ describe("TOOLTIP", function() {
 				expect(el.className).to.be.equal(expected[i - 1]);
 			}
 		}
+
 	};
 
 
@@ -127,13 +128,15 @@ describe("TOOLTIP", function() {
 				clientX: 100,
 				clientY: 100
 			}, chart);
+			setTimeout(function () {
+				const tooltipContainer = d3.select(chart.element).select(`.${CLASS.tooltipContainer}`);
+				const top = Math.floor(+tooltipContainer.style("top").replace(/px/, ""));
+				const left = Math.floor(+tooltipContainer.style("left").replace(/px/, ""));
 
-			const tooltipContainer =  d3.select(chart.element).select(`.${CLASS.tooltipContainer}`);
-			const top = Math.floor(+tooltipContainer.style("top").replace(/px/, ""));
-			const left = Math.floor(+tooltipContainer.style("left").replace(/px/, ""));
+				expect(top).to.be.equal(topExpected);
+				expect(left).to.be.equal(leftExpected);
+			}, 500)
 
-			expect(top).to.be.equal(topExpected);
-			expect(left).to.be.equal(leftExpected);
 		});
 	});
 
@@ -210,14 +213,17 @@ describe("TOOLTIP", function() {
 		});
 
 		it("set options tooltip.order=function", () => {
-			args.tooltip.order = sinon.spy(function(a, b) {
+			args.tooltip.order = sinon.spy(function (a, b) {
 				return a.value - b.value;
 			});
 		});
 
 		it("data.order function should be called", () => {
 			checkTooltip(chart);
- 			expect(args.tooltip.order.called).to.be.true;
+			setTimeout(function () {
+				expect(args.tooltip.order.called).to.be.true;
+			}, 500)
+
 		});
 	});
 });

--- a/spec/internals/tooltip-spec.js
+++ b/spec/internals/tooltip-spec.js
@@ -122,8 +122,6 @@ describe("TOOLTIP", function() {
 		it("chart tooltip.onshown function should be called", () => {
 			checkCallback(chart, 'onshown', 2);
 		});
-
-
 	});
 
 	describe("tooltip position", () => {

--- a/spec/internals/tooltip-spec.js
+++ b/spec/internals/tooltip-spec.js
@@ -128,15 +128,12 @@ describe("TOOLTIP", function () {
 				clientX: 100,
 				clientY: 100
 			}, chart);
-			setTimeout(function () {
-				const tooltipContainer = d3.select(chart.element).select(`.${CLASS.tooltipContainer}`);
-				const top = Math.floor(+tooltipContainer.style("top").replace(/px/, ""));
-				const left = Math.floor(+tooltipContainer.style("left").replace(/px/, ""));
+			const tooltipContainer = d3.select(chart.element).select(`.${CLASS.tooltipContainer}`);
+			const top = Math.floor(+tooltipContainer.style("top").replace(/px/, ""));
+			const left = Math.floor(+tooltipContainer.style("left").replace(/px/, ""));
 
-				expect(top).to.be.equal(topExpected);
-				expect(left).to.be.equal(leftExpected);
-			}, 500)
-
+			expect(top).to.be.equal(topExpected);
+			expect(left).to.be.equal(leftExpected);
 		});
 	});
 
@@ -220,10 +217,7 @@ describe("TOOLTIP", function () {
 
 		it("data.order function should be called", () => {
 			checkTooltip(chart);
-			setTimeout(function () {
-				expect(args.tooltip.order.called).to.be.true;
-			}, 500)
-
+			expect(args.tooltip.order.called).to.be.true;
 		});
 	});
 });

--- a/src/api/api.tooltip.js
+++ b/src/api/api.tooltip.js
@@ -75,7 +75,7 @@ const tooltip = extend(() => {}, {
 			$$.dispatchEvent(eventName, index, mouse);
 		});
 
-		$$.config.tooltip_onshow.call($$, args.data);
+		// $$.config.tooltip_onshow.call($$, args.data);
 	},
 
 	/**
@@ -90,7 +90,7 @@ const tooltip = extend(() => {}, {
 		// TODO: get target data by checking the state of focus
 		$$.dispatchEvent("mouseout", 0);
 
-		$$.config.tooltip_onhide.call(this);
+		// $$.config.tooltip_onhide.call(this);
 	}
 });
 

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -2503,6 +2503,7 @@ export default class Options {
 			 * @type {Object}
 			 * @property {Boolean} [tooltip.show=true] Show or hide tooltip.<br>
 			 * @property {Boolean} [tooltip.grouped=true] Set if tooltip is grouped or not for the data points.
+			 * @property {Boolean} [tooltip.linked=false] Set if tooltips on all visible charts with like x points are shown together when one is shown.<br>
 			 * @property {Function} [tooltip.format.title] Set format for the title of tooltip.<br>
 			 *  Specified function receives x of the data point to show.
 			 * @property {Function} [tooltip.format.name] Set format for the name of each data in tooltip.<br>
@@ -2514,6 +2515,18 @@ export default class Options {
 			 *  This option can be used to modify the tooltip position by returning object that has top and left.
 			 * @property {Function} [tooltip.contents] Set custom HTML for the tooltip.<br>
 			 *  Specified function receives data, defaultTitleFormat, defaultValueFormat and color of the data point to show. If tooltip.grouped is true, data includes multiple data points.
+			 * @property {Function} [tooltip.onshow] Set a callback that will be invoked before the tooltip is shown.<br>
+			 *   **Available Values:**
+			 *   - `this`: Reference to the current chart instance.
+			 * @property {Function} [tooltip.onhide] Set a callback that will be invoked before the tooltip is hidden.<br>
+			 *   **Available Values:**
+			 *   - `this`: Reference to the current chart instance.
+			 * @property {Function} [tooltip.onshown] Set a callback that will be invoked after the tooltip is shown.<br>
+			 *   **Available Values:**
+			 *   - `this`: Reference to the current chart instance.
+			 * @property {Function} [tooltip.onhidden] Set a callback that will be invoked after the tooltip is hidden.<br>
+			 *   **Available Values:**
+			 *   - `this`: Reference to the current chart instance.
 			 * @property {String|Function|null} [tooltip.order=null] Set tooltip data display order.<br><br>
 			 *  **Available Values:**
 			 *  - `desc`: In descending data value order
@@ -2547,23 +2560,25 @@ export default class Options {
 			 *         {x: 5, value: 250, id: "data1", index: 5, name: "data1"}
 			 *           ...
 			 *      },
-			 *      onShown: function(){
-			 *			// 'this' will give a reference to data from tooltip.js showTooltip method.
-			 *			// data	available:
-			 *			// chart: reference to the chart instance
-			 *			// element: html element
-			 *			// height
-			 *			// width
-			 *			// selectedData: data associated with tooltip {x: Tue Jan 01 2013 00:00:00 GMT-0500 (EST), value: 10, id: "data", index: 0, name: "data"}
-			 * 			// x: x coordinate from the first data element
-			 * 			// position: {top: 0, left: 0}
+			 *      onshow: function(){
+			 *			// 'this' will give a reference to chart
+			 *		    //  fires prior tooltip is shown
 			 *      },
-			 *      onHidden: function(){
+			 *      onhide: function(){
 			 *      	// 'this' will give a reference to chart
+			 *          //  fires prior tooltip is hidden
 			 *      },
-			 *      // Link any tooltips when multiple charts are on the screen
-			 *      linked: false
-			 *
+			 *      onshown: function(){
+			 *			// 'this' will give a reference to chart
+			 *		    //  fires after tooltip is shown
+			 *      },
+			 *      onhidden: function(){
+			 *      	// 'this' will give a reference to chart
+			 *          //  fires after tooltip is hidden
+			 *      },
+			 *      // Link any tooltips when multiple charts are on the screen where same x coordinates are available
+			 *      // Useful for timeseries correlation
+			 *      linked: true
 			 *  }
 			 */
 			tooltip_show: true,
@@ -2585,8 +2600,8 @@ export default class Options {
 			tooltip_linked: false,
 			tooltip_onshow: () => {},
 			tooltip_onhide: () => {},
-			tooltip_onShown: undefined,
-			tooltip_onHidden: undefined,
+			tooltip_onshown: () => {},
+			tooltip_onhidden: () => {},
 			tooltip_order: null,
 
 			/**

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -157,9 +157,12 @@ export default class Options {
 			zoom_extent: undefined,
 			zoom_privileged: false,
 			zoom_rescale: false,
-			zoom_onzoom: () => {},
-			zoom_onzoomstart: () => {},
-			zoom_onzoomend: () => {},
+			zoom_onzoom: () => {
+			},
+			zoom_onzoomstart: () => {
+			},
+			zoom_onzoomend: () => {
+			},
 			zoom_x_min: undefined,
 			zoom_x_max: undefined,
 
@@ -208,7 +211,8 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onover: () => {},
+			onover: () => {
+			},
 
 			/**
 			 * Set a callback to execute when mouse/touch leaves the chart.
@@ -221,7 +225,8 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onout: () => {},
+			onout: () => {
+			},
 
 			/**
 			 * Set a callback to execute when user resizes the screen.
@@ -234,7 +239,8 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onresize: () => {},
+			onresize: () => {
+			},
 
 			/**
 			 * SSet a callback to execute when screen resize finished.
@@ -247,7 +253,8 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onresized: () => {},
+			onresized: () => {
+			},
 
 			/**
 			 * Set a callback to execute before the chart is initialized
@@ -273,7 +280,8 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			oninit: () => {},
+			oninit: () => {
+			},
 
 			/**
 			 * Set a callback to execute after the chart is initialized
@@ -299,7 +307,8 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onrendered: () => {},
+			onrendered: () => {
+			},
 
 			/**
 			 * Set duration of transition (in milliseconds) for chart animation.<br><br>
@@ -744,7 +753,8 @@ export default class Options {
 			 *     onclick: function(d, element) { ... }
 			 * }
 			 */
-			data_onclick: () => {},
+			data_onclick: () => {
+			},
 
 			/**
 			 * Set a callback for mouse/touch over event on each data point.<br><br>
@@ -758,7 +768,8 @@ export default class Options {
 			 *     onover: function(d) { ... }
 			 * }
 			 */
-			data_onover: () => {},
+			data_onover: () => {
+			},
 
 			/**
 			 * Set a callback for mouse/touch out event on each data point.<br><br>
@@ -772,7 +783,8 @@ export default class Options {
 			 *     onout: function(d) { ... }
 			 * }
 			 */
-			data_onout: () => {},
+			data_onout: () => {
+			},
 
 			/**
 			 * Set a callback for on data selection.
@@ -789,7 +801,8 @@ export default class Options {
 			 *    }
 			 * }
 			 */
-			data_onselected: () => {},
+			data_onselected: () => {
+			},
 
 			/**
 			 * Set a callback for on data un-selection.
@@ -806,7 +819,8 @@ export default class Options {
 			 *    }
 			 * }
 			 */
-			data_onunselected: () => {},
+			data_onunselected: () => {
+			},
 
 			/**
 			 * Set a callback for minimum data
@@ -1017,7 +1031,8 @@ export default class Options {
 			subchart_show: false,
 			subchart_size_height: 60,
 			subchart_axis_x_show: true,
-			subchart_onbrush: () => {},
+			subchart_onbrush: () => {
+			},
 
 			/**
 			 * Set color of the data values
@@ -2171,13 +2186,13 @@ export default class Options {
 			 *  - circle
 			 *  - rectangle
 			 * @property {Array} [point.pattern=[]] The type of point or svg shape as string, to be drawn for each line<br>
- 			 * - **Note:**
+			 * - **Note:**
 			 *  - This is an `experimental` feature and can have some unexpected behaviors.
 			 *  - If chart has 'bubble' type, only circle can be used.
 			 *  - For IE, non circle point expansions are not supported due to lack of transform support.
 			 * - **Available Values:**
 			 *  - circle
- 			 *  - rectangle
+			 *  - rectangle
 			 *  - svg shape tag interpreted as string<br>
 			 *    (ex. `<polygon points='2.5 0 0 5 5 5'></polygon>`)
 			 * @example
@@ -2546,7 +2561,24 @@ export default class Options {
 			 *         // param data passed format
 			 *         {x: 5, value: 250, id: "data1", index: 5, name: "data1"}
 			 *           ...
-			 *      }
+			 *      },
+			 *      onShown: function(){
+			 *			// 'this' will give a reference to data from tooltip.js showTooltip method.
+			 *			// data	available:
+			 *			// chart: reference to the chart instance
+			 *			// element: html element
+			 *			// height
+			 *			// width
+			 *			// selectedData: data associated with tooltip {x: Tue Jan 01 2013 00:00:00 GMT-0500 (EST), value: 10, id: "data", index: 0, name: "data"}
+			 * 			// x: x coordinate from the first data element
+			 * 			// position: {top: 0, left: 0}
+			 *      },
+			 *      onHidden: function(){
+			 *      	// 'this' will give a reference to chart
+			 *      },
+			 *      // Link any tooltips when multiple charts are on the screen
+			 *      linked: false
+			 *
 			 *  }
 			 */
 			tooltip_show: true,
@@ -2565,8 +2597,13 @@ export default class Options {
 				top: "0px",
 				left: "50px"
 			},
-			tooltip_onshow: () => {},
-			tooltip_onhide: () => {},
+			tooltip_linked: false,
+			tooltip_onshow: () => {
+			},
+			tooltip_onhide: () => {
+			},
+			tooltip_onShown: undefined,
+			tooltip_onHidden: undefined,
 			tooltip_order: null,
 
 			/**

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -157,12 +157,9 @@ export default class Options {
 			zoom_extent: undefined,
 			zoom_privileged: false,
 			zoom_rescale: false,
-			zoom_onzoom: () => {
-			},
-			zoom_onzoomstart: () => {
-			},
-			zoom_onzoomend: () => {
-			},
+			zoom_onzoom: () => {},
+			zoom_onzoomstart: () => {},
+			zoom_onzoomend: () => {},
 			zoom_x_min: undefined,
 			zoom_x_max: undefined,
 
@@ -211,8 +208,7 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onover: () => {
-			},
+			onover: () => {},
 
 			/**
 			 * Set a callback to execute when mouse/touch leaves the chart.
@@ -225,8 +221,7 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onout: () => {
-			},
+			onout: () => {},
 
 			/**
 			 * Set a callback to execute when user resizes the screen.
@@ -239,8 +234,7 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onresize: () => {
-			},
+			onresize: () => {},
 
 			/**
 			 * SSet a callback to execute when screen resize finished.
@@ -253,8 +247,7 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onresized: () => {
-			},
+			onresized: () => {},
 
 			/**
 			 * Set a callback to execute before the chart is initialized
@@ -280,8 +273,7 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			oninit: () => {
-			},
+			oninit: () => {},
 
 			/**
 			 * Set a callback to execute after the chart is initialized
@@ -307,8 +299,7 @@ export default class Options {
 			 *   ...
 			 * }
 			 */
-			onrendered: () => {
-			},
+			onrendered: () => {},
 
 			/**
 			 * Set duration of transition (in milliseconds) for chart animation.<br><br>
@@ -753,8 +744,7 @@ export default class Options {
 			 *     onclick: function(d, element) { ... }
 			 * }
 			 */
-			data_onclick: () => {
-			},
+			data_onclick: () => {},
 
 			/**
 			 * Set a callback for mouse/touch over event on each data point.<br><br>
@@ -768,8 +758,7 @@ export default class Options {
 			 *     onover: function(d) { ... }
 			 * }
 			 */
-			data_onover: () => {
-			},
+			data_onover: () => {},
 
 			/**
 			 * Set a callback for mouse/touch out event on each data point.<br><br>
@@ -783,8 +772,7 @@ export default class Options {
 			 *     onout: function(d) { ... }
 			 * }
 			 */
-			data_onout: () => {
-			},
+			data_onout: () => {},
 
 			/**
 			 * Set a callback for on data selection.
@@ -801,8 +789,7 @@ export default class Options {
 			 *    }
 			 * }
 			 */
-			data_onselected: () => {
-			},
+			data_onselected: () => {},
 
 			/**
 			 * Set a callback for on data un-selection.
@@ -819,8 +806,7 @@ export default class Options {
 			 *    }
 			 * }
 			 */
-			data_onunselected: () => {
-			},
+			data_onunselected: () => {},
 
 			/**
 			 * Set a callback for minimum data
@@ -1031,8 +1017,7 @@ export default class Options {
 			subchart_show: false,
 			subchart_size_height: 60,
 			subchart_axis_x_show: true,
-			subchart_onbrush: () => {
-			},
+			subchart_onbrush: () => {},
 
 			/**
 			 * Set color of the data values
@@ -2598,10 +2583,8 @@ export default class Options {
 				left: "50px"
 			},
 			tooltip_linked: false,
-			tooltip_onshow: () => {
-			},
-			tooltip_onhide: () => {
-			},
+			tooltip_onshow: () => {},
+			tooltip_onhide: () => {},
 			tooltip_onShown: undefined,
 			tooltip_onHidden: undefined,
 			tooltip_order: null,

--- a/src/core.js
+++ b/src/core.js
@@ -17,7 +17,7 @@ const bb = {
 	 * Version information
 	 * @property {String} version version
 	 * @example
-	 * 	bb.version;  // "1.0.0"
+	 *    bb.version;  // "1.0.0"
 	 * @memberOf bb
 	 */
 	version: "#__VERSION__#",
@@ -49,6 +49,8 @@ const bb = {
 	 */
 	generate(config) {
 		const inst = new Chart(config);
+
+		inst.internal.charts = this.instance;
 
 		this.instance.push(inst);
 

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -257,10 +257,8 @@ extend(ChartInternal.prototype, {
 			$$.api.internal.charts.forEach(c => {
 				if (c !== $$.api) {
 					const tt = c.internal.tooltip;
-					const cWidth = tt.property("offsetWidth");
-					const cHeight = tt.property("offsetHeight");
 
-					if (!cHeight && !cWidth) {
+					if (tt.style("display") !== "block") {
 						c.tooltip.show({x: x});
 					}
 				}
@@ -268,15 +266,18 @@ extend(ChartInternal.prototype, {
 		}
 
 		if (config.tooltip_onShown) {
-			config.tooltip_onShown.call({
-				width: tWidth,
-				height: tHeight,
-				position: position,
-				selectedData: selectedData,
-				element: element,
-				x: x,
-				chart: this.api
-			});
+			if (!$$.cache.tooltip_shown_callback) {
+				config.tooltip_onShown.call({
+					width: tWidth,
+					height: tHeight,
+					position: position,
+					selectedData: selectedData,
+					element: element,
+					x: x,
+					chart: this.api
+				});
+				$$.cache.tooltip_shown_callback = true;
+			}
 		}
 	},
 
@@ -294,10 +295,8 @@ extend(ChartInternal.prototype, {
 			$$.api.internal.charts.forEach(c => {
 				if (c !== $$.api) {
 					const tt = c.internal.tooltip;
-					const cWidth = tt.property("offsetWidth");
-					const cHeight = tt.property("offsetHeight");
 
-					if (cHeight && cWidth) {
+					if (tt.style("display") === "block") {
 						c.tooltip.hide();
 					}
 				}
@@ -306,6 +305,7 @@ extend(ChartInternal.prototype, {
 
 		if (config.tooltip_onHidden) {
 			config.tooltip_onHidden.call(this.api);
+			delete $$.cache.tooltip_shown_callback;
 		}
 	}
 });

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -232,23 +232,23 @@ extend(ChartInternal.prototype, {
 			return;
 		}
 
-		// Get tooltip dimensions
-		const tWidth = $$.tooltip.property("offsetWidth");
-		const tHeight = $$.tooltip.property("offsetHeight");
-		const position = positionFunction.call(this, dataToShow, tWidth, tHeight, element);
-		const x = selectedData[0].x || undefined;
-
 		const beforeShow = new Promise(resolve => {
 			// tooltip_show_callback is used to prevent duplicate
 			// calls on showTooltip updates when mouse is moved
-			if (!$$.cache.tooltip_show_callback) {
-				$$.config.tooltip_onshow.call(this.api);
-				$$.cache.tooltip_show_callback = true;
-			}
+			// if (config.tooltip_onshow && !$$.cache.tooltip_show_callback) {
+			// 	config.tooltip_onshow.call(this.api);
+			// 	$$.cache.tooltip_show_callback = true;
+			// }
 			resolve("beforeShow");
 		});
 
 		const show = new Promise(resolve => {
+			// Get tooltip dimensions
+			const tWidth = $$.tooltip.property("offsetWidth");
+			const tHeight = $$.tooltip.property("offsetHeight");
+			const position = positionFunction.call(this, dataToShow, tWidth, tHeight, element);
+			const x = selectedData[0].x || undefined;
+
 			$$.tooltip.html(
 				config.tooltip_contents.call(
 					$$,
@@ -273,7 +273,7 @@ extend(ChartInternal.prototype, {
 		beforeShow.then(() => show).then(() => {
 			// tooltip_shown_callback is used to prevent duplicate
 			// calls on showTooltip updates when mouse is moved
-			if (!$$.cache.tooltip_shown_callback) {
+			if (config.tooltip_onshown && !$$.cache.tooltip_shown_callback) {
 				config.tooltip_onshown.call(this.api);
 				$$.cache.tooltip_shown_callback = true;
 			}
@@ -289,10 +289,10 @@ extend(ChartInternal.prototype, {
 		const config = $$.config;
 
 		const beforeHide = new Promise(resolve => {
-			if ($$.cache.tooltip_show_callback) {
-				$$.config.tooltip_onhide.call(this.api);
-				delete $$.cache.tooltip_show_callback;
-			}
+			// if (config.tooltip_onhide && $$.cache.tooltip_show_callback) {
+			// 	config.tooltip_onhide.call(this.api);
+			// 	delete $$.cache.tooltip_show_callback;
+			// }
 			resolve("beforeHide");
 		});
 
@@ -303,7 +303,7 @@ extend(ChartInternal.prototype, {
 		});
 
 		beforeHide.then(() => hide).then(() => {
-			if ($$.cache.tooltip_shown_callback) {
+			if (config.tooltip_onhidden && $$.cache.tooltip_shown_callback) {
 				config.tooltip_onhidden.call(this.api);
 				delete $$.cache.tooltip_shown_callback;
 			}

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -232,13 +232,28 @@ extend(ChartInternal.prototype, {
 			return;
 		}
 
-		// tooltip_show_callback is used to prevent duplicate
-		// calls on showTooltip updates when mouse is moved
-		if (config.tooltip_onshow && !$$.cache.tooltip_show_callback) {
-			config.tooltip_onshow.call(this.api);
-			$$.cache.tooltip_show_callback = true;
+		if ($$._handleBeforeShown($$, config)) {
+			if ($$._handleShow($$, config, selectedData, forArc, positionFunction, dataToShow, element)) {
+				$$._handleAfterShown($$, config);
+			}
 		}
+	},
 
+	/**
+	 * Hide the tooltip
+	 * @private
+	 */
+	hideTooltip() {
+		const $$ = this;
+		const config = $$.config;
+
+		if ($$._handleBeforeHide($$, config)) {
+			if ($$._handleHide($$, config)) {
+				$$._handleAfterHide($$, config);
+			}
+		}
+	},
+	_handleShow($$, config, selectedData, forArc, positionFunction, dataToShow, element) {
 		$$.tooltip.html(
 			config.tooltip_contents.call(
 				$$,
@@ -261,36 +276,45 @@ extend(ChartInternal.prototype, {
 			.style("left", `${position.left}px`);
 
 		$$._handleLinkedCharts({show: 1, x: x});
-
+		return true;
+	},
+	_handleBeforeShown($$, config) {
+		// tooltip_show_callback is used to prevent duplicate
+		// calls on showTooltip updates when mouse is moved
+		if (config.tooltip_onshow && !$$.cache.tooltip_show_callback) {
+			config.tooltip_onshow.call(this.api);
+			$$.cache.tooltip_show_callback = true;
+		}
+		return true;
+	},
+	_handleAfterShown($$, config) {
 		// tooltip_shown_callback is used to prevent duplicate
 		// calls on showTooltip updates when mouse is moved
 		if (config.tooltip_onshown && !$$.cache.tooltip_shown_callback) {
 			config.tooltip_onshown.call(this.api);
 			$$.cache.tooltip_shown_callback = true;
 		}
+		return true;
 	},
-
-	/**
-	 * Hide the tooltip
-	 * @private
-	 */
-	hideTooltip() {
-		const $$ = this;
-		const config = $$.config;
-
+	_handleHide($$, config) {
+		this.tooltip.style("display", "none");
+		$$._handleLinkedCharts({hide: true});
+		return true;
+	},
+	_handleBeforeHide($$, config) {
 		if (config.tooltip_onhide && $$.cache.tooltip_show_callback) {
 			config.tooltip_onhide.call(this.api);
 			delete $$.cache.tooltip_show_callback;
 		}
-		this.tooltip.style("display", "none");
-		$$._handleLinkedCharts({hide: true});
-
+		return true;
+	},
+	_handleAfterHide($$, config) {
 		if (config.tooltip_onhidden && $$.cache.tooltip_shown_callback) {
 			config.tooltip_onhidden.call(this.api);
 			delete $$.cache.tooltip_shown_callback;
 		}
+		return true;
 	},
-
 	_handleLinkedCharts(data) {
 		const $$ = this;
 

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -255,7 +255,9 @@ extend(ChartInternal.prototype, {
 
 		if (config.tooltip_linked) {
 			$$.api.internal.charts.forEach(c => {
-				if (c !== $$.api) {
+				const isInDom = document.body.contains(c.element);
+
+				if (c !== $$.api && isInDom) {
 					const tt = c.internal.tooltip;
 
 					if (tt.style("display") !== "block") {
@@ -293,7 +295,9 @@ extend(ChartInternal.prototype, {
 
 		if (config.tooltip_linked) {
 			$$.api.internal.charts.forEach(c => {
-				if (c !== $$.api) {
+				const isInDom = document.body.contains(c.element);
+
+				if (c !== $$.api && isInDom) {
 					const tt = c.internal.tooltip;
 
 					if (tt.style("display") === "block") {

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -232,52 +232,42 @@ extend(ChartInternal.prototype, {
 			return;
 		}
 
-		const beforeShow = new Promise(resolve => {
-			// tooltip_show_callback is used to prevent duplicate
-			// calls on showTooltip updates when mouse is moved
-			// if (config.tooltip_onshow && !$$.cache.tooltip_show_callback) {
-			// 	config.tooltip_onshow.call(this.api);
-			// 	$$.cache.tooltip_show_callback = true;
-			// }
-			resolve("beforeShow");
-		});
+		// tooltip_show_callback is used to prevent duplicate
+		// calls on showTooltip updates when mouse is moved
+		if (config.tooltip_onshow && !$$.cache.tooltip_show_callback) {
+			config.tooltip_onshow.call(this.api);
+			$$.cache.tooltip_show_callback = true;
+		}
 
-		const show = new Promise(resolve => {
-			// Get tooltip dimensions
-			const tWidth = $$.tooltip.property("offsetWidth");
-			const tHeight = $$.tooltip.property("offsetHeight");
-			const position = positionFunction.call(this, dataToShow, tWidth, tHeight, element);
-			const x = selectedData[0].x || undefined;
+		$$.tooltip.html(
+			config.tooltip_contents.call(
+				$$,
+				selectedData,
+				$$.axis.getXAxisTickFormat(),
+				$$.getYFormat(forArc),
+				$$.color
+			))
+			.style("display", "block");
 
-			$$.tooltip.html(
-				config.tooltip_contents.call(
-					$$,
-					selectedData,
-					$$.axis.getXAxisTickFormat(),
-					$$.getYFormat(forArc),
-					$$.color
-				))
-				.style("display", "block");
+		// Get tooltip dimensions
+		const tWidth = $$.tooltip.property("offsetWidth");
+		const tHeight = $$.tooltip.property("offsetHeight");
+		const position = positionFunction.call(this, dataToShow, tWidth, tHeight, element);
+		const x = selectedData[0].x || undefined;
 
+		// Set tooltip
+		$$.tooltip
+			.style("top", `${position.top}px`)
+			.style("left", `${position.left}px`);
 
-			// Set tooltip
-			$$.tooltip
-				.style("top", `${position.top}px`)
-				.style("left", `${position.left}px`);
+		$$._handleLinkedCharts({show: 1, x: x});
 
-			$$._handleLinkedCharts({show: 1, x: x});
-
-			resolve("show");
-		});
-
-		beforeShow.then(() => show).then(() => {
-			// tooltip_shown_callback is used to prevent duplicate
-			// calls on showTooltip updates when mouse is moved
-			if (config.tooltip_onshown && !$$.cache.tooltip_shown_callback) {
-				config.tooltip_onshown.call(this.api);
-				$$.cache.tooltip_shown_callback = true;
-			}
-		});
+		// tooltip_shown_callback is used to prevent duplicate
+		// calls on showTooltip updates when mouse is moved
+		if (config.tooltip_onshown && !$$.cache.tooltip_shown_callback) {
+			config.tooltip_onshown.call(this.api);
+			$$.cache.tooltip_shown_callback = true;
+		}
 	},
 
 	/**
@@ -288,26 +278,17 @@ extend(ChartInternal.prototype, {
 		const $$ = this;
 		const config = $$.config;
 
-		const beforeHide = new Promise(resolve => {
-			// if (config.tooltip_onhide && $$.cache.tooltip_show_callback) {
-			// 	config.tooltip_onhide.call(this.api);
-			// 	delete $$.cache.tooltip_show_callback;
-			// }
-			resolve("beforeHide");
-		});
+		if (config.tooltip_onhide && $$.cache.tooltip_show_callback) {
+			config.tooltip_onhide.call(this.api);
+			delete $$.cache.tooltip_show_callback;
+		}
+		this.tooltip.style("display", "none");
+		$$._handleLinkedCharts({hide: true});
 
-		const hide = new Promise(resolve => {
-			this.tooltip.style("display", "none");
-			$$._handleLinkedCharts({hide: true});
-			resolve("hide");
-		});
-
-		beforeHide.then(() => hide).then(() => {
-			if (config.tooltip_onhidden && $$.cache.tooltip_shown_callback) {
-				config.tooltip_onhidden.call(this.api);
-				delete $$.cache.tooltip_shown_callback;
-			}
-		});
+		if (config.tooltip_onhidden && $$.cache.tooltip_shown_callback) {
+			config.tooltip_onhidden.call(this.api);
+			delete $$.cache.tooltip_shown_callback;
+		}
 	},
 
 	_handleLinkedCharts(data) {

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -246,11 +246,38 @@ extend(ChartInternal.prototype, {
 		const tWidth = $$.tooltip.property("offsetWidth");
 		const tHeight = $$.tooltip.property("offsetHeight");
 		const position = positionFunction.call(this, dataToShow, tWidth, tHeight, element);
+		const x = selectedData[0].x || undefined;
 
 		// Set tooltip
 		$$.tooltip
 			.style("top", `${position.top}px`)
 			.style("left", `${position.left}px`);
+
+		if (config.tooltip_linked) {
+			$$.api.internal.charts.forEach(c => {
+				if (c !== $$.api) {
+					const tt = c.internal.tooltip;
+					const cWidth = tt.property("offsetWidth");
+					const cHeight = tt.property("offsetHeight");
+
+					if (!cHeight && !cWidth) {
+						c.tooltip.show({x: x});
+					}
+				}
+			});
+		}
+
+		if (config.tooltip_onShown) {
+			config.tooltip_onShown.call({
+				width: tWidth,
+				height: tHeight,
+				position: position,
+				selectedData: selectedData,
+				element: element,
+				x: x,
+				chart: this.api
+			});
+		}
 	},
 
 	/**
@@ -258,6 +285,27 @@ extend(ChartInternal.prototype, {
 	 * @private
 	 */
 	hideTooltip() {
+		const $$ = this;
+		const config = $$.config;
+
 		this.tooltip.style("display", "none");
+
+		if (config.tooltip_linked) {
+			$$.api.internal.charts.forEach(c => {
+				if (c !== $$.api) {
+					const tt = c.internal.tooltip;
+					const cWidth = tt.property("offsetWidth");
+					const cHeight = tt.property("offsetHeight");
+
+					if (cHeight && cWidth) {
+						c.tooltip.hide();
+					}
+				}
+			});
+		}
+
+		if (config.tooltip_onHidden) {
+			config.tooltip_onHidden.call(this.api);
+		}
 	}
 });


### PR DESCRIPTION
Ref #308

**Adding reference to bb.instances: Chart.internals.charts**
see: src/core.js

bb already had a feature that stored all chart instances. This PR adds a reference to this collection in the Chart.internals that can be used elsewhere (see linked tooltip option)

**Adding tooltip options: onShown: function, onHidden: function tooltip**

````
tooltip: {
   onShown: function(){
    	// 'this' will give a reference to data from tooltip.js showTooltip method.
    	// data	available:
    	// chart: reference to the chart instance
    	// element: html element
    	// height
    	// width
    	// selectedData: data associated with tooltip {x: Tue Jan 01 2013 00:00:00 GMT-0500 (EST), value: 10, id: "data", index: 0, name: "data"}
    	// x: x coordinate from the first data element
    	// position: {top: 0, left: 0}
   	  console.log(this);
   },
   onHidden: function(){
   	  // 'this' will give a reference to chart
   	  console.log(this);
   },
}
````

Adding tooltip option: linked: boolean
````
tooltip: {
   // Link any tooltips when multiple charts are on the screen
   linked: true // default false
}
````
Makes use of Chart.internals.charts which has a reference to bb.instances. Any charts in the bb.instances that are currently rendered will show tooltips at like x axis.

Basic demo file at: /demo/linked-tooltips.html
