### PR TITLE
refactor(ChartInternal): Improve redraw

### DIFF
--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -29,6 +29,9 @@ describe("Interface & initialization", () => {
 		expect(internal.convertInputType()).to.be.equal(internal.inputType);
 
 		expect(chart).to.be.equal(bb.instance[0]);
+
+		// onrendered value should be undefined for default
+		expect(chart.internal.config.onrendered).to.be.undefined;
 	});
 
 	it("should return version string", () => {

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -293,13 +293,13 @@ export default class Options {
 			 * @name onrendered
 			 * @memberOf Options
 			 * @type {Function}
-			 * @default function(){}
+			 * @default undefined
 			 * @example
 			 * onrendered: function() {
 			 *   ...
 			 * }
 			 */
-			onrendered: () => {},
+			onrendered: undefined,
 
 			/**
 			 * Set duration of transition (in milliseconds) for chart animation.<br><br>


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#429

## Details
<!-- Detailed description of the change/feature -->
- Avoid the call of generateWait() when the condition aren't met.
- Change 'onrendered' option's default value to undefined to not fulfill condition for generateWait().
- Timer interval to check transition end, increased from 20 to 50.