### PR TITLE
Patch 1

### DIFF
--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -161,7 +161,7 @@ export interface YAxisConfiguration {
 	/**
 	 * Set additional axes for Axis
 	 */
-	axes: AxesConfiguration[];
+	axes?: AxesConfiguration[];
 }
 
 export interface XTickConfiguration {

--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -90,7 +90,7 @@ export interface XAxisConfiguration {
 	/**
 	 * Set additional axes for Axis
 	 */
-	axes: AxesConfiguration[];
+	axes?: AxesConfiguration[];
 }
 
 export interface YAxisConfiguration {


### PR DESCRIPTION


## Issue
If not optional, users are forced to set axes property to an empty array for single axes scenario.

## Details
Make XAxisConfiguration and YAxisConfiguration's property `axes` optional.
