### PR TITLE
fix(event): Correct on resizing all generated charts

### DIFF
--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -38,63 +38,6 @@ describe("Interface & initialization", () => {
 		expect(bb.version.length > 0).to.be.ok;
 	});
 
-	it("should resize correctly in flex container", done => {
-		// set flex container
-		document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
-		const chart = util.generate({
-			bindto: "#flex-container",
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-
-		const chartWidth = +chart.internal.svg.attr("width");
-		const diff = 50;
-
-		// shrink width & resize
-		document.body.style.width = `${document.body.offsetWidth - diff}px`;
-		chart.internal.resizeFunction();
-
-		setTimeout(() => {
-			expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
-
-			// reset the body
-			document.body.innerHTML = "";
-			done();
-		}, 100);
-	});
-
-	it("height shouldn't be increased on resize event", done => {
-		const body = document.body;
-		body.innerHTML = '<div id="chartResize"></div>';
-
-		const chart = bb.generate({
-			bindto: "#chartResize",
-			data: {
-				columns: [
-					["data1", 30, 200, 100, 400],
-					["data2", 500, 800, 500, 2000]
-				]
-			}
-		});
-		const chartHeight = +chart.internal.svg.attr("height");
-
-		body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
-		chart.internal.resizeFunction();
-
-		setTimeout(() => {
-			expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
-
-			// reset the body
-			body.removeAttribute("style");
-			body.innerHTML = "";
-			done();
-		}, 500);
-	});
-
 	it("instantiate with different classname on wrapper element", () => {
 		const bindtoClassName = "billboard-js";
 		const chart = bb.generate({
@@ -111,5 +54,101 @@ describe("Interface & initialization", () => {
 		});
 
 		expect(d3.select(chart.element).classed(bindtoClassName)).to.be.true;
+	});
+
+	describe("auto resize", () => {
+		it("should resize correctly in flex container", done => {
+			// set flex container
+			document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
+			const chart = util.generate({
+				bindto: "#flex-container",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				}
+			});
+
+			const chartWidth = +chart.internal.svg.attr("width");
+			const diff = 50;
+
+			// shrink width & resize
+			document.body.style.width = `${document.body.offsetWidth - diff}px`;
+			d3.select(window).on("resize.bb")();
+
+			setTimeout(() => {
+				try {
+					expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
+
+					// reset the body
+					document.body.innerHTML = "";
+				} catch(e) {}
+
+				done();
+			}, 500);
+		});
+
+		it("height shouldn't be increased on resize event", done => {
+			const body = document.body;
+			body.innerHTML = '<div id="chartResize"></div>';
+
+			const chart = bb.generate({
+				bindto: "#chartResize",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				}
+			});
+			const chartHeight = +chart.internal.svg.attr("height");
+
+			body.style.width = `${+body.style.width.replace("px", "") - 100}px`;
+			d3.select(window).on("resize.bb")();
+
+			setTimeout(() => {
+				try {
+					expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
+
+					// reset the body
+					body.removeAttribute("style");
+					body.innerHTML = "";
+				} catch(e) {}
+
+				done();
+			}, 500);
+		});
+
+		it("should be resizing all generated chart elements", done => {
+			const width = 300;
+			const body = document.body;
+			const options = {
+				data: {
+					columns: [
+						["data1", 30]
+					]
+				}
+			};
+			const chart1 = util.generate(options.bindto = "#chart1" && options);
+			const chart2 = util.generate(options.bindto = "#chart2" && options);
+
+			body.style.width = width + "px";
+
+			// run the resize handler
+			d3.select(window).on("resize.bb")();
+
+			setTimeout(() => {
+				try {
+					expect(+chart1.internal.svg.attr("width")).to.be.equal(width);
+					expect(+chart2.internal.svg.attr("width")).to.be.equal(width);
+
+					// should revert to not affect other tests
+					body.removeAttribute("style");
+				} catch(e) {}
+
+				done();
+			}, 500);
+		});
 	});
 });

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -57,14 +57,14 @@ describe("Interface & initialization", () => {
 	});
 
 	describe("auto resize", () => {
-		beforeEach(function(done) {
-			this.timeout(5000);
-			setTimeout(done, 2500);
-		});
+		it("should resize correctly in flex container", function(done) {
+			this.timeout(4000);
 
-		it("should resize correctly in flex container", done => {
+			const body = document.body;
+
 			// set flex container
-			document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
+			body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
+
 			const chart = util.generate({
 				bindto: "#flex-container",
 				data: {
@@ -79,20 +79,22 @@ describe("Interface & initialization", () => {
 			const diff = 50;
 
 			// shrink width & resize
-			document.body.style.width = `${document.body.offsetWidth - diff}px`;
+			body.style.width = `${document.body.offsetWidth - diff}px`;
 			d3.select(window).on("resize.bb")();
 
 			setTimeout(() => {
 				expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
 
 				// reset the body
-				document.body.innerHTML = "";
+				body.innerHTML = "";
 
 				done();
-			}, 500);
+			}, 200);
 		});
 
-		it("height shouldn't be increased on resize event", done => {
+		it("height shouldn't be increased on resize event", function(done) {
+			this.timeout(4000);
+
 			const body = document.body;
 			body.innerHTML = '<div id="chartResize"></div>';
 
@@ -121,7 +123,9 @@ describe("Interface & initialization", () => {
 			}, 500);
 		});
 
-		it("should be resizing all generated chart elements", done => {
+		it("should be resizing all generated chart elements", function(done) {
+			this.timeout(4000);
+
 			const width = 300;
 			const body = document.body;
 			const options = {

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -57,6 +57,11 @@ describe("Interface & initialization", () => {
 	});
 
 	describe("auto resize", () => {
+		beforeEach(function(done) {
+			this.timeout(3000);
+			setTimeout(done, 2500);
+		});
+
 		it("should resize correctly in flex container", done => {
 			// set flex container
 			document.body.innerHTML = '<div style="display:flex"><div style="display:block;flex-basis:0;flex-grow:1;flex-shrink:1"><div id="flex-container"></div></div></div>';
@@ -78,12 +83,10 @@ describe("Interface & initialization", () => {
 			d3.select(window).on("resize.bb")();
 
 			setTimeout(() => {
-				try {
-					expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
+				expect(+chart.internal.svg.attr("width")).to.be.equal(chartWidth - diff);
 
-					// reset the body
-					document.body.innerHTML = "";
-				} catch(e) {}
+				// reset the body
+				document.body.innerHTML = "";
 
 				done();
 			}, 500);
@@ -108,13 +111,11 @@ describe("Interface & initialization", () => {
 			d3.select(window).on("resize.bb")();
 
 			setTimeout(() => {
-				try {
-					expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
+				expect(+chart.internal.svg.attr("height")).to.be.equal(chartHeight);
 
-					// reset the body
-					body.removeAttribute("style");
-					body.innerHTML = "";
-				} catch(e) {}
+				// reset the body
+				body.removeAttribute("style");
+				body.innerHTML = "";
 
 				done();
 			}, 500);
@@ -139,13 +140,11 @@ describe("Interface & initialization", () => {
 			d3.select(window).on("resize.bb")();
 
 			setTimeout(() => {
-				try {
-					expect(+chart1.internal.svg.attr("width")).to.be.equal(width);
-					expect(+chart2.internal.svg.attr("width")).to.be.equal(width);
+				expect(+chart1.internal.svg.attr("width")).to.be.equal(width);
+				expect(+chart2.internal.svg.attr("width")).to.be.equal(width);
 
-					// should revert to not affect other tests
-					body.removeAttribute("style");
-				} catch(e) {}
+				// should revert to not affect other tests
+				body.removeAttribute("style");
 
 				done();
 			}, 500);

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -58,7 +58,7 @@ describe("Interface & initialization", () => {
 
 	describe("auto resize", () => {
 		beforeEach(function(done) {
-			this.timeout(3000);
+			this.timeout(5000);
 			setTimeout(done, 2500);
 		});
 

--- a/src/api/api.chart.js
+++ b/src/api/api.chart.js
@@ -67,7 +67,7 @@ extend(Chart.prototype, {
 			isDefined($$.intervalForObserveInserted) && window.clearInterval($$.intervalForObserveInserted);
 			isDefined($$.resizeTimeout) && window.clearTimeout($$.resizeTimeout);
 
-			d3Select(window).on("resize", null);
+			d3Select(window).on("resize.bb", null);
 			$$.selectChart.classed("bb", false).html("");
 
 			// releasing references

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -1154,7 +1154,11 @@ export default class ChartInternal {
 		$$.resizeFunction.add(() => config.onresized.call($$));
 
 		// attach resize event
-		d3Select(window).on("resize", $$.resizeFunction);
+		// get the possible previous attached
+		const resizeEvents = d3Select(window).on("resize.bb");
+
+		resizeEvents && $$.resizeFunction.add(resizeEvents);
+		d3Select(window).on("resize.bb", $$.resizeFunction);
 	}
 
 	generateResize() {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#466

## Details
<!-- Detailed description of the change/feature -->
Fix the side effect from #404.
D3's event binding, behaves removing previous attached.
Updated to keep all previous resize events.
