### PR TITLE
fix(event): Correct on resizing all generated charts

### DIFF
--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -56,89 +56,87 @@ describe("Interface & initialization", () => {
 		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
 	});
 
-	describe("check for auto resize", () => {
-		it("should resize correctly in flex container", done => {
-			// set flex container
-			document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
-			const chart = util.generate({
-				bindto: "#flex-container",
-				data: {
-					columns: [
-						["data1", 30, 200, 100, 400],
-						["data2", 500, 800, 500, 2000]
-					]
-				}
+	it("should resize correctly in flex container", done => {
+		// set flex container
+		document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
+		const chart = util.generate({
+			bindto: "#flex-container",
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 500, 800, 500, 2000]
+				]
+			}
+		});
+
+		const chartWidth = +chart.internal.svg.attr("width");
+		const diff = 50;
+
+		// shrink width & resize
+		document.body.style.width = `${document.body.offsetWidth - diff}px`;
+		chart.internal.resizeFunction();
+
+		setTimeout(() => {
+			expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
+
+			// reset the body
+			document.body.innerHTML = "";
+			done();
+		}, 300);
+	});
+
+	it("height shouldn't be increased on resize event", done => {
+		const body = document.body;
+		body.innerHTML = '<div id="chartResize"></div>';
+
+		const chart = bb.generate({
+			bindto: "#chartResize",
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 500, 800, 500, 2000]
+				]
+			}
+		});
+		const chartHeight = +chart.internal.svg.attr("height");
+
+		body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
+		chart.internal.resizeFunction();
+
+		setTimeout(() => {
+			expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
+
+			// reset the body
+			body.removeAttribute("style");
+			body.innerHTML = "";
+
+			done();
+		}, 300);
+	});
+
+	it("should be resizing all generated chart elements", done => {
+		const width = 300;
+		const options = {
+			data: {
+				columns: [
+					["data1", 30]
+				]
+			}
+		};
+		const chart = [util.generate(options), util.generate(options)];
+
+		document.body.style.width = width + "px";
+		chart[chart.length - 1].internal.resizeFunction();
+
+		setTimeout(() => {
+			chart.forEach(inst => {
+				expect(+inst.internal.svg.attr("width")).to.be.equal(width);
 			});
 
-			const chartWidth = +chart.internal.svg.attr("width");
-			const diff = 50;
+			// should revert to not affect other tests
+			document.body.style.width = "";
 
-			// shrink width & resize
-			document.body.style.width = `${document.body.offsetWidth - diff}px`;
-			chart.internal.resizeFunction();
-
-			setTimeout(() => {
-				expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
-
-				// reset the body
-				document.body.innerHTML = "";
-				done();
-			}, 100);
-		});
-
-		it("height shouldn't be increased on resize event", done => {
-			const body = document.body;
-			body.innerHTML = '<div id="chartResize"></div>';
-
-			const chart = bb.generate({
-				bindto: "#chartResize",
-				data: {
-					columns: [
-						["data1", 30, 200, 100, 400],
-						["data2", 500, 800, 500, 2000]
-					]
-				}
-			});
-			const chartHeight = +chart.internal.svg.attr("height");
-
-			body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
-			chart.internal.resizeFunction();
-
-			setTimeout(() => {
-				expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
-
-				// reset the body
-				body.removeAttribute("style");
-				body.innerHTML = "";
-
-				done();
-			}, 500);
-		});
-
-		it("should be resizing all generated chart elements", done => {
-			const width = 300;
-			const options = {
-				data: {
-					columns: [
-						["data1", 30]
-					]
-				}
-			};
-			const chart = [util.generate(options), util.generate(options)];
-
-			document.body.style.width = width + "px";
-			chart[chart.length - 1].internal.resizeFunction();
-
-			setTimeout(() => {
-				chart.forEach(inst => {
-					expect(+inst.internal.svg.attr("width")).to.be.equal(width);
-				});
-
-				// should revert to not affect other tests
-				document.body.style.width = "";
-
-				done();
-			}, 100);
-		});
+			done();
+		}, 300);
 	});
 });

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -38,63 +38,6 @@ describe("Interface & initialization", () => {
 		expect(bb.version.length > 0).to.be.ok;
 	});
 
