### PR TITLE
fix(internal): Fix on unexpected resize event firing

### DIFF
--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -166,7 +166,9 @@ describe("Interface & initialization", () => {
 			container.style.width = width + "px";
 
 			// run the resize handler
-			d3.select(window).on("resize.bb")();
+			chart.internal.api.internal.charts.forEach(c => {
+				c.internal.resizeFunction();
+			});
 
 			setTimeout(() => {
 				expect(+chart1.internal.svg.attr("width")).to.be.equal(width);

--- a/src/api/api.chart.js
+++ b/src/api/api.chart.js
@@ -2,7 +2,6 @@
  * Copyright (c) 2017 NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {select as d3Select} from "d3-selection";
 import Chart from "../internals/Chart";
 import {window} from "../internals/browser";
 import {notEmpty, isDefined, extend} from "../internals/util";
@@ -77,7 +76,7 @@ extend(Chart.prototype, {
 			// clear timers
 			isDefined($$.resizeTimeout) && window.clearTimeout($$.resizeTimeout);
 
-			d3Select(window).on("resize.bb", null);
+			window.removeEventListener("resize", $$.resizeFunction);
 			$$.selectChart.classed("bb", false).html("");
 
 			// releasing references

--- a/src/axis/Axis.js
+++ b/src/axis/Axis.js
@@ -418,7 +418,10 @@ export default class Axis {
 			!isYAxis && this.updateXAxisTickValues(targetsToShow, axis);
 
 			const dummy = $$.selectChart.append("svg")
-				.style("visibility", "hidden");
+				.style("visibility", "hidden")
+				.style("position", "fixed")
+				.style("top", "0px")
+				.style("left", "0px");
 
 			dummy.call(axis).selectAll("text")
 				.each(function() {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#571

## Details
<!-- Detailed description of the change/feature -->
The call of getBoundingClientRect on elements with visibility:hidden
w/o defining position, can possibly cause 'resize' event.
