### PR TITLE
Make source code es modules compatible

### DIFF
--- a/config/webpack.config.packaged.js
+++ b/config/webpack.config.packaged.js
@@ -1,6 +1,5 @@
 const merge = require("webpack-merge");
 const webpack = require("webpack");
-const StringReplacePlugin = require("string-replace-webpack-plugin");
 const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
 const uglifyConfig = require("./uglify");
 const banner = require("./banner");
@@ -11,19 +10,6 @@ const config = {
 		"billboard.pkgd.min": "./src/core.js",
 	},
 	devtool: false,
-	module: {
-		rules: [
-			{
-				test: /(core\.js)$/,
-				loader: StringReplacePlugin.replace({
-					replacements: [{
-						pattern: /import \"\.\/scss\/\w+\.scss\";/ig,
-						replacement: () => ""
-					}]
-				})
-			}
-		],
-	},
 	plugins: [
 		new UglifyJSPlugin(uglifyConfig),
 		new webpack.BannerPlugin({

--- a/config/webpack.config.production.js
+++ b/config/webpack.config.production.js
@@ -10,8 +10,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 const config = {
 	entry: {
-		"billboard": "./src/core.js",
-		"billboard.min": "./src/core.js"
+		"billboard.min": ["./src/scss/billboard.scss", "./src/core.js"]
 	},
 	module: {
 		rules: [

--- a/src/core.js
+++ b/src/core.js
@@ -59,9 +59,6 @@ import "./api/api.chart";
 import "./api/api.tooltip";
 import "./api/api.export";
 
-// base CSS
-import "./scss/billboard.scss";
-
 let defaults = {};
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const WebpackBar = require("webpackbar");
 
 const config = {
 	entry: {
-		billboard: "./src/core.js"
+		billboard: ["./src/scss/billboard.scss", "./src/core.js"]
 	},
 	output: {
 		path: path.resolve(__dirname, "dist"),


### PR DESCRIPTION
Hi there!
Thank you for your awesome work on this library!

I tried importing billboard.js using native javascript module imports in the browser and it works 100% except for the `import "./scss/billboard.scss";` line (of course), thus causing the import to fail.

This PR changes the build configuration a bit so that the scss file is not mentioned in the source files. The resulting output of the build scripts is 100% identical to the original.