### PR TITLE
skip: allow to set null for .config() api

### DIFF
--- a/spec/api/api.chart-spec.js
+++ b/spec/api/api.chart-spec.js
@@ -164,6 +164,10 @@ describe("API chart", () => {
 			max = +chart.config("gauge.max", expected);
 			expect(max).to.be.equal(expected);
 
+			expected = null;
+			max = chart.config("gauge.max", expected);
+			expect(max).to.be.equal(expected);
+
 			// check for the setter and redraw
 			expected = 100;
 			max = +chart.config("gauge.max", expected, true);

--- a/src/api/api.chart.js
+++ b/src/api/api.chart.js
@@ -119,8 +119,10 @@ extend(Chart.prototype, {
 		let res;
 
 		if (key in $$.config) {
-			if ((res = value)) {
+			if (isDefined(value)) {
 				$$.config[key] = value;
+				res = value;
+
 				redraw && this.flush(true);
 			} else {
 				res = $$.config[key];


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#502

## Details
<!-- Detailed description of the change/feature -->
Allow to set null, for cases to set falsy value.