### PR TITLE
add src to be ignored

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,3 +15,6 @@ jsdoc.json
 karma.conf.js
 webpack.config.js
 yarn.lock
+src/
+demo/
+doc/


### PR DESCRIPTION
Hi, when we install billboard.js with npm install, it came with folders src, demo and doc.
As this folders will not be used by delopers and increase the final npm package size of billboard.
Issue #679

## Details
<!-- Detailed description of the change/feature -->
I have ignored that folders into .npmignore in this request