### PR TITLE
fix(dev-env): Update main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.1-snapshot",
   "description": "Re-usable easy interface JavaScript chart library, based on D3 v4+",
   "homepage": "http://naver.github.io/billboard.js/",
-  "main": "dist/billboard.js",
+  "main": "src/core.js",
   "scripts": {
     "start": "webpack-serve --open",
     "build": "npm run build:production && npm run build:packaged && npm run build:theme",


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
Ref #391
Ref #525

## Details
<!-- Detailed description of the change/feature -->
Point 'src/core.js' file as main entry, to make import
only used d3 modules for module based work environments