### PR TITLE
fix(axis): Correct axis transition

### DIFF
--- a/src/axis/AxisRenderer.js
+++ b/src/axis/AxisRenderer.js
@@ -11,7 +11,7 @@ export default class AxisRenderer {
 	constructor(params = {}) {
 		const config = {
 			innerTickSize: 6,
-			outerTickSize: params.withOuterTick ? 6 : 0,
+			outerTickSize: params.outerTick ? 6 : 0,
 			orient: "bottom",
 			range: [],
 			tickArguments: null,
@@ -23,7 +23,7 @@ export default class AxisRenderer {
 			tickPadding: 3,
 			tickValues: null,
 			transition: null,
-			withoutTransition: params.withoutTransition
+			noTransition: params.noTransition
 		};
 
 		config.tickLength = Math.max(config.innerTickSize, 0) + config.tickPadding;
@@ -65,13 +65,13 @@ export default class AxisRenderer {
 
 		const {innerTickSize, tickLength, range} = config;
 
-		// get the axis' tick position configuration
-		const axisName = params.axisName;
-		const tickTextPos = axisName && /^(x|y|y2)$/.test(axisName) ?
-			params.config[`axis_${axisName}_tick_text_position`] : {x: 0, y: 0};
+		// // get the axis' tick position configuration
+		const name = params.name;
+		const tickTextPos = name && /^(x|y|y2)$/.test(name) ?
+			params.config[`axis_${name}_tick_text_position`] : {x: 0, y: 0};
 
 		// tick visiblity
-		const prefix = axisName === "subx" ? `subchart_axis_x` : `axis_${axisName}`;
+		const prefix = name === "subX" ? `subchart_axis_x` : `axis_${name}`;
 		const axisShow = params.config[`${prefix}_show`];
 		const tickShow = {
 			tick: axisShow ? params.config[`${prefix}_tick_show`] : false,

--- a/src/axis/AxisRendererHelper.js
+++ b/src/axis/AxisRendererHelper.js
@@ -13,6 +13,10 @@ export default class AxisRendererHelper {
 		this.config = config;
 		this.scale = scale;
 
+		if (!params.config.transition_duration) {
+			config.noTransition = true;
+		}
+
 		// set range
 		config.range = scale.rangeExtent ?
 			scale.rangeExtent() :
@@ -121,7 +125,7 @@ export default class AxisRendererHelper {
 	transitionise(selection) {
 		const config = this.config;
 
-		return config.withoutTransition ?
+		return config.noTransition ?
 			selection.interrupt() : selection.transition(config.transition);
 	}
 }

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -680,8 +680,8 @@ export default class Options {
 			 * data: {
 			 *   colors: {
 			 *     data1: "#ff0000",
-			 * 	   data2: function(d) {
-			 * 		  return "#000";
+			 *     data2: function(d) {
+			 *        return "#000";
 			 *     }
 			 *     ...
 			 *   }

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -153,7 +153,9 @@ export default class ChartInternal {
 		$$.legendItemHeight = 0;
 
 		$$.currentMaxTickWidths = {
-			x: 0, y: 0, y2: 0
+			x: {size: 0, domain: ""},
+			y: {size: 0, domain: ""},
+			y2: {size: 0, domain: ""}
 		};
 
 		$$.rotated_padding_left = 30;

--- a/src/internals/scale.js
+++ b/src/internals/scale.js
@@ -106,13 +106,12 @@ extend(ChartInternal.prototype, {
 	/**
 	 * Update scale
 	 * @private
-	 * @param {Boolean} withoutTransitionAtInit - param is given at the init rendering
+	 * @param {Boolean} isInit - param is given at the init rendering
 	 */
-	updateScales(withoutTransitionAtInit) {
+	updateScales(isInit) {
 		const $$ = this;
 		const config = $$.config;
 		const isRotated = config.axis_rotated;
-		const isInit = !$$.x;
 
 		// update edges
 		$$.xMin = isRotated ? 1 : 0;
@@ -126,41 +125,37 @@ extend(ChartInternal.prototype, {
 
 		// update scales
 		// x Axis
-		$$.x = $$.getX($$.xMin, $$.xMax, isInit ? undefined : $$.x.orgDomain(),
-			() => $$.xAxis.tickOffset());
+		$$.x = $$.getX($$.xMin, $$.xMax, $$.x && $$.x.orgDomain(), () => $$.xAxis.tickOffset());
 		$$.subX = $$.getX($$.xMin, $$.xMax, $$.orgXDomain, d => (d % 1 ? 0 : $$.subXAxis.tickOffset()));
 
 		$$.xAxisTickFormat = $$.axis.getXAxisTickFormat();
 		$$.xAxisTickValues = $$.axis.getXAxisTickValues();
 
 		$$.xAxis = $$.axis
-			.getXAxis("x", $$.x, $$.xOrient, $$.xAxisTickFormat,
-				$$.xAxisTickValues, config.axis_x_tick_outer, withoutTransitionAtInit);
+			.getXAxis("x", $$.x, config.axis_x_tick_outer, isInit);
 
 		$$.subXAxis = $$.axis
-			.getXAxis("subx", $$.subX, $$.subXOrient, $$.xAxisTickFormat,
-				$$.xAxisTickValues, config.axis_x_tick_outer, withoutTransitionAtInit);
+			.getXAxis("subX", $$.subX, config.axis_x_tick_outer, isInit);
 
 		// y Axis
-		$$.y = $$.getY($$.yMin, $$.yMax, isInit ? config.axis_y_default : $$.y.domain());
-		$$.subY = $$.getY($$.subYMin, $$.subYMax, isInit ? config.axis_y_default : $$.subY.domain());
+		$$.y = $$.getY($$.yMin, $$.yMax, $$.y ? $$.y.domain() : config.axis_y_default);
+		$$.subY = $$.getY($$.subYMin, $$.subYMax, $$.subY ? $$.subY.domain() : config.axis_y_default);
 
 		$$.yAxisTickValues = $$.axis.getYAxisTickValues();
 
 		$$.yAxis = $$.axis
-			.getYAxis("y", $$.y, $$.yOrient, config.axis_y_tick_format,
-				$$.yAxisTickValues, config.axis_y_tick_outer);
+			.getYAxis("y", $$.y, config.axis_y_tick_outer, isInit);
 
 		// y2 Axis
 		if (config.axis_y2_show) {
-			$$.y2 = $$.getY($$.yMin, $$.yMax, isInit ? config.axis_y2_default : $$.y2.domain());
-			$$.subY2 = $$.getY($$.subYMin, $$.subYMax, isInit ? config.axis_y2_default : $$.subY2.domain());
+			$$.y2 = $$.getY($$.yMin, $$.yMax, $$.y2 ? $$.y2.domain() : config.axis_y2_default);
+			$$.subY2 = $$.getY($$.subYMin, $$.subYMax,
+				$$.subY2 ? $$.subY2.domain() : config.axis_y2_default);
 
 			$$.y2AxisTickValues = $$.axis.getY2AxisTickValues();
 
 			$$.y2Axis = $$.axis
-				.getYAxis("y2", $$.y2, $$.y2Orient, config.axis_y2_tick_format,
-					$$.y2AxisTickValues, config.axis_y2_tick_outer);
+				.getYAxis("y2", $$.y2, config.axis_y2_tick_outer, isInit);
 		}
 
 		// update for arc


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#759

## Details
<!-- Detailed description of the change/feature -->
- Fixed to not applying transiton when transition.duration is falsy
- Avoid computing max tick width value if domain hasn't been changed.
  > This will degrade dramastically on layout/style recalc.
  > Left: with this changes / Right: 1.7.1 release
  > ![benchmark](https://user-images.githubusercontent.com/2178435/52456497-573ab780-2b98-11e9-83ab-0bfefff7b1d9.gif)

- Simplified .getXAxis()/.getYAxis() arguments numbers
