### PR TITLE
fix(zoom): Correct zooming for category axis type

### DIFF
--- a/spec/api/api.zoom-spec.js
+++ b/spec/api/api.zoom-spec.js
@@ -30,10 +30,10 @@ describe("API zoom", function() {
 
 			chart.zoom(target);
 
-			const domain = chart.internal.zoomScale.domain();
+			const domain = chart.internal.zoomScale.domain().map(Math.round);
 
-			expect(Math.round(domain[0])).to.be.equal(target[0]);
-			expect(Math.round(domain[1])).to.be.equal(target[1]);
+			expect(domain[0]).to.be.equal(target[0]);
+			expect(domain[1]).to.be.equal(target[1]);
 		});
 
 		it("should be zoomed properly again", () => {
@@ -41,10 +41,10 @@ describe("API zoom", function() {
 
 			chart.zoom(target);
 
-			const domain = chart.internal.zoomScale.domain();
+			const domain = chart.internal.zoomScale.domain().map(Math.round);
 
-			expect(Math.round(domain[0])).to.be.equal(target[0]);
-			expect(Math.round(domain[1])).to.be.equal(target[1]);
+			expect(domain[0]).to.be.equal(target[0]);
+			expect(domain[1]).to.be.equal(target[1]);
 		});
 
 		it("should be zoomed and showing focus grid properly when target contained minus value", () => {
@@ -57,11 +57,11 @@ describe("API zoom", function() {
 			// If target contained minus value should not be null
 			expect(zoomScale).to.not.be.null;
 
-			const domain = chart.internal.zoomScale.domain();
+			const domain = chart.internal.zoomScale.domain().map(Math.round);
 
 			// domain value must be above than target
-			expect(Math.round(domain[0])).to.be.above(target[0]);
-			expect(Math.round(domain[1])).to.be.above(target[1]);
+			expect(domain[0]).to.be.above(target[0]);
+			expect(domain[1]).to.be.above(target[1]);
 		});
 	});
 
@@ -126,6 +126,52 @@ describe("API zoom", function() {
 		});
 	});
 
