### PR TITLE
fix(env): be specific about d3 dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3479,6 +3479,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-5.5.0.tgz",
       "integrity": "sha512-HRDSYvT3n7kMvJH7Avp7iR0Xsz97bkCFka9aOg04EdyXyiAP8yQzUpLH3712y9R7ffVo1g94t1OYFHBB0yI9vQ==",
+      "dev": true,
       "requires": {
         "d3-array": "1",
         "d3-axis": "1",
@@ -3521,7 +3522,8 @@
     "d3-axis": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.8.tgz",
-      "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo="
+      "integrity": "sha1-MacFoLU15ldZ3hQXOjGTMTfxjvo=",
+      "dev": true
     },
     "d3-brush": {
       "version": "1.0.4",
@@ -3539,6 +3541,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
       "integrity": "sha1-fexPC6iG9xP+ERxF92NBT290yiw=",
+      "dev": true,
       "requires": {
         "d3-array": "1",
         "d3-path": "1"
@@ -3558,6 +3561,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.0.tgz",
       "integrity": "sha512-6zccxidQRtcydx0lWqHawdW1UcBzKZTxv0cW90Dlx98pY/L7GjQJmftH1tWopYFDaLCoXU0ECg9x/z2EuFT8tg==",
+      "dev": true,
       "requires": {
         "d3-array": "^1.1.1"
       }
@@ -3595,6 +3599,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.1.0.tgz",
       "integrity": "sha512-j+V4vtT6dceQbcKYLtpTueB8Zvc+wb9I93WaFtEQIYNADXl0c1ZJMN3qQo0CssiTsAqK8pePwc7f4qiW+b0WOg==",
+      "dev": true,
       "requires": {
         "d3-dsv": "1"
       }
@@ -3603,6 +3608,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
       "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+      "dev": true,
       "requires": {
         "d3-collection": "1",
         "d3-dispatch": "1",
@@ -3619,6 +3625,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.10.0.tgz",
       "integrity": "sha512-VK/buVGgexthTTqGRNXQ/LSo3EbOFu4p2Pjud5drSIaEnOaF2moc8A3P7WEljEO1JEBEwbpAJjFWMuJiUtoBcw==",
+      "dev": true,
       "requires": {
         "d3-array": "1"
       }
@@ -3626,7 +3633,8 @@
     "d3-hierarchy": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.6.tgz",
-      "integrity": "sha512-nn4bhBnwWnMSoZgkBXD7vRyZ0xVUsNMQRKytWYHhP1I4qHw+qzApCTgSQTZqMdf4XXZbTMqA59hFusga+THA/g=="
+      "integrity": "sha512-nn4bhBnwWnMSoZgkBXD7vRyZ0xVUsNMQRKytWYHhP1I4qHw+qzApCTgSQTZqMdf4XXZbTMqA59hFusga+THA/g==",
+      "dev": true
     },
     "d3-interpolate": {
       "version": "1.2.0",
@@ -3644,17 +3652,20 @@
     "d3-polygon": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.3.tgz",
-      "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI="
+      "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI=",
+      "dev": true
     },
     "d3-quadtree": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
-      "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg="
+      "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg=",
+      "dev": true
     },
     "d3-random": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-1.1.0.tgz",
-      "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM="
+      "integrity": "sha1-ZkLlBsb6OmSFldKyRpeIqNElKdM=",
+      "dev": true
     },
     "d3-scale": {
       "version": "2.1.0",
@@ -3673,6 +3684,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.3.0.tgz",
       "integrity": "sha512-YwMbiaW2bStWvQFByK8hA6hk7ToWflspIo2TRukCqERd8isiafEMBXmwfh8c7/0Z94mVvIzIveRLVC6RAjhgeA==",
+      "dev": true,
       "requires": {
         "d3-color": "1",
         "d3-interpolate": "1"
@@ -3725,7 +3737,8 @@
     "d3-voronoi": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
-      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw=",
+      "dev": true
     },
     "d3-zoom": {
       "version": "1.7.1",
@@ -5747,14 +5760,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5769,20 +5780,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5899,8 +5907,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5912,7 +5919,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5927,7 +5933,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5935,14 +5940,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5961,7 +5964,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6042,8 +6044,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6055,7 +6056,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6177,7 +6177,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,21 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "d3": "^5.5.0"
+    "d3-array": "^1.2.1",
+    "d3-brush": "^1.0.4",
+    "d3-collection": "^1.0.4",
+    "d3-color": "^1.2.0",
+    "d3-drag": "^1.2.1",
+    "d3-dsv": "^1.0.8",
+    "d3-ease": "^1.0.3",
+    "d3-interpolate": "^1.2.0",
+    "d3-scale": "^2.1.0",
+    "d3-selection": "^1.3.0",
+    "d3-shape": "^1.2.0",
+    "d3-time": "^1.0.8",
+    "d3-time-format": "^2.1.1",
+    "d3-transition": "^1.1.1",
+    "d3-zoom": "^1.7.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",
@@ -65,6 +79,7 @@
     "coveralls": "^3.0.2",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.0",
+    "d3": "^5.5.0",
     "docdash": "^0.4.0",
     "eslint": "^5.2.0",
     "eslint-config-naver": "^2.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,14 +16,7 @@ const config = {
 		libraryTarget: "umd",
 		umdNamedDefine: true,
 	},
-	externals: (context, request, callback) => {
-		// every 'd3-*' import, will be externally required as 'd3'
-		if (/^d3-/.test(request)) {
-			return callback(null, "d3");
-		}
-
-		callback();
-	},
+	externals: /^d3-/,
 	devtool: "cheap-module-source-map",
 	module: {
 		rules: [


### PR DESCRIPTION
## Issue
Fix #391

## Details
This PR removes unnecessary d3 modules from dependencies. I tried it out in a project and it saved my bundle about 25kb gzipped.

Keeps d3 as a dev dependency for test assets, which adds `d3` to the test `window`. An overhaul of tests could be done later to remove d3 from devDependencies as well, but the important part here is keeping unnecessary bloat out of users' repos. This is just a quick, easy update to reduce overall size. Note for the maintainers: with the way npm works, there's no change to what modules are installed when developing.