### PR TITLE
feat(gauge): Enhance display multiline labels

### DIFF
--- a/spec/internals/arc-spec.js
+++ b/spec/internals/arc-spec.js
@@ -232,7 +232,7 @@ describe("ARC", () => {
 		});
 
 
-		it("should show custom min/max gauge labels", () => {
+		it("should show custom gauge labels", () => {
 			const chart = util.generate({
 				gauge: {
 					width: 10,
@@ -245,6 +245,9 @@ describe("ARC", () => {
 							}
 
 							return `Min: ${value}%`;
+						},
+						format: function(value) {
+							return value +"%\nTest\nValue";
 						}
 					}
 				},
@@ -256,12 +259,15 @@ describe("ARC", () => {
 				}
 			});
 
-			const chartArc = chart.internal.main.select(`.${CLASS.chartArcs}`);
+			const chartArc = chart.$.arc;
 			const min = chartArc.select(`.${CLASS.chartArcsGaugeMin}`);
 			const max = chartArc.select(`.${CLASS.chartArcsGaugeMax}`);
 
 			expect(min.text()).to.equal("Min: 0%");
 			expect(max.text()).to.equal("Max: 100%");
+
+			// gauge text should be multilined
+			expect(chartArc.selectAll(`.${CLASS.target}-data tspan`).size()).to.be.equal(3);
 		});
 
 		it("should not show gauge labels", () => {

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -2500,7 +2500,7 @@ export default class Options {
 			 * @type {Object}
 			 * @property {Boolean} [gauge.fullCircle=false] Show full circle as donut. When set to 'true', the max label will not be showed due to start and end points are same location.
 			 * @property {Boolean} [gauge.label.show=true] Show or hide label on gauge.
-			 * @property {Function} [gauge.label.format] Set formatter for the label on gauge.
+			 * @property {Function} [gauge.label.format] Set formatter for the label on gauge. Label text can be multilined with `\n` character.
 			 * @property {Function} [gauge.label.extents] Set customized min/max label text.
 			 * @property {Boolean} [gauge.expand=true] Enable or disable expanding gauge.
 			 * @property {Number} [gauge.expand.duration=50] Set the expand transition time in milliseconds.
@@ -2516,6 +2516,9 @@ export default class Options {
 			 *          show: false,
 			 *          format: function(value, ratio) {
 			 *              return value;
+			 *
+			 *              // to multiline, return with '\n' character
+			 *              // return value +"%\nLine1\n2Line2";
 			 *          },
 			 *          extents: function(value, isMax) {
 		 	 *              return (isMax ? "Max:" : "Min:") + value;


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#442

## Details
<!-- Detailed description of the change/feature -->
Implement to be multilined using '\n' character.

```js
bb.generate({
	gauge: {
		width: 30,
		max: 100,
		expand: true,
		label: {
                        format: function(value) {
				return value +"%\nTest\nValue";
                       }
		}
	},
	data: {
		columns: [
			["data", 8]
		],
		type: "gauge"
	}
});
```

![image](https://user-images.githubusercontent.com/2178435/43391529-d992095e-942b-11e8-8ca4-969577eac2f5.png)

