### PR TITLE
refactor(all): Remove use of d3-array & d3-collection

### DIFF
--- a/src/api/api.zoom.js
+++ b/src/api/api.zoom.js
@@ -2,14 +2,10 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {
-	min as d3Min,
-	max as d3Max
-} from "d3-array";
 import {zoomIdentity as d3ZoomIdentity, zoomTransform as d3ZoomTransform} from "d3-zoom";
 import Chart from "../internals/Chart";
 import CLASS from "../config/classes";
-import {callFn, isDefined, isObject, isString, extend} from "../internals/util";
+import {callFn, extend, getMinMax, isDefined, isObject, isString} from "../internals/util";
 
 /**
  * Zoom by giving x domain.
@@ -126,7 +122,7 @@ extend(zoom, {
 		const config = $$.config;
 
 		if (max === 0 || max) {
-			config.zoom_x_max = d3Max([$$.orgXDomain[1], max]);
+			config.zoom_x_max = getMinMax("max", [$$.orgXDomain[1], max]);
 		}
 
 		return config.zoom_x_max;
@@ -148,7 +144,7 @@ extend(zoom, {
 		const config = $$.config;
 
 		if (min === 0 || min) {
-			config.zoom_x_min = d3Min([$$.orgXDomain[0], min]);
+			config.zoom_x_min = getMinMax("min", [$$.orgXDomain[0], min]);
 		}
 
 		return config.zoom_x_min;

--- a/src/data/data.convert.js
+++ b/src/data/data.convert.js
@@ -8,7 +8,6 @@ import {
 	csvParseRows as d3CsvParseRows,
 	tsvParseRows as d3TsvParseRows,
 } from "d3-dsv";
-import {keys as d3Keys} from "d3-collection";
 import ChartInternal from "../internals/ChartInternal";
 import {isUndefined, isDefined, isObject, isValue, notEmpty, extend, isArray, capitalize} from "../internals/util";
 
@@ -190,8 +189,9 @@ extend(ChartInternal.prototype, {
 	convertDataToTargets(data, appendXs) {
 		const $$ = this;
 		const config = $$.config;
-		const ids = d3Keys(data[0]).filter($$.isNotX, $$);
-		const xs = d3Keys(data[0]).filter($$.isX, $$);
+		const dataKeys = Object.keys(data[0] || {});
+		const ids = dataKeys.length ? dataKeys.filter($$.isNotX, $$) : [];
+		const xs = dataKeys.length ? dataKeys.filter($$.isX, $$) : [];
 		let xsData;
 
 		// save x for update data by load when custom x and bb.x API

--- a/src/interactions/zoom.js
+++ b/src/interactions/zoom.js
@@ -3,10 +3,6 @@
  * billboard.js project is licensed under the MIT license
  */
 import {
-	min as d3Min,
-	max as d3Max
-} from "d3-array";
-import {
 	mouse as d3Mouse,
 	event as d3Event,
 	select as d3Select
@@ -15,7 +11,7 @@ import {drag as d3Drag} from "d3-drag";
 import {zoom as d3Zoom} from "d3-zoom";
 import ChartInternal from "../internals/ChartInternal";
 import CLASS from "../config/classes";
-import {extend, callFn, diffDomain} from "../internals/util";
+import {extend, callFn, diffDomain, getMinMax, isDefined} from "../internals/util";
 
 extend(ChartInternal.prototype, {
 	/**
@@ -196,8 +192,15 @@ extend(ChartInternal.prototype, {
 	getZoomDomain() {
 		const $$ = this;
 		const config = $$.config;
-		const min = d3Min([$$.orgXDomain[0], config.zoom_x_min]);
-		const max = d3Max([$$.orgXDomain[1], config.zoom_x_max]);
+		let [min, max] = $$.orgXDomain;
+
+		if (isDefined(config.zoom_x_min)) {
+			min = getMinMax("min", [min, config.zoom_x_min]);
+		}
+
+		if (isDefined(config.zoom_x_max)) {
+			max = getMinMax("max", [max, config.zoom_x_max]);
+		}
 
 		return [min, max];
 	},

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -13,7 +13,6 @@ import {
 	select as d3Select,
 	selectAll as d3SelectAll
 } from "d3-selection";
-import {extent as d3Extent} from "d3-array";
 import {transition as d3Transition} from "d3-transition";
 
 import Axis from "../axis/Axis";
@@ -230,7 +229,7 @@ export default class ChartInternal {
 		$$.updateScales();
 
 		// Set domains for each scale
-		$$.x.domain(d3Extent($$.getXDomain($$.data.targets)));
+		$$.x.domain($$.getXDomain($$.data.targets).sort());
 		$$.y.domain($$.getYDomain($$.data.targets, "y"));
 		$$.y2.domain($$.getYDomain($$.data.targets, "y2"));
 		$$.subX.domain($$.x.domain());

--- a/src/internals/util.js
+++ b/src/internals/util.js
@@ -20,8 +20,9 @@ const diffDomain = d => d[1] - d[0];
 const isObjectType = v => typeof v === "object";
 const isEmpty = o => (
 	isUndefined(o) || o === null ||
-		(isString(o) && o.length === 0) ||
-		(isObjectType(o) && Object.keys(o).length === 0)
+	(isString(o) && o.length === 0) ||
+	(isObjectType(o) && !(o instanceof Date) && Object.keys(o).length === 0) ||
+	(isNumber(o) && isNaN(o))
 );
 const notEmpty = o => !isEmpty(o);
 
@@ -184,6 +185,64 @@ const getCssRules = styleSheets => {
 	return rules;
 };
 
+/**
+ * Get unique value from array
+ * @param {Array} data
+ * @return {Array} Unique array value
+ * @private
+ */
+const getUnique = data => data.filter((v, i, self) => self.indexOf(v) === i);
+
+/**
+ * Merge array
+ * @param {Array} arr
+ * @return {Array}
+ * @private
+ */
+const mergeArray = arr => (arr && arr.length ? arr.reduce((p, c) => p.concat(c)) : []);
+
+/**
+ * Get min/max value
+ * @param {String} type 'min' or 'max'
+ * @param {Array} data Array data value
+ * @retun {Number|Date|undefined}
+ * @private
+ */
+const getMinMax = (type, data) => {
+	let res = data.filter(v => notEmpty(v));
+
+	if (res.length) {
+		if (isNumber(res[0])) {
+			res = Math[type](...res);
+		} else if (res[0] instanceof Date) {
+			const sortFn = type === "min" ? (a, b) => a - b : (a, b) => b - a;
+
+			res = res.sort(sortFn)[0];
+		}
+	} else {
+		res = undefined;
+	}
+
+	return res;
+};
+
+/**
+ * Get range
+ * @param {Number} start Start number
+ * @param {Number} end End number
+ * @return {Array}
+ * @private
+ */
+const getRange = (start, end) => {
+	const res = [];
+
+	for (let i = start; i < end; i++) {
+		res.push(i);
+	}
+
+	return res;
+};
+
 // emulate event
 const emulateEvent = {
 	mouse: (() => {
@@ -251,10 +310,13 @@ export {
 	extend,
 	getBrushSelection,
 	getCssRules,
+	getMinMax,
 	getOption,
 	getPathBox,
 	getRandom,
+	getRange,
 	getRectSegList,
+	getUnique,
 	hasValue,
 	isArray,
 	isBoolean,
@@ -267,6 +329,7 @@ export {
 	isString,
 	isUndefined,
 	isValue,
+	mergeArray,
 	notEmpty,
 	sanitise,
 	toArray

--- a/src/shape/bubble.js
+++ b/src/shape/bubble.js
@@ -2,12 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {
-	min as d3Min,
-	max as d3Max
-} from "d3-array";
 import ChartInternal from "../internals/ChartInternal";
-import {extend, isFunction, isNumber, isObject} from "../internals/util";
+import {extend, getMinMax, isFunction, isNumber, isObject} from "../internals/util";
 
 extend(ChartInternal.prototype, {
 	/**
@@ -37,7 +33,7 @@ extend(ChartInternal.prototype, {
 		let baseLength = $$.getCache(cacheKey);
 
 		if (!baseLength) {
-			$$.addCache(cacheKey, baseLength = d3Min([
+			$$.addCache(cacheKey, baseLength = getMinMax("min", [
 				$$.axes.x.select("path").node()
 					.getTotalLength(),
 				$$.axes.y.select("path").node()
@@ -64,7 +60,7 @@ extend(ChartInternal.prototype, {
 			maxR = ($$.getBaseLength() / ($$.getMaxDataCount() * 2)) + 12;
 		}
 
-		const max = d3Max($$.getMinMaxData().max.map(d => (isObject(d.value) ? d.value.mid : d.value)));
+		const max = getMinMax("max", $$.getMinMaxData().max.map(d => (isObject(d.value) ? d.value.mid : d.value)));
 		const maxArea = maxR * maxR * Math.PI;
 		const area = d.value * (maxArea / max);
 

--- a/src/shape/radar.js
+++ b/src/shape/radar.js
@@ -6,13 +6,9 @@ import {
 	select as d3Select,
 	event as d3Event
 } from "d3-selection";
-import {
-	max as d3Max,
-	range as d3Range
-} from "d3-array";
 import ChartInternal from "../internals/ChartInternal";
 import CLASS from "../config/classes";
-import {extend, isDefined, isEmpty, isUndefined, toArray} from "../internals/util";
+import {extend, getMinMax, getRange, isDefined, isEmpty, isUndefined, toArray} from "../internals/util";
 
 /**
  * Get the position value
@@ -76,7 +72,7 @@ extend(ChartInternal.prototype, {
 		const config = $$.config;
 
 		if (isEmpty(config.axis_x_categories)) {
-			config.axis_x_categories = d3Range(0, d3Max(targets).values.length);
+			config.axis_x_categories = getRange(0, getMinMax("max", targets.map(v => v.values.length)));
 		}
 
 		$$.generateRadarPoints();
@@ -168,7 +164,7 @@ extend(ChartInternal.prototype, {
 		const showText = config.radar_level_text_show;
 
 		const radarLevels = $$.radars.levels;
-		const levelData = d3Range(0, depth);
+		const levelData = getRange(0, depth);
 
 		const radius = config.radar_size_ratio * Math.min(width, height);
 		const levelRatio = levelData.map(l => radius * ((l + 1) / depth));
@@ -177,7 +173,7 @@ extend(ChartInternal.prototype, {
 		// Generate points
 		const points = levelData.map(v => {
 			const range = levelRatio[v];
-			const pos = d3Range(0, edge).map(i => (
+			const pos = getRange(0, edge).map(i => (
 				$$.getRadarPosition(["x", "y"], i, range, 1)).join(",")
 			);
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#708

## Details
<!-- Detailed description of the change/feature -->
Removed use of some d3's modules.
- d3-collection is deprecated
- d3-array replace using native APIs