-	it("should resize correctly in flex container", done => {
-		// set flex container
-		document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
-		const chart = util.generate({
-			bindto: "#flex-container",
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-
-		const chartWidth = +chart.internal.svg.attr("width");
-		const diff = 50;
-
-		// shrink width & resize
-		document.body.style.width = `${document.body.offsetWidth - diff}px`;
-		chart.internal.resizeFunction();
-
-		setTimeout(() => {
-			expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
-
-			// reset the body
-			document.body.innerHTML = "";
-			done();
-		}, 100);
-	});
-
-	it("height shouldn't be increased on resize event", done => {
-		const body = document.body;
-		body.innerHTML = '<div id="chartResize"></div>';
-
-		const chart = bb.generate({
-			bindto: "#chartResize",
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-		const chartHeight = +chart.internal.svg.attr("height");
-
-		body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
-		chart.internal.resizeFunction();
-
-		setTimeout(() => {
-			expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
-
-			// reset the body
-			body.removeAttribute("style");
-			body.innerHTML = "";
-			done();
-		}, 500);
-	});
-
 	it("instantiate with different classname on wrapper element", () => {
 		const bindtoClassName = "billboard-js";
 		const chart = bb.generate({
@@ -111,5 +54,92 @@ describe("Interface & initialization", () => {
 		});
 
 		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
+	});
+
+	describe("auto resize", () => {
+		it("should resize correctly in flex container", done => {
+			// set flex container
+			document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
+			const chart = util.generate({
+				bindto: "#flex-container",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				}
+			});
+
+			const chartWidth = +chart.internal.svg.attr("width");
+			const diff = 50;
+
+			// shrink width & resize
+			document.body.style.width = `${document.body.offsetWidth - diff}px`;
+			d3.select(window).on("resize.bb")();
+
+			setTimeout(() => {
+				expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
+
+				// reset the body
+				document.body.innerHTML = "";
+				done();
+			}, 500);
+		});
+
+		it("height shouldn't be increased on resize event", done => {
+			const body = document.body;
+			body.innerHTML = '<div id="chartResize"></div>';
+
+			const chart = bb.generate({
+				bindto: "#chartResize",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				}
+			});
+			const chartHeight = +chart.internal.svg.attr("height");
+
+			body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
+			d3.select(window).on("resize.bb")();
+
+			setTimeout(() => {
+				expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
+
+				// reset the body
+				body.removeAttribute("style");
+				body.innerHTML = "";
+				done();
+			}, 500);
+		});
+
+		it("should be resizing all generated chart elements", done => {
+			const width = 300;
+			const body = document.body;
+			const options = {
+				data: {
+					columns: [
+						["data1", 30]
+					]
+				}
+			};
+			const chart1 = util.generate(options.bindto = "#chart1" && options);
+			const chart2 = util.generate(options.bindto = "#chart2" && options);
+
+			body.style.width = width + "px";
+
+			// run the resize handler
+			d3.select(window).on("resize.bb")();
+
+			setTimeout(() => {
+				expect(+chart1.internal.svg.attr("width")).to.be.equal(width);
+				expect(+chart2.internal.svg.attr("width")).to.be.equal(width);
+
+				// should revert to not affect other tests
+				body.removeAttribute("style");
+				done();
+			}, 500);
+		});
 	});
 });

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -38,63 +38,6 @@ describe("Interface & initialization", () => {
 		expect(bb.version.length > 0).to.be.ok;
 	});
 
-	it("should resize correctly in flex container", done => {
-		// set flex container
-		document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
-		const chart = util.generate({
-			bindto: "#flex-container",
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-
-		const chartWidth = +chart.internal.svg.attr("width");
-		const diff = 50;
-
-		// shrink width & resize
-		document.body.style.width = `${document.body.offsetWidth - diff}px`;
-		chart.internal.resizeFunction();
-
-		setTimeout(() => {
-			expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
-
-			// reset the body
-			document.body.innerHTML = "";
-			done();
-		}, 100);
-	});
-
-	it("height shouldn't be increased on resize event", done => {
-		const body = document.body;
-		body.innerHTML = '<div id="chartResize"></div>';
-
-		const chart = bb.generate({
-			bindto: "#chartResize",
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-		const chartHeight = +chart.internal.svg.attr("height");
-
-		body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
-		chart.internal.resizeFunction();
-
-		setTimeout(() => {
-			expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
-
-			// reset the body
-			body.removeAttribute("style");
-			body.innerHTML = "";
-			done();
-		}, 500);
-	});
-
 	it("instantiate with different classname on wrapper element", () => {
 		const bindtoClassName = "billboard-js";
 		const chart = bb.generate({
@@ -111,5 +54,91 @@ describe("Interface & initialization", () => {
 		});
 
 		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
+	});
+
+	describe("check for auto resize", () => {
+		it("should resize correctly in flex container", done => {
+			// set flex container
+			document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
+			const chart = util.generate({
+				bindto: "#flex-container",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				}
+			});
+
+			const chartWidth = +chart.internal.svg.attr("width");
+			const diff = 50;
+
+			// shrink width & resize
+			document.body.style.width = `${document.body.offsetWidth - diff}px`;
+			chart.internal.resizeFunction();
+
+			setTimeout(() => {
+				expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
+
+				// reset the body
+				document.body.innerHTML = "";
+				done();
+			}, 100);
+		});
+
+		it("height shouldn't be increased on resize event", done => {
+			const body = document.body;
+			body.innerHTML = '<div id="chartResize"></div>';
+
+			const chart = bb.generate({
+				bindto: "#chartResize",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				}
+			});
+			const chartHeight = +chart.internal.svg.attr("height");
+
+			body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
+			chart.internal.resizeFunction();
+
+			setTimeout(() => {
+				expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
+
+				// reset the body
+				body.removeAttribute("style");
+				body.innerHTML = "";
+
+				done();
+			}, 500);
+		});
+
+		it("should be resizing all generated chart elements", done => {
+			const width = 300;
+			const options = {
+				data: {
+					columns: [
+						["data1", 30]
+					]
+				}
+			};
+			const chart = [util.generate(options), util.generate(options)];
+
+			document.body.style.width = width + "px";
+			chart[chart.length - 1].internal.resizeFunction();
+
+			setTimeout(() => {
+				chart.forEach(inst => {
+					expect(+inst.internal.svg.attr("width")).to.be.equal(width);
+				});
+
+				// should revert to not affect other tests
+				document.body.style.width = "";
+
+				done();
+			}, 100);
+		});
 	});
 });

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -60,6 +60,7 @@ describe("Interface & initialization", () => {
 		it("should resize correctly in flex container", done => {
 			// set flex container
 			document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
+
 			const chart = util.generate({
 				bindto: "#flex-container",
 				data: {
@@ -83,7 +84,7 @@ describe("Interface & initialization", () => {
 				// reset the body
 				document.body.innerHTML = "";
 				done();
-			}, 100);
+			}, 300);
 		});
 
 		it("height shouldn't be increased on resize event", done => {
@@ -111,7 +112,7 @@ describe("Interface & initialization", () => {
 				body.removeAttribute("style");
 				body.innerHTML = "";
 				done();
-			}, 300);
+			}, 500);
 		});
 
 		it("should be resizing all generated chart elements", done => {
@@ -124,8 +125,8 @@ describe("Interface & initialization", () => {
 					]
 				}
 			};
-			const chart1 = util.generate(options);
-			const chart2 = util.generate(options);
+			const chart1 = util.generate(options.bindto = "#chart1" && options);
+			const chart2 = util.generate(options.bindto = "#chart2" && options);
 
 			body.style("width", width + "px");
 
@@ -140,7 +141,7 @@ describe("Interface & initialization", () => {
 				body.style("width", null);
 
 				done();
-			}, 500);
+			}, 700);
 		});
 	});
 });

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -38,6 +38,63 @@ describe("Interface & initialization", () => {
 		expect(bb.version.length > 0).to.be.ok;
 	});
 