+	describe("zoom category type", () => {
+		before(() => {
+			chart = util.generate({
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250]
+					]
+				},
+				axis: {
+					x: {
+						type: "category"
+					}
+				},
+				zoom: {
+					enabled: true
+				}
+			});
+		});
+
+		it("should be zoomed properly", done => {
+			const target = [1,2];
+
+			const internal = chart.internal;
+
+			chart.zoom(target);
+
+			setTimeout(() => {
+				const rectlist = internal.main.selectAll(`.${CLASS.eventRect}`)
+					.filter((v, i) => target.indexOf(i) !== -1);
+				const rectSize = rectlist.attr("width");
+				const domain = internal.zoomScale.domain().map(Math.round);
+
+				expect(domain[0]).to.be.equal(target[0]);
+				expect(domain[1] - 1).to.be.equal(target[1]);
+
+				rectlist.each(function(d, i) {
+					const x = +d3.select(this).attr("x");
+
+					expect(x * i).to.be.closeTo(rectSize * i, 5);
+				});
+
+				done();
+			}, 1000);
+		});
+	});
+
 	describe("zoom bar chart", () => {
 		before(() => {
 			chart = util.generate({
@@ -145,11 +191,14 @@ describe("API zoom", function() {
 
 		it("should be zoomed properly", done => {
 			const target = [3, 5];
-			const bars = d3.select(`.${CLASS.chartBars}`).node();
-			const rects = d3.select(`.${CLASS.eventRects}`).node();
-			const rectlist = d3.selectAll(`.${CLASS.eventRect}`).nodes();
+			const internal = chart.internal;
+			const main = internal.main;
+
+			const bars = main.select(`.${CLASS.chartBars}`).node();
+			const rects = main.select(`.${CLASS.eventRects}`).node();
+			const rectlist = main.selectAll(`.${CLASS.eventRect}`).nodes();
 			const orgWidth = bars.getBoundingClientRect().width;
-			const rectWidth = chart.internal.getEventRectWidth();
+			const rectWidth = internal.getEventRectWidth();
 
 			chart.zoom(target);
 
@@ -157,6 +206,7 @@ describe("API zoom", function() {
 				rectlist.forEach(v => {
 					expect(parseFloat(d3.select(v).attr("width"))).to.be.equal(rectWidth);
 				});
+
 				expect(bars.getBoundingClientRect().width/orgWidth).to.be.above(2.5);
 				expect(rects.getBoundingClientRect().width/orgWidth).to.be.above(2.5);
 
@@ -184,10 +234,10 @@ describe("API zoom", function() {
 
 			chart.zoom(target);
 
-			domain = chart.internal.zoomScale.domain();
+			domain = chart.internal.zoomScale.domain().map(Math.round);
 
-			expect(Math.round(domain[0])).to.be.equal(target[0]);
-			expect(Math.round(domain[1])).to.be.equal(target[1]);
+			expect(domain[0]).to.be.equal(target[0]);
+			expect(domain[1]).to.be.equal(target[1]);
 
 			chart.unzoom();
 
@@ -226,8 +276,8 @@ describe("API zoom", function() {
 			});
 
 			// check the returned domain value
-			chart.zoom(domain).forEach((v, i) => {
-				expect(Math.round(v)).to.not.equal(domain[i]);
+			chart.zoom(domain).map(Math.round).forEach((v, i) => {
+				expect(v).to.not.equal(domain[i]);
 			});
 
 			expect(+main.select(selector).attr("x")).to.be.equal(xValue);
@@ -240,8 +290,8 @@ describe("API zoom", function() {
 			// when enable zoom
 			chart.zoom.enable(true);
 
-			chart.zoom(domain).forEach((v, i) => {
-				expect(Math.round(v)).to.equal(domain[i]);
+			chart.zoom(domain).map(Math.round).forEach((v, i) => {
+				expect(v).to.equal(domain[i]);
 			});
 
 			expect(+main.select(selector).attr("x")).to.below(xValue);

--- a/src/api/api.chart.js
+++ b/src/api/api.chart.js
@@ -39,6 +39,9 @@ extend(Chart.prototype, {
 	 * chart.flush();
 	 */
 	flush() {
+		// reset possible zoom scale
+		this.internal.zoomScale = null;
+
 		this.internal.updateAndRedraw({
 			withLegend: true,
 			withTransition: false,

--- a/src/api/api.zoom.js
+++ b/src/api/api.zoom.js
@@ -8,7 +8,7 @@ import {
 } from "d3-array";
 import {zoomIdentity as d3ZoomIdentity} from "d3-zoom";
 import Chart from "../internals/Chart";
-import {isDefined, isObject, extend} from "../internals/util";
+import {isDefined, isObject, isFunction, extend} from "../internals/util";
 
 /**
  * Zoom by giving x domain.
@@ -44,7 +44,7 @@ const zoom = function(domainValue) {
 			const orgDomain = $$.x.orgDomain();
 			const k = (orgDomain[1] - orgDomain[0]) / (domain[1] - domain[0]);
 			const tx = isTimeSeries ?
-				(0 - k * $$.x(domain[0].getTime())) : domain[0] - k * $$.x(domain[0]);
+				(0 - k * $$.x(domain[0].getTime())) : domain[0] - k * ($$.x(domain[0]) - $$.xAxis.tickOffset());
 
 			$$.zoom.updateTransformScale(
 				d3ZoomIdentity.translate(tx, 0).scale(k)
@@ -59,7 +59,7 @@ const zoom = function(domainValue) {
 			withDimension: false
 		});
 
-		$$.config.zoom_onzoom.call(this, $$.x.orgDomain());
+		isFunction($$.config.zoom_onzoom) && $$.config.zoom_onzoom.call(this, $$.x.orgDomain());
 	} else {
 		resultDomain = ($$.zoomScale || $$.x).domain();
 	}

--- a/src/axis/bb.axis.js
+++ b/src/axis/bb.axis.js
@@ -121,10 +121,8 @@ export default function(params = {}) {
 	function copyScale() {
 		const newScale = scale.copy();
 
-		if (params.isCategory || !newScale.domain().length) {
-			const domain = scale.domain();
-
-			newScale.domain([domain[0], domain[1] - 1]);
+		if (!newScale.domain().length) {
+			newScale.domain(scale.domain());
 		}
 
 		return newScale;
@@ -464,6 +462,12 @@ export default function(params = {}) {
 		return axis;
 	};
 
+	/**
+	 * Return tick's offset value.
+	 * The value will be set for 'category' axis type.
+	 * @return {number}
+	 * @private
+	 */
 	axis.tickOffset = () => tickOffset;
 
 	/**

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -133,11 +133,11 @@ export default class Options {
 			 * @property {Array} [zoom.extent=[1, 10]] Change zoom extent.
 			 * @property {Number} [zoom.x.min] Set x Axis minimum zoom range
 			 * @property {Number} [zoom.x.max] Set x Axis maximum zoom range
-			 * @property {Function} [zoom.onzoom=function(){}] Set callback that is called when the chart is zooming.<br>
-			 *  Specified function receives the zoomed domain.
-			 * @property {Function} [zoom.onzoomstart=function(){}] Set callback that is called when zooming starts.<br>
+			 * @property {Function} [zoom.onzoomstart=undefined] Set callback that is called when zooming starts.<br>
 			 *  Specified function receives the zoom event.
-			 * @property {Function} [zoom.onzoomend=function(){}] Set callback that is called when zooming ends.<br>
+			 * @property {Function} [zoom.onzoom=undefined] Set callback that is called when the chart is zooming.<br>
+			 *  Specified function receives the zoomed domain.
+			 * @property {Function} [zoom.onzoomend=undefined] Set callback that is called when zooming ends.<br>
 			 *  Specified function receives the zoomed domain.
 			 * @example
 			 *  zoom: {
@@ -148,8 +148,8 @@ export default class Options {
 			 *          min: -1,  // set min range
 			 *          max: 10  // set max range
 			 *      },
-			 *      onzoom: function(domain) { ... },
 			 *      onzoomstart: function(event) { ... },
+			 *      onzoom: function(domain) { ... },
 			 *      onzoomend: function(domain) { ... }
 			 *  }
 			 */
@@ -157,9 +157,9 @@ export default class Options {
 			zoom_extent: undefined,
 			zoom_privileged: false,
 			zoom_rescale: false,
-			zoom_onzoom: () => {},
-			zoom_onzoomstart: () => {},
-			zoom_onzoomend: () => {},
+			zoom_onzoom: undefined,
+			zoom_onzoomstart: undefined,
+			zoom_onzoomend: undefined,
 			zoom_x_min: undefined,
 			zoom_x_max: undefined,
 

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -532,6 +532,7 @@ export default class ChartInternal {
 		const $$ = this;
 		const main = $$.main;
 		const config = $$.config;
+		const isRotated = config.axis_rotated;
 
 		const areaIndices = $$.getShapeIndices($$.isAreaType);
 		const barIndices = $$.getShapeIndices($$.isBarType);
@@ -639,12 +640,10 @@ export default class ChartInternal {
 					const index = tickValues.indexOf(e);
 
 					index >= 0 &&
-						d3Select(this)
-							.style("display", index % intervalForCulling ? "none" : "block");
+						d3Select(this).style("display", index % intervalForCulling ? "none" : "block");
 				});
 			} else {
-				$$.svg.selectAll(`.${CLASS.axisX} .tick text`)
-					.style("display", "block");
+				$$.svg.selectAll(`.${CLASS.axisX} .tick text`).style("display", "block");
 			}
 		}
 
@@ -724,15 +723,15 @@ export default class ChartInternal {
 		// event rects will redrawn when flow called
 		if (config.interaction_enabled && !options.flow && withEventRect) {
 			$$.redrawEventRect();
-			$$.updateZoom && $$.updateZoom();
+			config.zoom_enabled && $$.bindZoomOnEventRect();
 		}
 
 		// update circleY based on updated parameters
 		$$.updateCircleY();
 
 		// generate circle x/y functions depending on updated params
-		const cx = (config.axis_rotated ? $$.circleY : $$.circleX).bind($$);
-		const cy = (config.axis_rotated ? $$.circleX : $$.circleY).bind($$);
+		const cx = (isRotated ? $$.circleY : $$.circleX).bind($$);
+		const cy = (isRotated ? $$.circleX : $$.circleY).bind($$);
 
 		// generate flow
 		const flow = options.flow && $$.generateFlow({

--- a/src/internals/domain.js
+++ b/src/internals/domain.js
@@ -200,8 +200,6 @@ extend(ChartInternal.prototype, {
 		const xPadding = config.axis_x_padding;
 		let maxDataCount;
 		let padding;
-		let paddingLeft;
-		let paddingRight;
 
 		if ($$.isCategorized()) {
 			padding = 0;
@@ -212,21 +210,18 @@ extend(ChartInternal.prototype, {
 			padding = diff * 0.01;
 		}
 
+		let left = padding;
+		let right = padding;
+
 		if (isObject(xPadding) && notEmpty(xPadding)) {
-			paddingLeft = isValue(xPadding.left) ? xPadding.left : padding;
-			paddingRight = isValue(xPadding.right) ? xPadding.right : padding;
+			left = isValue(xPadding.left) ? xPadding.left : padding;
+			right = isValue(xPadding.right) ? xPadding.right : padding;
 		} else if (isNumber(config.axis_x_padding)) {
-			paddingLeft = xPadding;
-			paddingRight = xPadding;
-		} else {
-			paddingLeft = padding;
-			paddingRight = padding;
+			left = xPadding;
+			right = xPadding;
 		}
 
-		return {
-			left: paddingLeft,
-			right: paddingRight
-		};
+		return {left, right};
 	},
 
 	getXDomain(targets) {

--- a/src/internals/util.js
+++ b/src/internals/util.js
@@ -223,12 +223,69 @@ const getCssRules = styleSheets => {
 	return rules;
 };
 
+// emulate event
+const emulateEvent = {
+	mouse: (() => {
+		const getParams = () => ({
+			bubbles: false, cancelable: false, screenX: 0, screenY: 0, clientX: 0, clientY: 0
+		});
+
+		try {
+			// eslint-disable-next-line no-new
+			new MouseEvent("t");
+
+			return (el, eventType, params = getParams()) => {
+				el.dispatchEvent(new MouseEvent(eventType, params));
+			};
+		} catch (e) {
+			// Polyfills DOM4 MouseEvent
+			return (el, eventType, params = getParams()) => {
+				const mouseEvent = document.createEvent("MouseEvent");
+
+				// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/initMouseEvent
+				mouseEvent.initMouseEvent(
+					eventType,
+					params.bubbles,
+					params.cancelable,
+					window,
+					0, // the event's mouse click count
+					params.screenX, params.screenY,
+					params.clientX, params.clientY,
+					false, false, false, false, 0, null
+				);
+
+				el.dispatchEvent(mouseEvent);
+			};
+		}
+	})(),
+	touch: (el, eventType, params) => {
+		const touchObj = new Touch(Object.assign({
+			identifier: Date.now(),
+			target: el,
+			radiusX: 2.5,
+			radiusY: 2.5,
+			rotationAngle: 10,
+			force: 0.5
+		}, params));
+
+		el.dispatchEvent(new TouchEvent(eventType, {
+			cancelable: true,
+			bubbles: true,
+			shiftKey: true,
+			touches: [touchObj],
+			targetTouches: [],
+			changedTouches: [touchObj]
+		}));
+	}
+};
+
 export {
 	asHalfPixel,
 	brushEmpty,
 	capitalize,
 	ceil10,
 	diffDomain,
+	emulateEvent,
 	extend,
 	getBrushSelection,
 	getCssRules,

--- a/src/shape/shape.js
+++ b/src/shape/shape.js
@@ -185,8 +185,8 @@ extend(ChartInternal.prototype, {
 
 	getInterpolateType(d) {
 		const $$ = this;
-		const interpolation = $$.isInterpolationType($$.config.spline_interpolation_type) ?
-			$$.config.spline_interpolation_type : "cardinal";
+		const type = $$.config.spline_interpolation_type;
+		const interpolation = $$.isInterpolationType(type) ? type : "cardinal";
 
 		return $$.isSplineType(d) ?
 			interpolation : (


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#177

## Details
<!-- Detailed description of the change/feature -->
- Added internal 'getCustomizedScale()' to handle scale updates when zoom occurs and sum with the category offset
- Update default value for zoom events options(onzoomstart, onzoom, onzoomend) to undefined to avoid unnecessary call
- Reset zoom scaling when `.flush()` is called
- Moved 'emulateEvent' to util.js
- And some refactorings