### PR TITLE
fix(api): Remove cached data when .unload() is called

### DIFF
--- a/spec/api/api.load-spec.js
+++ b/spec/api/api.load-spec.js
@@ -275,7 +275,19 @@ describe("API load", function() {
 					}, 500);
 				}
 			});
+		});
 
-		})
+		it("check for .unload()", () => {
+			const target = "data2";
+
+			// when
+			chart.unload({
+				ids: target,
+				done: () => {
+					expect(chart.data(target).length).to.be.equal(0);
+					expect(chart.internal.getCache(target)).to.be.null;
+				}
+			});
+		});
 	});
 });

--- a/src/api/api.load.js
+++ b/src/api/api.load.js
@@ -71,12 +71,6 @@ extend(Chart.prototype, {
 			config.data_colors[id] = args.colors[id];
 		});
 
-		// use cache if exists
-		if ("cacheIds" in args && $$.hasCaches(args.cacheIds, true)) {
-			$$.load($$.getCache(args.cacheIds, true), args.done);
-			return;
-		}
-
 		// unload if needed
 		if ("unload" in args && args.unload !== false) {
 			// TODO: do not unload if target will load (included in url/rows/columns)
@@ -98,12 +92,17 @@ extend(Chart.prototype, {
 	 * @instance
 	 * @memberOf Chart
 	 * @param {Object} args
-	 * - If ids given, the data that has specified target id will be unloaded. ids should be String or Array. If ids is not specified, all data will be unloaded.
-	 * - If done given, the specified function will be called after data loded.
+	 *  | key | Type | Description |
+	 *  | --- | --- | --- |
+	 *  | ids | String &vert; Array | Target id data to be unloaded. If not given, all data will be unloaded. |
+	 *  | done | Fuction | Callback after data is unloaded. |
 	 * @example
 	 *  // Unload data2 and data3
 	 *  chart.unload({
-	 *    ids: ["data2", "data3"]
+	 *    ids: ["data2", "data3"],
+	 *    done: function() {
+	 *       // called after the unloaded
+	 *    }
 	 *  });
 	 */
 	unload(argsValue) {
@@ -116,13 +115,16 @@ extend(Chart.prototype, {
 			args = {ids: [args]};
 		}
 
-		$$.unload($$.mapToTargetIds(args.ids), () => {
+		const ids = $$.mapToTargetIds(args.ids);
+
+		$$.unload(ids, () => {
 			$$.redraw({
 				withUpdateOrgXDomain: true,
 				withUpdateXDomain: true,
 				withLegend: true
 			});
 
+			$$.removeCache(ids);
 			args.done && args.done();
 		});
 	}

--- a/src/internals/cache.js
+++ b/src/internals/cache.js
@@ -3,27 +3,36 @@
  * billboard.js project is licensed under the MIT license
  */
 import ChartInternal from "./ChartInternal";
-import {extend} from "./util";
+import {toArray, extend} from "./util";
 
 extend(ChartInternal.prototype, {
-	hasCaches(key, isDataType = false) {
-		if (isDataType) {
-			for (let i = 0, len = key.length; i < len; i++) {
-				if (!(key[i] in this.cache)) {
-					return false;
-				}
-			}
-
-			return true;
-		} else {
-			return key in this.cache;
-		}
-	},
-
+	/**
+	 * Add cache
+	 * @param {String} key
+	 * @param {*} value
+	 * @param {Boolean} isDataType
+	 * @private
+	 */
 	addCache(key, value, isDataType = false) {
 		this.cache[key] = isDataType ? this.cloneTarget(value) : value;
 	},
 
+	/**
+	 * Remove cache
+	 * @param {String|Array} key
+	 * @private
+	 */
+	removeCache(key) {
+		toArray(key).forEach(v => delete this.cache[v]);
+	},
+
+	/**
+	 * Get cahce
+	 * @param {String|Array} key
+	 * @param {Boolean} isDataType
+	 * @return {*}
+	 * @private
+	 */
 	getCache(key, isDataType = false) {
 		if (isDataType) {
 			const targets = [];


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#626

## Details
<!-- Detailed description of the change/feature -->
- Remove unnecessary .hasCaches()
- Add .removeCache()
- Enforce .unload API doc
- Remove cached data when is unloaded