+	it("should resize correctly in flex container", done => {
+		// set flex container
+		document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
+		const chart = util.generate({
+			bindto: "#flex-container",
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 500, 800, 500, 2000]
+				]
+			}
+		});
+
+		const chartWidth = +chart.internal.svg.attr("width");
+		const diff = 50;
+
+		// shrink width & resize
+		document.body.style.width = `${document.body.offsetWidth - diff}px`;
+		chart.internal.resizeFunction();
+
+		setTimeout(() => {
+			expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
+
+			// reset the body
+			document.body.innerHTML = "";
+			done();
+		}, 100);
+	});
+
+	it("height shouldn't be increased on resize event", done => {
+		const body = document.body;
+		body.innerHTML = '<div id="chartResize"></div>';
+
+		const chart = bb.generate({
+			bindto: "#chartResize",
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 500, 800, 500, 2000]
+				]
+			}
+		});
+		const chartHeight = +chart.internal.svg.attr("height");
+
+		body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
+		chart.internal.resizeFunction();
+
+		setTimeout(() => {
+			expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
+
+			// reset the body
+			body.removeAttribute("style");
+			body.innerHTML = "";
+			done();
+		}, 500);
+	});
+
 	it("instantiate with different classname on wrapper element", () => {
 		const bindtoClassName = "billboard-js";
 		const chart = bb.generate({
@@ -54,94 +111,5 @@ describe("Interface & initialization", () => {
 		});
 
 		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
-	});
-
-	describe("auto resizing", () => {
-		it("should resize correctly in flex container", done => {
-			// set flex container
-			document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
-
-			const chart = util.generate({
-				bindto: "#flex-container",
-				data: {
-					columns: [
-						["data1", 30, 200, 100, 400],
-						["data2", 500, 800, 500, 2000]
-					]
-				}
-			});
-
-			const chartWidth = +chart.internal.svg.attr("width");
-			const diff = 50;
-
-			// shrink width & resize
-			document.body.style.width = `${document.body.offsetWidth - diff}px`;
-			chart.internal.resizeFunction();
-
-			setTimeout(() => {
-				expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
-
-				// reset the body
-				document.body.innerHTML = "";
-				done();
-			}, 300);
-		});
-
-		it("height shouldn't be increased on resize event", done => {
-			const body = document.body;
-			body.innerHTML = '<div id="chartResize"></div>';
-
-			const chart = bb.generate({
-				bindto: "#chartResize",
-				data: {
-					columns: [
-						["data1", 30, 200, 100, 400],
-						["data2", 500, 800, 500, 2000]
-					]
-				}
-			});
-			const chartHeight = +chart.internal.svg.attr("height");
-
-			body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
-			chart.internal.resizeFunction();
-
-			setTimeout(() => {
-				expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
-
-				// reset the body
-				body.removeAttribute("style");
-				body.innerHTML = "";
-				done();
-			}, 500);
-		});
-
-		it("should be resizing all generated chart elements", done => {
-			const width = 300;
-			const body = d3.select(document.body);
-			const options = {
-				data: {
-					columns: [
-						["data1", 30]
-					]
-				}
-			};
-			const chart1 = util.generate(options.bindto = "#chart1" && options);
-			const chart2 = util.generate(options.bindto = "#chart2" && options);
-
-			body.style("width", width + "px");
-
-			// run the resize handler
-			d3.select(window).on("resize.bb")();
-
-			setTimeout(() => {
-				expect(+chart1.internal.svg.attr("width")).to.be.equal(width);
-				expect(+chart2.internal.svg.attr("width")).to.be.equal(width);
-
-				// should revert to not affect other tests
-				body.style("width", null);
-
-				done();
-			}, 700);
-		});
 	});
 });

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -38,24 +38,6 @@ describe("Interface & initialization", () => {
 		expect(bb.version.length > 0).to.be.ok;
 	});
 
