### PR TITLE
refactor(internal): Substitute resize event binding

### DIFF
--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -18,7 +18,7 @@ import {transition as d3Transition} from "d3-transition";
 
 import Axis from "../axis/Axis";
 import CLASS from "../config/classes";
-import {addEvent, notEmpty, asHalfPixel, isValue, getOption, isFunction, isDefined, isUndefined, isString, isNumber, isObject} from "./util";
+import {notEmpty, asHalfPixel, isValue, getOption, isFunction, isDefined, isUndefined, isString, isNumber, isObject} from "./util";
 
 /**
  * Internal chart class.
@@ -84,6 +84,7 @@ export default class ChartInternal {
 	initParams() {
 		const $$ = this;
 		const config = $$.config;
+		const isRotated = config.axis_rotated;
 
 		// datetime to be used for uniqueness
 		$$.datetimeId = `bb-${+new Date()}`;
@@ -133,15 +134,15 @@ export default class ChartInternal {
 		$$.focusedTargetIds = [];
 		$$.defocusedTargetIds = [];
 
-		$$.xOrient = config.axis_rotated ? "left" : "bottom";
+		$$.xOrient = isRotated ? "left" : "bottom";
 
-		$$.yOrient = config.axis_rotated ?
+		$$.yOrient = isRotated ?
 			(config.axis_y_inner ? "top" : "bottom") : (config.axis_y_inner ? "right" : "left");
 
-		$$.y2Orient = config.axis_rotated ?
+		$$.y2Orient = isRotated ?
 			(config.axis_y2_inner ? "bottom" : "top") : (config.axis_y2_inner ? "left" : "right");
 
-		$$.subXOrient = config.axis_rotated ? "left" : "bottom";
+		$$.subXOrient = isRotated ? "left" : "bottom";
 		$$.isLegendRight = config.legend_position === "right";
 		$$.isLegendInset = config.legend_position === "inset";
 
@@ -162,7 +163,7 @@ export default class ChartInternal {
 		};
 
 		$$.rotated_padding_left = 30;
-		$$.rotated_padding_right = config.axis_rotated && !config.axis_x_show ? 0 : 30;
+		$$.rotated_padding_right = isRotated && !config.axis_x_show ? 0 : 30;
 		$$.rotated_padding_top = 5;
 
 		$$.withoutFadeIn = {};
@@ -1133,9 +1134,8 @@ export default class ChartInternal {
 
 		if (config.resize_auto) {
 			$$.resizeFunction.add(() => {
-				if ($$.resizeTimeout !== undefined) {
+				isDefined($$.resizeTimeout) &&
 					window.clearTimeout($$.resizeTimeout);
-				}
 
 				$$.resizeTimeout = window.setTimeout(() => {
 					delete $$.resizeTimeout;
@@ -1148,7 +1148,7 @@ export default class ChartInternal {
 			config.onresized.call($$);
 		});
 
-		addEvent(window, "resize", $$.resizeFunction);
+		d3Select(window).on("resize", $$.resizeFunction);
 	}
 
 	generateResize() {

--- a/src/internals/util.js
+++ b/src/internals/util.js
@@ -148,49 +148,6 @@ function extend(target = {}, source) {
 	return target;
 }
 
-const SUPPORT_ADDEVENTLISTENER = "addEventListener" in document;
-const SUPPORT_PASSIVE = (() => {
-	let supportsPassiveOption = false;
-
-	try {
-		if (SUPPORT_ADDEVENTLISTENER && Object.defineProperty) {
-			document.addEventListener("test", null, Object.defineProperty({}, "passive", {
-				get() {
-					supportsPassiveOption = true;
-				},
-			}));
-		}
-	} catch (e) {}
-
-	return supportsPassiveOption;
-})();
-
-function addEvent(element, type, handler, eventListenerOptions) {
-	if (SUPPORT_ADDEVENTLISTENER) {
-		let options = eventListenerOptions || false;
-
-		if (isObjectType(eventListenerOptions)) {
-			options = SUPPORT_PASSIVE ? eventListenerOptions : false;
-		}
-
-		element.addEventListener(type, handler, options);
-	} else if (element.attachEvent) {
-		element.attachEvent(`on${type}`, handler);
-	} else {
-		element[`on${type}`] = handler;
-	}
-}
-
-function removeEvent(element, type, handler) {
-	if (element.removeEventListener) {
-		element.removeEventListener(type, handler, false);
-	} else if (element.detachEvent) {
-		element.detachEvent(`on${type}`, handler);
-	} else {
-		element[`on${type}`] = null;
-	}
-}
-
 /**
  * Return first letter capitalized
  * @param {String} str
@@ -266,7 +223,6 @@ const getCssRules = styleSheets => {
 };
 
 export {
-	addEvent,
 	asHalfPixel,
 	brushEmpty,
 	capitalize,
@@ -292,7 +248,6 @@ export {
 	isValue,
 	notEmpty,
 	merge,
-	removeEvent,
 	sanitise,
 	toArray
 };


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#404, #347

## Details
<!-- Detailed description of the change/feature -->
- Get rid internal event biding, replacing to d3's event binding.
- Reinforce some condition on .destroy() API
