### PR TITLE
fix(Zoom): Updated domain values onzoom/onzoomend

### DIFF
--- a/spec/interactions/zoom-spec.js
+++ b/spec/interactions/zoom-spec.js
@@ -202,6 +202,29 @@ describe("ZOOM", function() {
 			// check if chart react on resize
 			expect(+domain.attr("d").match(rx)[1]).to.be.above(pathValue);
 		});
+
+		it("check for updated domain on zoomScale after zoom in", () => {
+			const zoomValue = [1, 3];
+
+			chart.zoom(zoomValue); // zoom in
+			expect(chart.internal.zoomScale.domain()).to.eql(zoomValue); // zoomScale value is updated on zoom in
+
+			chart.unzoom(); // zoom set to initial
+			expect(chart.internal.zoomScale).to.be.null; // zoomScale null on zoom out to initial
+
+		});
+
+		it("check for subX domain values after zoom", () => {
+			const zoomValue = [1, 3];
+
+			chart.zoom(zoomValue); // zoom in
+			expect(chart.internal.subX.domain()).to.not.eql(zoomValue); // subX value not updated on zoom in
+
+			chart.unzoom(); // zoom set to initial
+			expect(chart.internal.subX.domain()).to.eql(chart.internal.x.orgDomain()); // subX value not updated on zoom in
+
+		});
+
     });
 
     describe("zoom type drag", () => {

--- a/src/interactions/zoom.js
+++ b/src/interactions/zoom.js
@@ -171,7 +171,7 @@ extend(ChartInternal.prototype, {
 		const $$ = this;
 		const startEvent = $$.zoom.startEvent;
 		const orgDomain = $$.subX.domain();
-		const scaledDomain = $$.zoomScale.domain();
+		const scaledDomain = $$.zoomScale ? $$.zoomScale.domain() : null;
 		const domain = (orgDomain === scaledDomain) ? orgDomain : scaledDomain;
 
 		// if click, do nothing. otherwise, click interaction will be canceled.

--- a/src/interactions/zoom.js
+++ b/src/interactions/zoom.js
@@ -170,9 +170,6 @@ extend(ChartInternal.prototype, {
 	onZoomEnd() {
 		const $$ = this;
 		const startEvent = $$.zoom.startEvent;
-		const orgDomain = $$.subX.domain();
-		const scaledDomain = $$.zoomScale ? $$.zoomScale.domain() : null;
-		const domain = (orgDomain === scaledDomain) ? orgDomain : scaledDomain;
 
 		// if click, do nothing. otherwise, click interaction will be canceled.
 		if (!startEvent ||
@@ -184,7 +181,7 @@ extend(ChartInternal.prototype, {
 		$$.redrawEventRect();
 		$$.updateZoom();
 
-		callFn($$.config.zoom_onzoomend, $$.api, domain);
+		callFn($$.config.zoom_onzoomend, $$.api, $$[$$.zoomScale ? "zoomScale" : "subX"].domain());
 	},
 
 	/**

--- a/src/interactions/zoom.js
+++ b/src/interactions/zoom.js
@@ -160,7 +160,7 @@ extend(ChartInternal.prototype, {
 		});
 
 		$$.cancelClick = isMousemove;
-		callFn(config.zoom_onzoom, $$.api, $$.subX.domain());
+		callFn(config.zoom_onzoom, $$.api, $$.zoomScale.domain());
 	},
 
 	/**
@@ -170,6 +170,9 @@ extend(ChartInternal.prototype, {
 	onZoomEnd() {
 		const $$ = this;
 		const startEvent = $$.zoom.startEvent;
+		const orgDomain = $$.subX.domain();
+		const scaledDomain = $$.zoomScale.domain();
+		const domain = (orgDomain === scaledDomain) ? orgDomain : scaledDomain;
 
 		// if click, do nothing. otherwise, click interaction will be canceled.
 		if (!startEvent ||
@@ -181,7 +184,7 @@ extend(ChartInternal.prototype, {
 		$$.redrawEventRect();
 		$$.updateZoom();
 
-		callFn($$.config.zoom_onzoomend, $$.api, $$.subX.domain());
+		callFn($$.config.zoom_onzoomend, $$.api, domain);
 	},
 
 	/**


### PR DESCRIPTION
Updated the domain value passed to callFn on onzoom/onzoomend callback

Ref #770

## Issue
Onzoom function doesn't return the updated domain values #770

## Details
In the function onZoom(), while passing the value of the domain to the callFn(), the subX value was used instead of zoomScale (which contains the updated domain value).
In the function onZoomEnd(), the above changes were done, but also when the chart is fully zoomed out, zoomScale becomes null, hence during that scenario, subX will be used instead of zoomScale.
