### PR TITLE
feat(pie): Enhance innerRadius option

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3343,21 +3343,42 @@ d3.select(".chart_area")
 				}
 			}
 		},
-		InnerRadius: {
-			options: {
-				data: {
-					columns: [
-						["data1", 30],
-						["data2", 50],
-						["data3", 20]
-					],
-					type: "pie"
-				},
-				pie: {
-					innerRadius: 20
+		InnerRadius: [
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 30],
+							["data2", 50],
+							["data3", 20]
+						],
+						type: "pie"
+					},
+					pie: {
+						innerRadius: 20
+					}
 				}
-			}
-		},
+			},
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 30],
+							["data2", 50],
+							["data3", 20]
+						],
+						type: "pie"
+					},
+					pie: {
+						innerRadius: {
+							data1: 50,
+							data2: 80,
+							data3: 0
+						}
+					}
+				}
+			},
+		],
 		PadAngle: {
 			options: {
 				data: {

--- a/spec/shape/shape.arc-spec.js
+++ b/spec/shape/shape.arc-spec.js
@@ -182,6 +182,43 @@ describe("SHAPE ARC", () => {
 				expect(value).to.be.equal(d.value);
 			});
 		});
+
+		it("check for variant innerRadius", done => {
+			const innerRadius = {
+				data1: 50,
+				data2: 80,
+				data3: 0
+			};
+			const chart = util.generate({
+				data: {
+					columns: [
+						["data1", 30],
+						["data2", 50],
+						["data3", 20]
+					],
+					type: "pie"
+				},
+				pie: {
+					innerRadius
+				}
+			});
+
+			const expected = {
+				data1: "M-8.110822788676742e-14,211.85A211.85,211.85,0,0,1,-201.48132297712823,-65.46525025833276L-47.55282581475767,-15.450849718747406A50,50,0,0,0,-1.9142843494634746e-14,50Z",
+				data2: "M1.2972071219968338e-14,-211.85A211.85,211.85,0,1,1,-8.110822788676742e-14,211.85L-3.06285495914156e-14,80A80,80,0,1,0,4.898587196589413e-15,-80Z",
+				data3: "M-201.48132297712823,-65.46525025833276A211.85,211.85,0,0,1,1.4924438455356651e-13,-211.85L0,0Z"
+			};
+
+			expect(chart.internal.innerRadius).to.be.deep.equal(innerRadius);
+
+			setTimeout(() => {
+				chart.$.arc.selectAll("path").each(function(d) {
+					expect(this.getAttribute("d")).to.be.equal(expected[d.data.id]);
+				});
+
+				done();
+			}, 500);
+		});
 	});
 
 	describe("show gauge", () => {

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -2947,7 +2947,7 @@ export default class Options {
 			 * @property {Number|Function} [pie.label.ratio=undefined] Set ratio of labels position.
 			 * @property {Boolean|Object} [pie.expand=true] Enable or disable expanding pie pieces.
 			 * @property {Number} [pie.expand.duration=50] Set expand transition time in ms.
-			 * @property {Number} [pie.innerRadius=0] Sets the inner radius of pie arc.
+			 * @property {Number|Object} [pie.innerRadius=0] Sets the inner radius of pie arc.
 			 * @property {Number} [pie.padAngle=0] Set padding between data.
 			 * @property {Number} [pie.padding=0] Sets the gap between pie arcs.
 			 * @example
@@ -2980,6 +2980,13 @@ export default class Options {
 			 *      },
 			 *
 			 *      innerRadius: 0,
+			 *
+			 *      // set different innerRadius for each data
+			 *      innerRadius: {
+			 *      	data1: 10,
+			 *      	data2: 0
+			 *      }
+			 *
 			 *      padAngle: 0.1,
 			 *      padding: 0
 			 *  }

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -385,7 +385,10 @@ export interface ChartOptions {
 		/**
 		 * Sets the inner radius of pie arc.
 		 */
-		innerRadius?: number;
+		innerRadius?: number | {
+			[key: string]: number
+			
+		};
 
 		/**
 		 * Set padding between data.


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#856

## Details
<!-- Detailed description of the change/feature -->
Implement innerRadius to be applicable for each dataset.

![image](https://user-images.githubusercontent.com/2178435/57061816-4d3cd680-6cf9-11e9-919e-b69a836d4aba.png)

```js
bb.generate({
	data: {
		columns: [
			["data1", 30],
			["data2", 50],
			["data3", 20]
		],
		type: "pie"
	},
	pie: {
		innerRadius: {
			data1: 50,
			data2: 80,
			data3: 0
		}
	}
});
```
