### PR TITLE
fix(point): Correct point expansion on old IEs

### DIFF
--- a/spec/shape/shape.point-spec.js
+++ b/spec/shape/shape.point-spec.js
@@ -35,6 +35,18 @@ describe("SHAPE POINT", () => {
 
 			expect(circles.length).to.be.equal(6);
 		});
+
+		it("circle points are expanded?", () => {
+			const index = 1;
+			const r = chart.config("point.r");
+
+			// when
+			chart.internal.expandCircles(index);
+
+			chart.$.line.circles.filter(d => d.x === index).each(function() {
+				expect(+this.getAttribute("r")).to.be.above(r);
+			});
+		});
 	});
 
 	describe("rectangle point type", () => {
@@ -90,7 +102,7 @@ describe("SHAPE POINT", () => {
 
 		it("set options point.pattern", () => {
 			args.point.pattern = [
-				"<g><circle cx='10' cy='10' r='10'></circle><rect x='5' y='5' width='10' height='10'></rect></g>"
+				"<g><circle cx='10' cy='10' r='10'></circle><rect x='5' y='5' width='10' height='10' style='fill:#fff'></rect></g>"
 			];
 		});
 
@@ -100,6 +112,19 @@ describe("SHAPE POINT", () => {
 
 			chart.$.defs.selectAll("g").each(function() {
 				expect(this.innerHTML).to.be.equal(innerHTML);
+			});
+		});
+
+		it("custom points are expanded?", () => {
+			const index = 1;
+
+			// when
+			chart.internal.expandCircles(index);
+
+			chart.$.line.circles.filter(d => d.x === index).each(function() {
+				const scale = +this.getAttribute("transform").match(/scale\((.*)\)/)[1];
+
+				expect(scale).to.be.equal(1.75);
 			});
 		});
 	});

--- a/src/axis/AxisRenderer.js
+++ b/src/axis/AxisRenderer.js
@@ -210,7 +210,7 @@ export default class AxisRenderer {
 				}
 
 				tickTransform.call(helperInst, tickEnter, scale0);
-				tickTransform.call(helperInst, helperInst.transitionise(tick).style("opacity", 1), scale1);
+				tickTransform.call(helperInst, helperInst.transitionise(tick).style("opacity", "1"), scale1);
 			}
 		});
 

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -304,7 +304,8 @@ extend(ChartInternal.prototype, {
 					$$.getYFormat(forArc),
 					$$.color
 				))
-				.style("display", config.tooltip_doNotHide === false ? "block" : null)
+				.style("display", null)
+				.style("visibility", null) // for IE9
 				.datum({
 					index,
 					current: dataStr,
@@ -340,7 +341,10 @@ extend(ChartInternal.prototype, {
 			callFn(config.tooltip_onhide, $$);
 
 			// hide tooltip
-			this.tooltip.style("display", "none").datum(null);
+			this.tooltip
+				.style("display", "none")
+				.style("visibility", "hidden") // for IE9
+				.datum(null);
 
 			callFn(config.tooltip_onhidden, $$);
 		}

--- a/src/shape/line.js
+++ b/src/shape/line.js
@@ -623,7 +623,7 @@ extend(ChartInternal.prototype, {
 					const x = ratio * (+point.attr("x") + width / 2);
 					const y = ratio * (+point.attr("y") + height / 2);
 
-					point.style("transform", `translate(${x}px, ${y}px) scale(${scale})`);
+					point.attr("transform", `translate(${x} ${y}) scale(${scale})`);
 				}
 			});
 		}
@@ -642,7 +642,7 @@ extend(ChartInternal.prototype, {
 		circles.attr("r", r);
 
 		!$$.isCirclePoint() &&
-			circles.style("transform", `scale(${r(circles) / $$.config.point_r})`);
+			circles.attr("transform", `scale(${r(circles) / $$.config.point_r})`);
 	},
 
 	pointR(d) {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#897

## Details
<!-- Detailed description of the change/feature -->
- Change CSS props set as 'transform' attribute rather than style
property.
- Fix opacity value setting as string type to work on IE9
- For tooltip visibility: add 'visibility' prop to work on IE9

