### PR TITLE
fix(color): Correct the way on setting pattern value

### DIFF
--- a/spec/internals/color-spec.js
+++ b/spec/internals/color-spec.js
@@ -48,7 +48,7 @@ describe("COLOR", () => {
 			expect(pttrn).to.deep.equal(pattern);
 
 			// check if pattern value are cached
-			expect(internal.getCache("colorPattern")).to.deep.equal(pattern);
+			expect(document.body["__colorPattern__"]).to.deep.equal(pattern);
 		});
 
 		it("check if color pattern applied to data elements", () => {

--- a/src/internals/color.js
+++ b/src/internals/color.js
@@ -45,9 +45,9 @@ extend(ChartInternal.prototype, {
 	 * @private
 	 */
 	getColorFromCss() {
-		const $$ = this;
-		const cacheKey = "colorPattern";
-		let pattern = $$.getCache(cacheKey);
+		const cacheKey = "__colorPattern__";
+		const body = document.body;
+		let pattern = body[cacheKey];
 
 		if (!pattern) {
 			const delimiter = ";";
@@ -55,7 +55,7 @@ extend(ChartInternal.prototype, {
 
 			span.className = CLASS.colorPattern;
 			span.style.display = "none";
-			document.body.appendChild(span);
+			body.appendChild(span);
 
 			const content = window.getComputedStyle(span).backgroundImage;
 
@@ -68,8 +68,7 @@ extend(ChartInternal.prototype, {
 					.map(v => v.trim().replace(/[\"'\s]/g, ""))
 					.filter(Boolean);
 
-
-				$$.addCache(cacheKey, pattern);
+				body[cacheKey] = pattern;
 			}
 		}
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#507

## Details
<!-- Detailed description of the change/feature -->
Internal cache isn't shared among different instances.
Use body's property to store pattern value instead.
