### PR TITLE
refactor(size): Reduce duplicated dimension call

### DIFF
--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -380,7 +380,12 @@ export default class ChartInternal {
 		}
 	}
 
-	updateSizes() {
+	/**
+	 * Update size values
+	 * @param {Boolean} isInit If is called at initialization
+	 * @private
+	 */
+	updateSizes(isInit) {
 		const $$ = this;
 		const config = $$.config;
 		const isRotated = config.axis_rotated;
@@ -399,8 +404,7 @@ export default class ChartInternal {
 		const subchartHeight = config.subchart_show && !hasArc ?
 			(config.subchart_size_height + subchartXAxisHeight) : 0;
 
-		$$.currentWidth = $$.getCurrentWidth();
-		$$.currentHeight = $$.getCurrentHeight();
+		!isInit && $$.setContainerSize();
 
 		// for main
 		$$.margin = isRotated ? {
@@ -560,6 +564,7 @@ export default class ChartInternal {
 		const config = $$.config;
 		const targetsToShow = $$.filterTargetsToShow($$.data.targets);
 
+		const initializing = options.initializing;
 		const flow = options.flow;
 		const wth = $$.getWithOption(options);
 		const duration = wth.Transition ? config.transition_duration : 0;
@@ -567,8 +572,10 @@ export default class ChartInternal {
 		const durationForAxis = wth.TransitionForAxis ? duration : 0;
 		const transitions = transitionsValue || $$.axis.generateTransitions(durationForAxis);
 
-		!(options.initializing && config.tooltip_init_show) &&
+		!(initializing && config.tooltip_init_show) &&
 			$$.inputType === "touch" && $$.hideTooltip();
+
+		$$.updateSizes(initializing);
 
 		// update legend and transform each g
 		if (wth.Legend && config.legend_show) {
@@ -884,9 +891,6 @@ export default class ChartInternal {
 		options.withTransitionForExit = false;
 		options.withTransitionForTransform = getOption(options, "withTransitionForTransform", options.withTransition);
 
-		// MEMO: this needs to be called before updateLegend and it means this ALWAYS needs to be called)
-		$$.updateSizes();
-
 		// MEMO: called in updateLegend in redraw if withLegend
 		if (!(options.withLegend && config.legend_show)) {
 			transitions = $$.axis.generateTransitions(
@@ -1145,11 +1149,8 @@ export default class ChartInternal {
 			}
 		}
 
-		$$.updateSizes();
-
 		// pass 'withoutAxis' param to not animate at the init rendering
 		$$.updateScales(withoutAxis);
-
 		$$.updateSvgSize();
 		$$.transformAll(false);
 	}

--- a/src/internals/legend.js
+++ b/src/internals/legend.js
@@ -66,7 +66,6 @@ extend(ChartInternal.prototype, {
 		}
 
 		// Update size and scale
-		$$.updateSizes();
 		$$.updateScales();
 		$$.updateSvgSize();
 

--- a/src/internals/size.js
+++ b/src/internals/size.js
@@ -7,6 +7,17 @@ import CLASS from "../config/classes";
 import {isValue, ceil10, extend, capitalize} from "./util";
 
 extend(ChartInternal.prototype, {
+	/**
+	 * Update container size
+	 * @private
+	 */
+	setContainerSize() {
+		const $$ = this;
+
+		$$.currentWidth = $$.getCurrentWidth();
+		$$.currentHeight = $$.getCurrentHeight();
+	},
+
 	getCurrentWidth() {
 		const $$ = this;
 
@@ -123,21 +134,17 @@ extend(ChartInternal.prototype, {
 	 */
 	getParentRectValue(key) {
 		const offsetName = `offset${capitalize(key)}`;
-		let parent = this.selectChart.node();
+		const container = this.selectChart.node();
 		let v;
 
-		while (!v && parent && parent.tagName !== "BODY") {
-			try {
-				v = parent.getBoundingClientRect()[key];
-			} catch (e) {
-				if (offsetName in parent) {
-					// In IE in certain cases getBoundingClientRect
-					// will cause an "unspecified error"
-					v = parent[offsetName];
-				}
+		try {
+			v = container.getBoundingClientRect()[key];
+		} catch (e) {
+			if (offsetName in container) {
+				// In IE in certain cases getBoundingClientRect
+				// will cause an "unspecified error"
+				v = container[offsetName];
 			}
-
-			parent = parent.parentNode;
 		}
 
 		if (key === "width") {


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
- Reduce retrieving unnecessary .updateSize() calls
- Chaged the way on getting chart container's dimension
