### PR TITLE
chore(doc): Update jsdoc output options

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -30,6 +30,27 @@
   },
   "docdash": {
     "static": true,
-    "sort": true
+    "sort": true,
+    "sectionOrder": [
+      "Namespaces",
+      "Classes"
+    ],
+    "meta": {
+      "title": "billboard.js API doc",
+      "description": "Re-usable, easy interface JavaScript chart library based on D3 v4+",
+      "keyword": "chart, SVG, D3, Data Visualization"
+    },
+    "search": true,
+    "typedefs": true,
+    "menu":{
+      "Examples": {
+        "href":"https://naver.github.io/billboard.js/demo/",
+        "target":"_blank"
+      },
+      "GitHub": {
+        "href":"https://github.com/naver/billboard.js",
+        "target":"_blank"
+      }
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3840,9 +3840,9 @@
       }
     },
     "docdash": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/docdash/-/docdash-0.4.0.tgz",
-      "integrity": "sha1-BcOlDYMYmYFpnuDAdtOjlQ237AA=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/docdash/-/docdash-1.0.0.tgz",
+      "integrity": "sha512-HhK72PT4z55og8FDqskO/tTYXxU+LovRz+9pCDHLnUoPchkxjdIJidS+96LqW3CLrRdBmnkDRrcVrDFGLIluTw==",
       "dev": true
     },
     "doctrine": {
@@ -5528,12 +5528,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5548,17 +5550,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5675,7 +5680,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5687,6 +5693,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5701,6 +5708,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5708,12 +5716,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5732,6 +5742,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5812,7 +5823,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5824,6 +5836,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5945,6 +5958,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,9 +2520,9 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-docdash@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/docdash/-/docdash-0.4.0.tgz#05c3a50d83189981699ee0c076d3a3950db7ec00"
+docdash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/docdash/-/docdash-1.0.0.tgz#5b7df10fed3d341fc4416a8978c65ad561869d18"
 
 doctrine@1.5.0:
   version "1.5.0"


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
Due to the docdash 1.0 update, add some useful options for API doc generation.
This will add search field and some updates. 

![image](https://user-images.githubusercontent.com/2178435/44501582-cc88fd80-a6c8-11e8-9510-3ad7ba7ecc96.png)
