### PR TITLE
fix(api): Fix css encoding in exported svg

### DIFF
--- a/spec/api/api.export-spec.js
+++ b/spec/api/api.export-spec.js
@@ -101,4 +101,19 @@ describe("API export", () => {
 			});
 		}, 500);
 	});
+  
+	it("should export valid svg even with weird css", done => {
+		document.body.innerHTML += `<style>@font-face{src:url("#&<>'\0");}</style>`;
+
+		let dataURL = chart.export();
+
+		// test generated svg
+		let svg = atob(dataURL.split("base64,")[1]);
+		let oParser = new DOMParser();
+		let doc = oParser.parseFromString(svg, "image/svg+xml");
+
+		// check that it does not start with error message
+		expect(doc.documentElement.nodeName === "svg").to.be.true;
+		done();
+	});
 });

--- a/src/api/api.export.js
+++ b/src/api/api.export.js
@@ -34,11 +34,19 @@ const nodeToSvgDataUrl = (node, size) => {
 
 	const nodeXml = new XMLSerializer().serializeToString(clone);
 
+	// escape css for XML
+	const style = document.createElement("style");
+
+	style.type = "text/css";
+	style.appendChild(document.createTextNode(cssText.join("\n")));
+
+	const styleXml = new XMLSerializer().serializeToString(style);
+
 	// foreignObject not supported in IE11 and below
 	// https://msdn.microsoft.com/en-us/library/hh834675(v=vs.85).aspx
 	const dataStr = `<svg xmlns="${d3Namespaces.svg}" width="${size.width}" height="${size.height}">
 			<foreignObject width="100%" height="100%">
-				<style>${cssText.join("\n")}</style>
+				${styleXml}
 				${nodeXml.replace(/(url\()[^#]+/g, "$1")}
 			</foreignObject></svg>`
 		.replace("/\n/g", "%0A");


### PR DESCRIPTION
Encode all style elements before including them in export svg, to avoid XML special character problems.
Added a test for export with "weird" css.

Ref #843

## Issue
#843

## Details
Not sure if this is the most elegant way to solve this problem.