-	it("instantiate with different classname on wrapper element", () => {
-		const bindtoClassName = "billboard-js";
-		const chart = bb.generate({
-			bindto: {
-				element: "#chart",
-				classname: bindtoClassName
-			},
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-
-		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
-	});
-
 	it("should resize correctly in flex container", done => {
 		// set flex container
 		document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
@@ -82,7 +64,7 @@ describe("Interface & initialization", () => {
 			// reset the body
 			document.body.innerHTML = "";
 			done();
-		}, 300);
+		}, 100);
 	});
 
 	it("height shouldn't be increased on resize event", done => {
@@ -109,9 +91,8 @@ describe("Interface & initialization", () => {
 			// reset the body
 			body.removeAttribute("style");
 			body.innerHTML = "";
-
 			done();
-		}, 300);
+		}, 500);
 	});
 
 	it("should be resizing all generated chart elements", done => {
@@ -138,5 +119,23 @@ describe("Interface & initialization", () => {
 
 			done();
 		}, 300);
+	});
+
+	it("instantiate with different classname on wrapper element", () => {
+		const bindtoClassName = "billboard-js";
+		const chart = bb.generate({
+			bindto: {
+				element: "#chart",
+				classname: bindtoClassName
+			},
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 500, 800, 500, 2000]
+				]
+			}
+		});
+
+		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
 	});
 });

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -56,86 +56,91 @@ describe("Interface & initialization", () => {
 		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
 	});
 
