### PR TITLE
fix(point): Check for node.children existance for IE / Edge

### DIFF
--- a/src/shape/point.js
+++ b/src/shape/point.js
@@ -7,7 +7,7 @@ import {
 	select as d3Select
 } from "d3-selection";
 import ChartInternal from "../internals/ChartInternal";
-import {isFunction, isObjectType, toArray, extend, notEmpty} from "../internals/util";
+import {isFunction, isObjectType, toArray, extend, notEmpty, isDefined} from "../internals/util";
 
 extend(ChartInternal.prototype, {
 	hasValidPointType(type) {
@@ -39,7 +39,7 @@ extend(ChartInternal.prototype, {
 		clone.style.stroke = "inherit";
 
 		// when has child nodes
-		if (node.children.length) {
+		if (isDefined(node.children) && node.children.length) {
 			clone.innerHTML = toArray(node.children)
 				.map(v => v.outerHTML)
 				.join("");


### PR DESCRIPTION
Check if node.children is defined before trying to access its length property.

## Issue 
Ref #601

## Details
Chart with custom points throws errors in IE11/Edge, trying to access length property for node.children