### PR TITLE
merging existing template class & billboard legendItem class

### DIFF
--- a/src/internals/legend.js
+++ b/src/internals/legend.js
@@ -312,7 +312,7 @@ extend(ChartInternal.prototype, {
 		const isTouch = $$.inputType === "touch";
 
 		item
-			.attr("class", id => $$.generateClass(CLASS.legendItem, id))
+			.attr("class", id => `${!!item.attr("class") && item.attr("class")}${$$.generateClass(CLASS.legendItem, id)}`)
 			.style("visibility", id => ($$.isLegendToShow(id) ? "visible" : "hidden"))
 			.style("cursor", "pointer")
 			.on("click", id => {


### PR DESCRIPTION

## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
<!-- Detailed description of the change/feature -->
Hi, although I have been using this chart library well, I found that current billboard.js is overriding `legend.contents.template` class.  I opened this PR because I need to use my own class too for style. :)   
If there're existing options or ways to do like this, please let me know.  

* BEFORE => overriding existed class to billboard legendItem class
* NOW => `${external template class} ${billboard generated legendItem class}`