-	it("should resize correctly in flex container", done => {
-		// set flex container
-		document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
-		const chart = util.generate({
-			bindto: "#flex-container",
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-
-		const chartWidth = +chart.internal.svg.attr("width");
-		const diff = 50;
-
-		// shrink width & resize
-		document.body.style.width = `${document.body.offsetWidth - diff}px`;
-		chart.internal.resizeFunction();
-
-		setTimeout(() => {
-			expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
-
-			// reset the body
-			document.body.innerHTML = "";
-			done();
-		}, 100);
-	});
-
-	it("height shouldn't be increased on resize event", done => {
-		const body = document.body;
-		body.innerHTML = '<div id="chartResize"></div>';
-
-		const chart = bb.generate({
-			bindto: "#chartResize",
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-		const chartHeight = +chart.internal.svg.attr("height");
-
-		body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
-		chart.internal.resizeFunction();
-
-		setTimeout(() => {
-			expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
-
-			// reset the body
-			body.removeAttribute("style");
-			body.innerHTML = "";
-			done();
-		}, 500);
-	});
-
-	it("should be resizing all generated chart elements", done => {
-		const width = 300;
-		const options = {
-			data: {
-				columns: [
-					["data1", 30]
-				]
-			}
-		};
-		const chart = [util.generate(options), util.generate(options)];
-
-		document.body.style.width = width + "px";
-		chart[chart.length - 1].internal.resizeFunction();
-
-		setTimeout(() => {
-			chart.forEach(inst => {
-				expect(+inst.internal.svg.attr("width")).to.be.equal(width);
+	describe("auto resizing", () => {
+		it("should resize correctly in flex container", done => {
+			// set flex container
+			document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
+			const chart = util.generate({
+				bindto: "#flex-container",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				}
 			});
 
-			// should revert to not affect other tests
-			document.body.style.width = "";
+			const chartWidth = +chart.internal.svg.attr("width");
+			const diff = 50;
 
-			done();
-		}, 1000);
+			// shrink width & resize
+			document.body.style.width = `${document.body.offsetWidth - diff}px`;
+			chart.internal.resizeFunction();
+
+			setTimeout(() => {
+				expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
+
+				// reset the body
+				document.body.innerHTML = "";
+				done();
+			}, 100);
+		});
+
+		it("height shouldn't be increased on resize event", done => {
+			const body = document.body;
+			body.innerHTML = '<div id="chartResize"></div>';
+
+			const chart = bb.generate({
+				bindto: "#chartResize",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				}
+			});
+			const chartHeight = +chart.internal.svg.attr("height");
+
+			body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
+			chart.internal.resizeFunction();
+
+			setTimeout(() => {
+				expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
+
+				// reset the body
+				body.removeAttribute("style");
+				body.innerHTML = "";
+				done();
+			}, 300);
+		});
+
+		it("should be resizing all generated chart elements", done => {
+			const width = 300;
+			const body = d3.select(document.body);
+			const options = {
+				data: {
+					columns: [
+						["data1", 30]
+					]
+				}
+			};
+			const chart1 = util.generate(options);
+			const chart2 = util.generate(options);
+
+			body.style("width", width + "px");
+
+			// run the resize handler
+			d3.select(window).on("resize.bb")();
+
+			setTimeout(() => {
+				expect(+chart1.internal.svg.attr("width")).to.be.equal(width);
+				expect(+chart2.internal.svg.attr("width")).to.be.equal(width);
+
+				// should revert to not affect other tests
+				body.style("width", null);
+
+				done();
+			}, 500);
+		});
 	});
 });

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -38,6 +38,24 @@ describe("Interface & initialization", () => {
 		expect(bb.version.length > 0).to.be.ok;
 	});
 
+	it("instantiate with different classname on wrapper element", () => {
+		const bindtoClassName = "billboard-js";
+		const chart = bb.generate({
+			bindto: {
+				element: "#chart",
+				classname: bindtoClassName
+			},
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 500, 800, 500, 2000]
+				]
+			}
+		});
+
+		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
+	});
+
 	it("should resize correctly in flex container", done => {
 		// set flex container
 		document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
@@ -118,24 +136,6 @@ describe("Interface & initialization", () => {
 			document.body.style.width = "";
 
 			done();
-		}, 300);
-	});
-
-	it("instantiate with different classname on wrapper element", () => {
-		const bindtoClassName = "billboard-js";
-		const chart = bb.generate({
-			bindto: {
-				element: "#chart",
-				classname: bindtoClassName
-			},
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-
-		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
+		}, 1000);
 	});
 });

--- a/src/api/api.chart.js
+++ b/src/api/api.chart.js
@@ -67,7 +67,7 @@ extend(Chart.prototype, {
 			isDefined($$.intervalForObserveInserted) && window.clearInterval($$.intervalForObserveInserted);
 			isDefined($$.resizeTimeout) && window.clearTimeout($$.resizeTimeout);
 
-			d3Select(window).on("resize", null);
+			d3Select(window).on("resize.bb", null);
 			$$.selectChart.classed("bb", false).html("");
 
 			// releasing references

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -1154,7 +1154,11 @@ export default class ChartInternal {
 		$$.resizeFunction.add(() => config.onresized.call($$));
 
 		// attach resize event
-		d3Select(window).on("resize", $$.resizeFunction);
+		// get the possible previous attached
+		const resizeEvents = d3Select(window).on("resize.bb");
+
+		resizeEvents && $$.resizeFunction.add(resizeEvents);
+		d3Select(window).on("resize.bb", $$.resizeFunction);
 	}
 
 	generateResize() {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#466

## Details
<!-- Detailed description of the change/feature -->
Fix the side effect from #404.

D3's event binding, behaves removing previous attached.
Updated to keep all previous resize events.
