### PR TITLE
fix(zoom): Maintain zoommed scale on .zoom()

### DIFF
--- a/spec/interactions/zoom-spec.js
+++ b/spec/interactions/zoom-spec.js
@@ -111,11 +111,6 @@ describe("ZOOM", function() {
 			const main = chart.internal.main;
 			const eventRect = main.select(`.${CLASS.eventRect}-2`).node();
 
-			util.fireEvent(eventRect, "mousedown", {
-				clientX: 100,
-				clientY: 150
-			}, chart);
-
 			new Promise((resolve, reject) => {
 				util.fireEvent(eventRect, "mousedown", {
 					clientX: 100,
@@ -382,6 +377,67 @@ describe("ZOOM", function() {
 
 				done();
 			}, 500);
+		});
+	});
+
+	describe ("zoom scale consistency for dragging", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 3150, 250],
+						["data2", 50, 20, 10, 40, 15, 6025]
+					]
+				},
+				zoom: {
+					enabled: true
+				}
+			};
+		});
+
+		it("zoom scale should maintained on dragging interaction", done => {
+			const internal = chart.internal;
+			const main = internal.main;
+			const zoomDomain = [0,2];
+
+			// when
+			chart.zoom(zoomDomain);
+
+			const eventRect = main.select(`.${CLASS.eventRect}-2`).node();
+			const zoomedDomain = internal.x.domain();
+
+			expect(zoomedDomain).to.be.deep.equal(zoomDomain);
+
+			new Promise((resolve, reject) => {
+				util.fireEvent(eventRect, "mousedown", {
+					clientX: 100,
+					clientY: 150
+				}, chart);
+
+				resolve();
+			}).then(() => {
+				return new Promise((resolve, reject) => {
+					setTimeout(() => {
+						util.fireEvent(eventRect, "mousemove", {
+							clientX: 130,
+							clientY: 150
+						}, chart);
+
+						resolve();
+					}, 500);
+				});
+			}).then(() => {
+				setTimeout(() => {
+					util.fireEvent(eventRect, "mouseup", {
+						clientX: 150,
+						clientY: 150
+					}, chart);
+
+					expect(internal.x.domain()).to.be.deep.equal(zoomedDomain);
+
+					done();
+				}, 500);
+			});
 		});
 	});
 });

--- a/src/api/api.zoom.js
+++ b/src/api/api.zoom.js
@@ -1,20 +1,23 @@
 /**
- * Copyright (c) 2017 NAVER Corp.
+ * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
 import {
 	min as d3Min,
 	max as d3Max
 } from "d3-array";
-import {zoomIdentity as d3ZoomIdentity} from "d3-zoom";
+import {zoomIdentity as d3ZoomIdentity, zoomTransform as d3ZoomTransform} from "d3-zoom";
 import Chart from "../internals/Chart";
+import CLASS from "../config/classes";
 import {callFn, isDefined, isObject, isString, extend} from "../internals/util";
 
 /**
  * Zoom by giving x domain.
+ * - **NOTE:** For `wheel` type zoom, the minimum zoom range will be set as the given domain.<br>
+ * To get the initial state, [.unzoom()](#unzoom) should be called.
  * @method zoom
  * @instance
- * @memberOf Chart
+ * @memberof Chart
  * @param {Array} domainValue If domain is given, the chart will be zoomed to the given domain. If no argument is given, the current zoomed domain will be returned.
  * @return {Array} domain value in array
  * @example
@@ -70,7 +73,7 @@ extend(zoom, {
 	 * Enable and disable zooming.
 	 * @method zoom․enable
 	 * @instance
-	 * @memberOf Chart
+	 * @memberof Chart
 	 * @param {String|Boolean} enabled Possible string values are "wheel" or "drag". If enabled is true, "wheel" will be used. If false is given, zooming will be disabled.<br>When set to false, the current zooming status will be reset.
 	 * @example
 	 *  // Enable zooming using the mouse wheel
@@ -111,7 +114,7 @@ extend(zoom, {
 	 * Set or get x Axis maximum zoom range value
 	 * @method zoom․max
 	 * @instance
-	 * @memberOf Chart
+	 * @memberof Chart
 	 * @param {Number} [max] maximum value to set for zoom
 	 * @return {Number} zoom max value
 	 * @example
@@ -133,7 +136,7 @@ extend(zoom, {
 	 * Set or get x Axis minimum zoom range value
 	 * @method zoom․min
 	 * @instance
-	 * @memberOf Chart
+	 * @memberof Chart
 	 * @param {Number} [min] minimum value tp set for zoom
 	 * @return {Number} zoom min value
 	 * @example
@@ -155,7 +158,7 @@ extend(zoom, {
 	 * Set zoom range
 	 * @method zoom․range
 	 * @instance
-	 * @memberOf Chart
+	 * @memberof Chart
 	 * @param {Object} [range]
 	 * @return {Object} zoom range value
 	 * {
@@ -190,7 +193,7 @@ extend(Chart.prototype, {
 	 * Unzoom zoomed area
 	 * @method unzoom
 	 * @instance
-	 * @memberOf Chart
+	 * @memberof Chart
 	 * @example
 	 *  chart.unzoom();
 	 */
@@ -203,8 +206,15 @@ extend(Chart.prototype, {
 				$$.brush.getSelection().call($$.brush.move, null) :
 				$$.zoom.updateTransformScale(d3ZoomIdentity);
 
-			$$.updateZoom();
+			$$.updateZoom(true);
 			$$.zoom.resetBtn && $$.zoom.resetBtn.style("display", "none");
+
+			// reset transform
+			const eventRects = $$.main.select(`.${CLASS.eventRects}`);
+
+			if (d3ZoomTransform(eventRects.node()) !== d3ZoomIdentity) {
+				$$.zoom.transform(eventRects, d3ZoomIdentity);
+			}
 
 			$$.redraw({
 				withTransition: true,


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#654

## Details
<!-- Detailed description of the change/feature -->
- Make zoom scale consistent
- Reset transform value for .unzoom()

![zoom-consistency](https://user-images.githubusercontent.com/2178435/49917485-ae971100-fee2-11e8-90a5-9631da7444cf.gif)

