### PR TITLE
chore(package): tree-shaking drops 90% of the code

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "jsdoc:cmd": "jsdoc -c jsdoc.json"
   },
   "sideEffects": [
-    "dist/**/*.css"
+    "dist/**/*.css",
+    "src/**/*.js"
   ],
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Issue
https://github.com/rollup/rollup/issues/3039

## Details
In an es modules environment you can import billboard.js using `import {bb} from 'billboard.js/src/core'`.
If you bundle the code using rollup or webpack, most of the code is removed by the tree-shaking algorithm, because the files are marked as side-effect free, even though they contain side-effects.

Re https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
