### PR TITLE
fix(axis): Correct not to generate unnecessary ticks

### DIFF
--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -1153,4 +1153,29 @@ describe("AXIS", function() {
 				});
 		});
 	});
+
+	describe("when data is zero, unnecessary tick shouldn't be showing", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 0]
+					]
+				},
+				axis: {
+					y: {
+						tick: {
+							count: 4
+						}
+					}
+				}
+			}
+		});
+
+		it("only one tick should be generated even counts are greater than 1", () => {
+			const ticks = chart.$.main.selectAll(`.${CLASS.axisY} .tick`);
+
+			expect(ticks.size()).to.be.equal(1);
+		});
+	});
 });

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -642,27 +642,25 @@ export default class ChartInternal {
 			xDomainForZoom = $$.x.orgDomain();
 		}
 
-		$$.y.domain($$.getYDomain(targetsToShow, "y", xDomainForZoom));
-		$$.y2.domain($$.getYDomain(targetsToShow, "y2", xDomainForZoom));
+		["y", "y2"].forEach(key => {
+			const axis = $$[key];
+			const tickValues = config[`axis_${key}_tick_values`];
+			const tickCount = config[`axis_${key}_tick_count`];
 
-		if (!config.axis_y_tick_values && config.axis_y_tick_count) {
-			$$.yAxis.tickValues(
-				$$.axis.generateTickValues(
-					$$.y.domain(),
-					config.axis_y_tick_count,
-					$$.isTimeSeriesY()
-				)
-			);
-		}
+			axis.domain($$.getYDomain(targetsToShow, key, xDomainForZoom));
 
-		if (!config.axis_y2_tick_values && config.axis_y2_tick_count) {
-			$$.y2Axis.tickValues(
-				$$.axis.generateTickValues(
-					$$.y2.domain(),
-					config.axis_y2_tick_count
-				)
-			);
-		}
+			if (!tickValues && tickCount) {
+				const domain = axis.domain();
+
+				$$[`${key}Axis`].tickValues(
+					$$.axis.generateTickValues(
+						domain,
+						domain.every(v => v === 0) ? 1 : tickCount,
+						$$.isTimeSeriesY()
+					)
+				);
+			}
+		});
 
 		// axes
 		$$.axis.redraw(transitions, hideAxis);


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#348

## Details
<!-- Detailed description of the change/feature -->
When given data is zero and tick count is greater than 1,
limit tick generation count to 1.
