### PR TITLE
fix(api): Cancel transitions on destroy.

### DIFF
--- a/src/api/api.chart.js
+++ b/src/api/api.chart.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
+import CLASS from "../config/classes";
 import Chart from "../internals/Chart";
 import {window} from "../internals/browser";
 import {notEmpty, isDefined, extend} from "../internals/util";
@@ -74,6 +75,7 @@ extend(Chart.prototype, {
 			$$.charts.splice($$.charts.indexOf(this), 1);
 
 			// clear timers
+			$$.svg.selectAll(`.${CLASS.target}`).transition();
 			isDefined($$.resizeTimeout) && window.clearTimeout($$.resizeTimeout);
 
 			window.removeEventListener("resize", $$.resizeFunction);

--- a/src/data/data.load.js
+++ b/src/data/data.load.js
@@ -57,6 +57,10 @@ extend(ChartInternal.prototype, {
 		const $$ = this;
 		let data;
 
+		if (!$$.config) {
+			return;
+		}
+
 		// reset internally cached data
 		$$.resetCache();
 


### PR DESCRIPTION
Resolves #766

I also added a check to the `data.load.js`, because even after the transition is cancelled, `loadFromArgs` is still sometimes called on the empty `ChartInternal` object.