### PR TITLE
fix(style): side effects on css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "commitmsg": "node ./config/validate-commit-msg.js",
     "prepush": "npm run lint"
   },
-  "sideEffects": false,
+  "sideEffects": ["dist/**/*.css"],
   "repository": {
     "type": "git",
     "url": "https://github.com/naver/billboard.js"


### PR DESCRIPTION
ref: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

> Note that any imported file is subject to tree shaking. This means if you use something like css-loader in your project and import a CSS file, it needs to be added to the side effect list so it will not be unintentionally dropped in production mode:

you can check example below 😃 
https://github.com/arkist/billboard.js-sideEffect