### PR TITLE
refactor(all): Decreasing node generation

### DIFF
--- a/spec/interactions/subchart-spec.js
+++ b/spec/interactions/subchart-spec.js
@@ -118,5 +118,18 @@ describe("SUBCHART", () => {
 			expect(axis.length).to.be.equal(1);
 			expect(axis[0].classList.contains("domain")).to.be.true;
 		});
+
+		it("set options subchart.show=false", () => {
+			args.subchart.show = false;
+		});
+
+		it("shouldn't be generating subchart's nodes", () => {
+			const subchart = chart.$.svg.selectAll("[clip-path]").filter(function() {
+				return /subchart/.test(this.getAttribute("clip-path"))
+			});
+
+			expect(subchart.empty()).to.be.true;
+			expect(chart.internal.clipSubchart).to.be.undefined;
+		})
 	});
 });

--- a/spec/internals/core-spec.js
+++ b/spec/internals/core-spec.js
@@ -261,7 +261,7 @@ describe("CORE", function() {
 			const previous = chart.internal.main.select(`.${CLASS.chart}`).node().previousSibling;
 
 			// chart element should positioned after axis element
-			expect(d3.select(previous).classed(CLASS.axisY2)).to.be.true;
+			expect(d3.select(previous).classed(CLASS.grid)).to.be.true;
 		});
 	});
 });

--- a/spec/internals/data-spec.js
+++ b/spec/internals/data-spec.js
@@ -1666,4 +1666,35 @@ describe("DATA", () => {
 			expect(tooltipValue).to.be.equal(100);
 		});
 	});
+
+	describe("data.empty.label.text", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [],
+					empty: {
+						label: {
+							text: "No Data"
+						}
+					}
+				}
+			};
+		});
+
+		it("check for empty label text", () => {
+			const emptyLabelText = chart.$.main.select(`.${CLASS.text}.${CLASS.empty}`);
+
+			expect(+emptyLabelText.style("opacity")).to.be.equal(1);
+		});
+
+		it("set options empty.label.text=''", () => {
+			args.data.empty.label.text = "";
+		});
+
+		it("shouldn't be generating empty label text node", () => {
+			const emptyLabelText = chart.$.main.select(`.${CLASS.text}.${CLASS.empty}`);
+
+			expect(emptyLabelText.empty()).to.be.true;
+		});
+	});
 });

--- a/spec/internals/grid-spec.js
+++ b/spec/internals/grid-spec.js
@@ -29,7 +29,10 @@ describe("GRID", function() {
 				},
 				grid: {
 					y: {
-						show: false
+						show: false,
+						lines: [
+							{value: 2, text: "Label on 2"}
+						]
 					}
 				}
 			};
@@ -108,8 +111,18 @@ describe("GRID", function() {
 		});
 	});
 
