### PR TITLE
fix(browser): Fix to work on Node.js env

### DIFF
--- a/config/webpack.config.plugin.js
+++ b/config/webpack.config.plugin.js
@@ -31,7 +31,8 @@ const config = {
 		library: ["bb", "plugin", "[name]"],
 		libraryExport: "default",
 		libraryTarget: "umd",
-		umdNamedDefine: true
+		umdNamedDefine: true,
+		globalObject: "this"
 	},
 	devtool: false,
 	plugins: [

--- a/src/api/api.export.js
+++ b/src/api/api.export.js
@@ -4,6 +4,7 @@
  */
 import {namespaces as d3Namespaces} from "d3-selection";
 import Chart from "../internals/Chart";
+import {document} from "../internals/browser";
 import {extend, isFunction, toArray, getCssRules} from "../internals/util";
 
 /**

--- a/src/interactions/interaction.js
+++ b/src/interactions/interaction.js
@@ -9,6 +9,7 @@ import {
 } from "d3-selection";
 import {drag as d3Drag} from "d3-drag";
 import ChartInternal from "../internals/ChartInternal";
+import {document} from "../internals/browser";
 import CLASS from "../config/classes";
 import {emulateEvent, extend, isBoolean, isNumber, isObject} from "../internals/util";
 

--- a/src/interactions/zoom.js
+++ b/src/interactions/zoom.js
@@ -10,6 +10,7 @@ import {
 import {drag as d3Drag} from "d3-drag";
 import {zoom as d3Zoom} from "d3-zoom";
 import ChartInternal from "../internals/ChartInternal";
+import {document} from "../internals/browser";
 import CLASS from "../config/classes";
 import {extend, callFn, diffDomain, getMinMax, isDefined} from "../internals/util";
 

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -16,7 +16,7 @@ import {
 import {transition as d3Transition} from "d3-transition";
 import Axis from "../axis/Axis";
 import CLASS from "../config/classes";
-import {isMobile} from "../internals/browser";
+import {document, window} from "../internals/browser";
 import {notEmpty, asHalfPixel, getOption, isValue, isArray, isFunction, isString, isNumber, isObject, callFn, sendStats, sortValue} from "./util";
 
 /**
@@ -1286,6 +1286,10 @@ export default class ChartInternal {
 	convertInputType() {
 		const $$ = this;
 		const config = $$.config;
+		const isMobile = (
+			window.navigator && "maxTouchPoints" in window.navigator && window.navigator.maxTouchPoints > 0
+		) || false;
+
 		const hasMouse = config.interaction_inputType_mouse && !isMobile ? ("onmouseover" in window) : false;
 		let hasTouch = false;
 

--- a/src/internals/browser.js
+++ b/src/internals/browser.js
@@ -17,14 +17,7 @@ const win = (() => {
 
 const doc = win && win.document;
 
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
-const isMobile = (
-	win.navigator && win.navigator.userAgent &&
-		win.navigator.userAgent.indexOf("Mobi") > -1
-) || false;
-
 export {
 	win as window,
-	doc as document,
-	isMobile
+	doc as document
 };

--- a/src/internals/clip.js
+++ b/src/internals/clip.js
@@ -3,6 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import ChartInternal from "./ChartInternal";
+import {document, window} from "../internals/browser";
 import {extend} from "./util";
 
 extend(ChartInternal.prototype, {
@@ -33,8 +34,9 @@ extend(ChartInternal.prototype, {
 			return null;
 		}
 
-		const isIE9 = window.navigator.appVersion
-			.toLowerCase().indexOf("msie 9.") >= 0;
+		const isIE9 = window.navigator ?
+			window.navigator.appVersion
+				.toLowerCase().indexOf("msie 9.") >= 0 : false;
 
 		return `url(${(isIE9 ? "" : document.URL.split("#")[0])}#${id})`;
 	},

--- a/src/internals/color.js
+++ b/src/internals/color.js
@@ -5,6 +5,7 @@
 import {select as d3Select} from "d3-selection";
 import {scaleOrdinal as d3ScaleOrdinal} from "d3-scale";
 import ChartInternal from "./ChartInternal";
+import {document, window} from "./browser";
 import CLASS from "../config/classes";
 import {notEmpty, extend, isFunction, isObject, isString} from "./util";
 

--- a/src/internals/legend.js
+++ b/src/internals/legend.js
@@ -8,6 +8,7 @@ import {
 	namespaces as d3Namespaces
 } from "d3-selection";
 import ChartInternal from "./ChartInternal";
+import {document} from "./browser";
 import CLASS from "../config/classes";
 import {extend, callFn, isDefined, getOption, isEmpty, isFunction, notEmpty, tplProcess} from "./util";
 

--- a/src/internals/size.js
+++ b/src/internals/size.js
@@ -3,6 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import ChartInternal from "./ChartInternal";
+import {document} from "./browser";
 import CLASS from "../config/classes";
 import {isValue, ceil10, extend, capitalize} from "./util";
 

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -7,6 +7,7 @@ import {
 	mouse as d3Mouse
 } from "d3-selection";
 import ChartInternal from "./ChartInternal";
+import {document} from "./browser";
 import CLASS from "../config/classes";
 import {extend, isFunction, isObject, isString, isValue, callFn, sanitise, tplProcess, isUndefined} from "./util";
 

--- a/src/internals/util.js
+++ b/src/internals/util.js
@@ -5,6 +5,7 @@
  */
 import {event as d3Event} from "d3-selection";
 import {brushSelection as d3BrushSelection} from "d3-brush";
+import {document, window} from "./browser";
 import CLASS from "../config/classes";
 
 const isValue = v => v || v === 0;

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -12,6 +12,7 @@ import {
 } from "d3-shape";
 import {interpolate as d3Interpolate} from "d3-interpolate";
 import ChartInternal from "../internals/ChartInternal";
+import {document} from "../internals/browser";
 import CLASS from "../config/classes";
 import {extend, isFunction, isNumber, isUndefined, setTextValue} from "../internals/util";
 

--- a/src/shape/point.js
+++ b/src/shape/point.js
@@ -7,6 +7,7 @@ import {
 	select as d3Select
 } from "d3-selection";
 import ChartInternal from "../internals/ChartInternal";
+import {document} from "../internals/browser";
 import {getRandom, isFunction, isObjectType, toArray, extend, notEmpty} from "../internals/util";
 
 extend(ChartInternal.prototype, {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ const config = {
 		filename: "[name].js",
 		libraryTarget: "umd",
 		umdNamedDefine: true,
+		globalObject: "this"
 	},
 	externals: (context, request, callback) => {
 		// every 'd3-*' import, will be externally required as their name except root as 'd3'


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#558

## Details
<!-- Detailed description of the change/feature -->
- Make window & document to be referenced from `./src/internals/browser`.
- Move `.isMobile()` to ChartInternal.js' `.convertInputType()`.
- Add output.globalObject option to make webpack's bootstrap from `window`
to `this`.