### PR TITLE
skip: Fix side effects from the 1.5.0 changes

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -829,7 +829,7 @@ var demos = {
 				}
 			},
 			style: [
-				"#XAxisTickPosition .bb-axis-x line, .bb-axis-x path { visibility: hidden; }"
+				"#XAxisTickPosition .bb-axis-x line, #XAxisTickPosition .bb-axis-x path { visibility: hidden; }"
 			]
 		},
 		XAxisTimezone: {

--- a/demo/simple-sidebar.css
+++ b/demo/simple-sidebar.css
@@ -219,4 +219,4 @@ div.row {
 #RadarAxis .bb-levels polygon { stroke-dasharray: 1 3; stroke-width: 1px; }
 
 /* Style For tick position */
-#XAxisTickPosition .bb-axis-x line, .bb-axis-x path { visibility: hidden; }
+#XAxisTickPosition .bb-axis-x line, #XAxisTickPosition .bb-axis-x path { visibility: hidden; }

--- a/spec/api/api.chart-spec.js
+++ b/spec/api/api.chart-spec.js
@@ -64,6 +64,24 @@ describe("API chart", () => {
 
 			expect(pie.selectAll("path").size()).to.be.equal(chart.data().length);
 		});
+
+		it("should be transformed line -> pie -> line", done => {
+			const main = chart.internal.main;
+			const pie = main.select(`.${CLASS.chartArcs}`);
+
+			chart.transform("pie");
+
+			setTimeout(() => {
+				chart.transform("line");
+			}, 500);
+
+			setTimeout(() => {
+				// pie should be redrawn
+				expect(pie.selectAll("path").size()).to.be.equal(0);
+
+				done();
+			}, 1000);
+		});
 	});
 
 	describe("groups()", () => {

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -711,7 +711,7 @@ export default class ChartInternal {
 		$$.redrawTitle && $$.redrawTitle();
 
 		// arc
-		$$.hasArcType(null, ["radar"]) && $$.redrawArc(duration, durationForExit, withTransform);
+		$$.redrawArc && $$.redrawArc(duration, durationForExit, withTransform);
 
 		// radar
 		hasRadar && $$.redrawRadar();


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
- Revert the redrawArc call, it's causing pie not been hide on .transform() api
- Update wrong css rule for axis
