### PR TITLE
chore(dev-env): Improved external module loading build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.1-snapshot",
   "description": "Re-usable easy interface JavaScript chart library, based on D3 v4+",
   "homepage": "http://naver.github.io/billboard.js/",
-  "main": "src/core.js",
+  "main": "dist/billboard.js",
   "scripts": {
     "start": "webpack-serve --open",
     "build": "npm run build:production && npm run build:packaged && npm run build:theme",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,9 +17,14 @@ const config = {
 		umdNamedDefine: true,
 	},
 	externals: (context, request, callback) => {
-		// every 'd3-*' import, will be externally required as 'd3'
+		// every 'd3-*' import, will be externally required as their name except root as 'd3'
 		if (/^d3-/.test(request)) {
-			return callback(null, "d3");
+			return callback(null, {
+				commonjs: request,
+				commonjs2: request,
+				amd: request,
+				root: "d3"
+			});
 		}
 
 		callback();


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
Ref #525
Ref #391

## Details
<!-- Detailed description of the change/feature -->
Make only root is required with the name of 'd3' and others requiring as it is.