+	describe("check node generation", () => {
+		it("set options args.grid.y.lines = []", () => {
+			args.grid.y.lines = [];
+		});
+
+		it("shouldn't be generating grid elements", () => {
+			expect(chart.$.main.select(`.${CLASS.grid}.${CLASS.gridLines}`).empty()).to.be.true;
+		});
+	});
+
 	describe("y grid lines", () => {
-		describe("position #1", () => {
+		describe("position #1", () => {7
 			before(() => {
 				args = {
 					data: {

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -176,8 +176,6 @@ export default class ChartInternal {
 
 		$$.axis = new Axis($$);
 
-		config.subchart_show && $$.initBrush();
-
 		if (config.zoom_enabled) {
 			$$.initZoom();
 			$$.initZoomBehaviour();
@@ -266,8 +264,7 @@ export default class ChartInternal {
 				.on(isTouch ? "touchend" : "mouseleave", () => callFn(config.onout, $$));
 		}
 
-		config.svg_classname &&
-			$$.svg.attr("class", config.svg_classname);
+		config.svg_classname && $$.svg.attr("class", config.svg_classname);
 
 		// Define defs
 		$$.defs = $$.svg.append("defs");
@@ -276,7 +273,6 @@ export default class ChartInternal {
 		$$.clipXAxis = $$.appendClip($$.defs, $$.clipIdForXAxis);
 		$$.clipYAxis = $$.appendClip($$.defs, $$.clipIdForYAxis);
 		$$.clipGrid = $$.appendClip($$.defs, $$.clipIdForGrid);
-		$$.clipSubchart = $$.appendClip($$.defs, $$.clipIdForSubchart);
 
 		// set color patterns
 		if (isFunction(config.color_tiles) && $$.patterns) {
@@ -291,9 +287,12 @@ export default class ChartInternal {
 		$$.main = main;
 
 		// initialize subchart when subchart show option is set
-		config.subchart_show &&
-			$$.initSubchart &&
-				$$.initSubchart();
+		if (config.subchart_show) {
+			$$.clipSubchart = $$.appendClip($$.defs, $$.clipIdForSubchart);
+
+			$$.initBrush();
+			$$.initSubchart();
+		}
 
 		$$.initTooltip && $$.initTooltip();
 		$$.initLegend && $$.initLegend();
@@ -302,16 +301,15 @@ export default class ChartInternal {
 		// -- Main Region --
 
 		// text when empty
-		main.append("text")
-			.attr("class", `${CLASS.text} ${CLASS.empty}`)
-			.attr("text-anchor", "middle") // horizontal centering of text at x position in all browsers.
-			.attr("dominant-baseline", "middle"); // vertical centering of text at y position in all browsers, except IE.
+		if (config.data_empty_label_text) {
+			main.append("text")
+				.attr("class", `${CLASS.text} ${CLASS.empty}`)
+				.attr("text-anchor", "middle") // horizontal centering of text at x position in all browsers.
+				.attr("dominant-baseline", "middle"); // vertical centering of text at y position in all browsers, except IE.
+		}
 
 		// Regions
 		$$.initRegion();
-
-		// Grids
-		$$.initGrid();
 
 		// Add Axis here, when clipPath is 'false'
 		!config.clipPath && $$.axis.init();
@@ -320,15 +318,14 @@ export default class ChartInternal {
 		main.append("g").attr("class", CLASS.chart)
 			.attr("clip-path", $$.clipPath);
 
-		// Grid lines
-		config.grid_lines_front && $$.initGridLines();
-		config.grid_front && $$.initXYFocusGrid();
-
 		// Cover whole with rects for events
 		$$.initEventRect();
 
 		// Define g for chart
 		$$.initChartElements();
+
+		// Grids
+		$$.initGrid();
 
 		// if zoom privileged, insert rect to forefront
 		// TODO: is this needed?

--- a/src/internals/grid.js
+++ b/src/internals/grid.js
@@ -28,25 +28,27 @@ const getGridTextX = (isX, width, height) => d => {
 extend(ChartInternal.prototype, {
 	initGrid() {
 		const $$ = this;
-		const config = $$.config;
 
 		$$.xgrid = d3SelectAll([]);
 
-		!config.grid_lines_front && $$.initGridLines();
-		!config.grid_front && $$.initXYFocusGrid();
+		$$.initGridLines();
+		$$.initXYFocusGrid();
 	},
 
 	initGridLines() {
 		const $$ = this;
+		const config = $$.config;
 
-		$$.gridLines = $$.main.append("g")
-			.attr("clip-path", $$.clipPathForGrid)
-			.attr("class", `${CLASS.grid} ${CLASS.gridLines}`);
+		if (config.grid_x_lines.length || config.grid_y_lines.length) {
+			$$.gridLines = $$.main.insert("g", `.${CLASS.chart}${config.grid_lines_front ? " + *" : ""}`)
+				.attr("clip-path", $$.clipPathForGrid)
+				.attr("class", `${CLASS.grid} ${CLASS.gridLines}`);
 
-		$$.gridLines.append("g").attr("class", CLASS.xgridLines);
-		$$.gridLines.append("g").attr("class", CLASS.ygridLines);
+			$$.gridLines.append("g").attr("class", CLASS.xgridLines);
+			$$.gridLines.append("g").attr("class", CLASS.ygridLines);
 
-		$$.xgridLines = d3SelectAll([]);
+			$$.xgridLines = d3SelectAll([]);
+		}
 	},
 
 	updateXGrid(withoutUpdate) {
@@ -55,15 +57,16 @@ extend(ChartInternal.prototype, {
 		const isRotated = config.axis_rotated;
 		const xgridData = $$.generateGridData(config.grid_x_type, $$.x);
 		const tickOffset = $$.isCategorized() ? $$.xAxis.tickOffset() : 0;
+		const pos = d => $$.x(d) + (tickOffset * isRotated ? -1 : 1);
 
 		$$.xgridAttr = isRotated ? {
 			"x1": 0,
 			"x2": $$.width,
-			"y1": d => $$.x(d) - tickOffset,
-			"y2": d => $$.x(d) - tickOffset,
+			"y1": pos,
+			"y2": pos,
 		} : {
-			"x1": d => $$.x(d) + tickOffset,
-			"x2": d => $$.x(d) + tickOffset,
+			"x1": pos,
+			"x2": pos,
 			"y1": 0,
 			"y2": $$.height,
 		};
@@ -122,6 +125,8 @@ extend(ChartInternal.prototype, {
 
 	updateGrid(duration) {
 		const $$ = this;
+
+		!$$.gridLines && $$.initGridLines();
 
 		// hide if arc type
 		$$.grid.style("visibility", $$.hasArcType() ? "hidden" : "visible");
@@ -273,8 +278,10 @@ extend(ChartInternal.prototype, {
 	initXYFocusGrid() {
 		const $$ = this;
 		const config = $$.config;
+		const isFront = config.grid_front;
+		const className = `.${CLASS[isFront && $$.gridLines ? "gridLines" : "chart"]}${isFront ? " + *" : ""}`;
 
-		$$.grid = $$.main.append("g")
+		$$.grid = $$.main.insert("g", className)
 			.attr("clip-path", $$.clipPathForGrid)
 			.attr("class", CLASS.grid);
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#36

## Details
<!-- Detailed description of the change/feature -->
 not generate nodes for when:
 - subchart's clip-path if isn't used
 - data.empty.label.text isn't specified
 - grid lines aren't specified