### PR TITLE
feat(area): Intent to ship area.linearGradient

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1095,6 +1095,7 @@ var demos = {
 			]
 		},
 		XAxisTickTimeseries: {
+			description: "Drag over chart area and checkout the x Axis tick text label",
 			options: {
 				data: {
 					x: "x",
@@ -2455,6 +2456,74 @@ d3.select(".chart_area")
 					},
 					tooltip: {
 						linked: true
+					}
+				}
+			}
+		]
+	},
+	AreaChartOptions: {
+		Above: {
+			options: {
+				data: {
+					columns: [
+						["data1", 230, 280, 251, 400, 150, 546, 158],
+						["data2", 130, 357, 151, 400, 250, 250, 395]
+					],
+					type: "area",
+					groups: [["data1", "data2"]]
+				},
+				area: {
+					above: true
+				}
+			}
+		},
+		LinearGradient: [
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 230, 280, 251, 400, 150, 546, 158],
+							["data2", 130, 357, 151, 400, 250, 250, 395],
+							["data3", 330, 280, 320, 218, 450, 150, 500]
+						],
+						type: "area-spline",
+						groups: [["data1", "data2", "data3"]]
+					},
+					area: {
+						linearGradient: true
+					}
+				}
+			},
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 30, 200, 100, 400, 150, 250, 150, 200, 170, 240, 350, 150, 100, 400, 150, 250, 150, 200, 170, 240, 100, 150, 250, 150, 200, 170, 240, 30, 200, 100, 400, 150, 250, 150, 200, 170, 240, 350, 150, 100, 400, 350, 220, 250, 300, 270, 140, 150, 90, 150, 50, 120, 70, 40]
+						],
+						type: "area"
+					},
+					area: {
+						linearGradient: {
+							x: [1, 0],
+							y: [0, 1],
+							stops: [
+								[0, function(id) {
+             return id == "data1" ? "red" : "yellow";
+					          }, 1],
+								[0.3, "orange", 0.5],
+								[0.6, "green", 0.7],
+								[0.8, "purple", 0.7],
+								[1, null, 1],
+							]
+						}
+					},
+					point: {
+						r: 0,
+						focus: {
+							expand: {
+								r: 5
+							}
+						}
 					}
 				}
 			}

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -1599,7 +1599,7 @@ export default class Options {
 			 * @memberof Options
 			 * @type {Boolean}
 			 * @default true
-			 * @see [Demo](http://jindo.com/git/billboard.js/demo/#Axis.XAxisTickFitting)
+			 * @see [Demo](https://naver.github.io/billboard.js/demo/#Axis.XAxisTickFitting)
 			 * @see [Demo: for timeseries zoom](https://naver.github.io/billboard.js/demo/#Axis.XAxisTickTimeseries)
 			 * @example
 			 * axis: {
@@ -2859,15 +2859,49 @@ export default class Options {
 			 * @memberof Options
 			 * @type {Object}
 			 * @property {Boolean} [area.zerobased=true] Set if min or max value will be 0 on area chart.
-			 * @property {Boolean} [area.above=false]
+			 * @property {Boolean} [area.above=false] Set background area above the data chart line.
+			 * @property {Boolean|Object} [area.linearGradient=false] Set the linear gradient on area.<br><br>
+			 * Or customize by giving below object value:
+			 *  - x {Array}: `x1`, `x2` value
+			 *  - y {Array}: `y1`, `y2` value
+			 *  - stops {Array}: Each item should be having `[offset, stop-color, stop-opacity]` values.
+			 * @see [MDN's &lt;linearGradient>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient), [&lt;stop>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/stop)
+			 * @see [Demo](https://naver.github.io/billboard.js/demo/#Chart.AreaChart)
+			 * @see [Demo: above](https://naver.github.io/billboard.js/demo/#AreaChartOptions.Above)
+			 * @see [Demo: linearGradient](https://naver.github.io/billboard.js/demo/#AreaChartOptions.LinearGradient)
 			 * @example
 			 *  area: {
 			 *      zerobased: false,
-			 *      above: true
+			 *      above: true,
+			 *
+			 *      // will generate follwing linearGradient:
+			 *      // <linearGradient x1="0" x2="0" y1="0" y2="1">
+			 *      //    <stop offset="0" stop-color="$DATA_COLOR" stop-opacity="1"></stop>
+			 *      //    <stop offset="1" stop-color="$DATA_COLOR" stop-opacity="0"></stop>
+			 *      // </linearGradient>
+			 *      linearGradient: true,
+			 *
+			 *      // Or customized gradient
+			 *      linearGradient: {
+			 *      	x: [0, 0],  // x1, x2 attributes
+			 *      	y: [0, 0],  // y1, y2 attributes
+			 *      	stops: [
+			 *      		// offset, stop-color, stop-opacity
+			 *      		[0, "#7cb5ec", 1],
+			 *
+			 *      		// setting 'null' for stop-color, will set its original data color
+			 *      		[0.5, null, 0],
+			 *
+			 *      		// setting 'function' for stop-color, will pass data id as argument.
+			 *      		// It should return color string or null value
+			 *      		[1, function(id) { return id === "data1" ? "red" : "blue"; }, 0],
+			 *      	]
+			 *      }
 			 *  }
 			 */
 			area_zerobased: true,
 			area_above: false,
+			area_linearGradient: false,
 
 			/**
 			 * Set pie options

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -109,7 +109,7 @@ export interface ChartOptions {
 		/**
 		 * Set the color value for each data point when mouse/touch onover event occurs.
 		 */
-		onover: string | object | ((d: DataItem) => string);
+		onover: string | {[key: string]: string} | ((d: DataItem) => string);
 	};
 
 	interaction?: {
@@ -203,6 +203,20 @@ export interface ChartOptions {
 	};
 
 	area?: {
+		/**
+		 * Set background area above the data chart line.
+		 */
+		above?: boolean;
+
+		/**
+		 * Set the linear gradient on area.<br><br>
+		 * Or customize by giving below object value:
+		 *  - x {Array}: `x1`, `x2` value
+		 *  - y {Array}: `y1`, `y2` value
+		 *  - stops {Array}: Each item should be having `[offset, stop-color, stop-opacity]` values.
+		 */
+		linearGradient?: boolean | AreaLinearGradientOptions;
+
 		/**
 		 * Set if min or max value will be 0 on area chart.
 		 */
@@ -529,6 +543,30 @@ export interface ChartOptions {
 	 * Is to make chart element positioned over axis element.
 	 */
 	clipPath?: boolean;
+}
+
+export interface AreaLinearGradientOptions {
+	/**
+	 * x1, x2 attributes
+	 */
+	x?: [number, number];
+
+	/**
+	 * y1, y2 attributes
+	 */
+	y?: [number, number];
+
+	/**
+	 * The ramp of colors to use on a gradient
+	 */
+	stops?: [
+		/**
+		 * offset, stop-color, stop-opacity
+		 * - setting 'null' for stop-color, will set its original data color
+		 * - setting 'function' for stop-color, will pass data id as argument. It should return color string or null value
+		 */
+		[number, string | null | ((id: string) => string), number]
+	];
 }
 
 export interface RegionOptions {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#755

## Details
<!-- Detailed description of the change/feature -->
Implement `linearGradient` for area type

![image](https://user-images.githubusercontent.com/2178435/54009512-6f5d2100-41ae-11e9-9544-5bb041750eb6.png)

### Interface:
```js
{
	// will generate follwing linearGradient:
	// <linearGradient x1="0" x2="0" y1="1">
	//    <stop offset="0" stop-color="$DATA_COLOR" stop-opacity="0"></stop>
	//    <stop offset="1" stop-color="$DATA_COLOR" stop-opacity="1"></stop>
	// </linearGradient>
	linearGradient: true,
	
	// Or customized gradient
	linearGradient: {
		x: [0, 0],  // x1, x2 attributes
		y: [0, 0],  // y1, y2 attributes
		stops: [
			// offset, stop-color, stop-opacity
			[0, "#7cb5ec", 1],
	
			// setting 'null' for stop-color, will set its original data color
			[0.5, null, 0],
	
			// setting 'function' for stop-color, will pass data id as argument.
			// It should return color string or null value
			[1, function(id) { return id === "data1" ? "red" : "blue" }, 0],
		]
	}
}
```
