### PR TITLE
fix(data): Fix header option setting

### DIFF
--- a/spec/api/api.load-spec.js
+++ b/spec/api/api.load-spec.js
@@ -408,7 +408,7 @@ describe("API load", function() {
 		});
 	});
 
-	describe("XHR data loading", () => {
+	describe.skip("XHR data loading", () => {
 		const path = "/base/spec/assets/data/";
 
 		before(() => {

--- a/spec/api/api.load-spec.js
+++ b/spec/api/api.load-spec.js
@@ -14,6 +14,30 @@ describe("API load", function() {
 		chart = util.generate(args);
 	});
 
+	describe("XHR data loading", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: []
+				}
+			};
+		});
+
+		it("should be load data via 'url'", done => {
+			chart.load({
+				url: "/base/spec/assets/data/test.json",
+				mimeType: "json",
+				headers: {
+					"Content-Type": "text/xml"
+				},
+				done: () => {
+					expect(chart.data().length).to.be.equal(3);
+					done();
+				}
+			});
+		});
+	});
+
 	describe("check for load options", () => {
 		before(() => {
 			args = {
@@ -402,32 +426,6 @@ describe("API load", function() {
 						lastX = x;
 					});
 
-					done();
-				}
-			});
-		});
-	});
-
-	describe.skip("XHR data loading", () => {
-		const path = "/base/spec/assets/data/";
-
-		before(() => {
-			args = {
-				data: {
-					columns: []
-				}
-			};
-		});
-
-		it("should be load data via 'url'", done => {
-			chart.load({
-				url: `${path}test.json`,
-				mimeType: "json",
-				headers: {
-					"Content-Type": "text/xml"
-				},
-				done: () => {
-					expect(chart.data().length).to.be.equal(3);
 					done();
 				}
 			});

--- a/spec/api/api.load-spec.js
+++ b/spec/api/api.load-spec.js
@@ -364,7 +364,7 @@ describe("API load", function() {
 			["Dutch",0,0,0,0,0,0,0,0,0,0],
 			["French",0,1,0,0,0,0,0,0,0,1],
 			["Chinese",0,0,0,0,0,0,0,0,5,0],
-		];		
+		];
 		const cols2 = [
 			["x",0, 5, 7, 12, 20, 22, 23, 24, 30, 35],
 			["English",12,9,31,26,17,6,11,23,20,12],
@@ -394,7 +394,7 @@ describe("API load", function() {
 					let lastX = 0;
 
 					chart.$.main.selectAll(`.${CLASS.eventRects} rect`).each(function(v, i) {
-						const x = +this.getAttribute("x"); 
+						const x = +this.getAttribute("x");
 
 						expect(x).to.be.above(lastX);
 						expect(this.classList.contains(`${CLASS.eventRect}-${i}`)).to.be.true;
@@ -402,6 +402,32 @@ describe("API load", function() {
 						lastX = x;
 					});
 
+					done();
+				}
+			});
+		});
+	});
+
+	describe("XHR data loading", () => {
+		const path = "/base/spec/assets/data/";
+
+		before(() => {
+			args = {
+				data: {
+					columns: []
+				}
+			};
+		});
+
+		it("should be load data via 'url'", done => {
+			chart.load({
+				url: `${path}test.json`,
+				mimeType: "json",
+				headers: {
+					"Content-Type": "text/xml"
+				},
+				done: () => {
+					expect(chart.data().length).to.be.equal(3);
 					done();
 				}
 			});

--- a/spec/api/api.region-spec.js
+++ b/spec/api/api.region-spec.js
@@ -42,19 +42,19 @@ describe("API region", function() {
 		it("should update regions", done => {
 			const main = chart.$.main;
 			const expectedRegions = [
-					{
-						axis: "y",
-						start: 250,
-						end: 350,
-						class: "red"
-					},
-					{
-						axis: "y",
-						start: 25,
-						end: 75,
-						class: "red"
-					}
-				];
+				{
+					axis: "y",
+					start: 250,
+					end: 350,
+					class: "red"
+				},
+				{
+					axis: "y",
+					start: 25,
+					end: 75,
+					class: "red"
+				}
+			];
 			let regions;
 
 			// Call regions API
@@ -118,38 +118,38 @@ describe("API region", function() {
 		it("should add regions", done => {
 			const main = chart.$.main;
 			const expectedRegions = [
-					{
-						axis: "y",
-						start: 300,
-						end: 400,
-						class: "green",
-					},
-					{
-						axis: "y",
-						start: 0,
-						end: 100,
-						class: "green",
-					},
-					{
-						axis: "y",
-						start: 250,
-						end: 350,
-						class: "red"
-					},
-					{
-						axis: "y",
-						start: 25,
-						end: 75,
-						class: "red"
-					}
-				];
+				{
+					axis: "y",
+					start: 300,
+					end: 400,
+					class: "green",
+				},
+				{
+					axis: "y",
+					start: 0,
+					end: 100,
+					class: "green",
+				},
+				{
+					axis: "y",
+					start: 250,
+					end: 350,
+					class: "red"
+				},
+				{
+					axis: "y",
+					start: 25,
+					end: 75,
+					class: "red"
+				}
+			];
 
 			const expectedClasses = [
-					"green",
-					"green",
-					"red",
-					"red",
-				];
+				"green",
+				"green",
+				"red",
+				"red",
+			];
 
 			let regions;
 
@@ -183,7 +183,7 @@ describe("API region", function() {
 	});
 
 	describe("Remove regions using regions()", () => {
-		before(() =>
+		before(() => {
 			args = {
 				data: {
 					columns: [
@@ -210,18 +210,19 @@ describe("API region", function() {
 						class: "red"
 					},
 				]
-			});
+			}
+		});
 
 		it("should remove regions", done => {
 			const main = chart.$.main;
 			const expectedRegions = [
-					{
-						axis: "y",
-						start: 250,
-						end: 350,
-						class: "red"
-					},
-				];
+				{
+					axis: "y",
+					start: 250,
+					end: 350,
+					class: "red"
+				},
+			];
 			const expectedClasses = ["red"];
 			let regions;
 
@@ -256,14 +257,15 @@ describe("API region", function() {
 
 	// regions.add / remove
 	describe("regions()", () => {
-		before(() =>
-			args ={
+		before(() => {
+			args = {
 				data: {
 					columns: [
 						["data1", 30, 200, 100, 400, 150, 250]
 					]
 				}
-			});
+			}
+		});
 
 		it(".add() / .remove()", () => {
 			const regions = [

--- a/spec/api/api.region-spec.js
+++ b/spec/api/api.region-spec.js
@@ -4,6 +4,7 @@
  */
 /* eslint-disable */
 import util from "../assets/util";
+import CLASS from "../../src/config/classes";
 
 describe("API region", function() {
 	let chart;
@@ -60,7 +61,7 @@ describe("API region", function() {
 			chart.regions(expectedRegions);
 
 			setTimeout(() => {
-				regions = main.selectAll(".bb-region");
+				regions = main.selectAll(`.${CLASS.region}`);
 
 				expect(regions.size()).to.be.equal(expectedRegions.length);
 
@@ -156,7 +157,7 @@ describe("API region", function() {
 			chart.regions(expectedRegions);
 
 			setTimeout(() => {
-				regions = main.selectAll(".bb-region");
+				regions = main.selectAll(`.${CLASS.region}`);
 
 				expect(regions.size()).to.be.equal(expectedRegions.length);
 
@@ -228,7 +229,7 @@ describe("API region", function() {
 			chart.regions(expectedRegions);
 
 			setTimeout(() => {
-				regions = main.selectAll(".bb-region");
+				regions = main.selectAll(`.${CLASS.region}`);
 
 				expect(regions.size()).to.be.equal(expectedRegions.length);
 

--- a/spec/interactions/interaction-spec.js
+++ b/spec/interactions/interaction-spec.js
@@ -510,7 +510,7 @@ describe("INTERACTION", () => {
 				const rect = main.select(`.${CLASS.eventRect}.${CLASS.eventRect}`).node();
 				const circle = main.select(`.${CLASS.circles}-data2 circle`).node().getBBox();
 				const delta = 50;
-console.log(JSON.stringify(args))
+
 				util.fireEvent(rect, "click", {
 					clientX: circle.x + delta,
 					clientY: circle.y + delta

--- a/spec/internals/data-spec.js
+++ b/spec/internals/data-spec.js
@@ -141,6 +141,10 @@ describe("DATA", () => {
 			};
 		});
 
+		after(() => {
+			args = {};
+		})
+
 		it("should draw nested JSON correctly", () => {
 			const main = chart.internal.main;
 			const expectedCx = [98, 294, 490];
@@ -218,9 +222,8 @@ describe("DATA", () => {
 				expect(chart.data.values("data1")).to.deep.equal([220, 240, 270, 250, 280]);
 
 				done();
-			}, 300);
+			}, 500);
 		});
-
 	});
 
 	describe("check data.order", () => {

--- a/src/api/api.load.js
+++ b/src/api/api.load.js
@@ -22,14 +22,14 @@ extend(Chart.prototype, {
 	 *    | Key | Description |
 	 *    | --- | --- |
 	 *    | - url<br>- json<br>- rows<br>- columns | The data will be loaded. If data that has the same target id is given, the chart will be updated. Otherwise, new target will be added |
-	 *    | data | Data objects to be loaded |
+	 *    | data | Data objects to be loaded. Checkout the example. |
 	 *    | names | Same as data.names() |
 	 *    | xs | Same as data.xs option  |
 	 *    | classes | The classes specified by data.classes will be updated. classes must be Object that has target id as keys. |
 	 *    | categories | The categories specified by axis.x.categories or data.x will be updated. categories must be Array. |
 	 *    | axes | The axes specified by data.axes will be updated. axes must be Object that has target id as keys. |
 	 *    | colors | The colors specified by data.colors will be updated. colors must be Object that has target id as keys. |
-	 *    | headers |  Set 'json' if loading JSON via data.url.<br>@see [data․headers](Options.html#.data%25E2%2580%25A4headers) |
+	 *    | headers |  Set request header if loading via `data.url`.<br>@see [data․headers](Options.html#.data%25E2%2580%25A4headers) |
 	 *    | keys |  Choose which JSON objects keys correspond to desired data.<br>**NOTE:** Only for JSON object given as array.<br>@see [data․keys](Options.html#.data%25E2%2580%25A4keys) |
 	 *    | mimeType |  Set 'json' if loading JSON via url.<br>@see [data․mimeType](Options.html#.data%25E2%2580%25A4mimeType) |
 	 *    | - type<br>- types | The type of targets will be updated. type must be String and types must be Object. |
@@ -56,7 +56,23 @@ extend(Chart.prototype, {
 	 *
 	 * chart.load({
 	 *     url: './data/myAPI.json',
-	 *     mimeType: "json"
+	 *     mimeType: "json",
+	 *
+	 *     // set request header if is needed
+	 *     headers: {
+	 *       "Content-Type": "text/json"
+	 *     }
+	 * });
+	 * @example
+	 * chart.load({
+	 *     data: [
+	 *       // equivalent as: columns: [["data1", 30, 200, 100]]
+	 *       {"data1": 30}, {"data1": 200}, {"data1": 100}
+	 *
+	 *       // or
+	 *       // equivalent as: columns: [["data1", 10, 20], ["data2", 13, 30]]
+	 *       // {"data1": 10, "data2": 13}, {"data1": 20, "data2": 30}}
+	 *     ]
 	 * });
 	 */
 	load(args) {

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -1155,16 +1155,20 @@ export default class Options {
 
 			/**
 			 * Used if loading JSON via data.url.
+			 * - **Available Values:**
+			 *   - json
+			 *   - csv
+			 *   - tsv
 			 * @name data․mimeType
 			 * @memberof Options
 			 * @type {String}
-			 * @default undefined
+			 * @default csv
 			 * @example
 			 * data: {
 			 *     mimeType: "json"
 			 * }
 			 */
-			data_mimeType: undefined,
+			data_mimeType: "csv",
 
 			/**
 			 * Choose which JSON object keys correspond to desired data.

--- a/src/data/data.convert.js
+++ b/src/data/data.convert.js
@@ -56,13 +56,14 @@ extend(ChartInternal.prototype, {
 	convertUrlToData(url, mimeType = "csv", headers, keys, done) {
 		const req = new XMLHttpRequest();
 
+		req.open("GET", url);
+
 		if (headers) {
 			Object.keys(headers).forEach(key => {
 				req.setRequestHeader(key, headers[key]);
 			});
 		}
 
-		req.open("GET", url);
 		req.onreadystatechange = () => {
 			if (req.readyState === 4) {
 				if (req.status === 200) {

--- a/src/data/data.load.js
+++ b/src/data/data.load.js
@@ -66,7 +66,7 @@ extend(ChartInternal.prototype, {
 
 		const data = args.data || $$.convertData(args, d => $$.load($$.convertDataToTargets(d), args));
 
-		$$.load(data ? $$.convertDataToTargets(data) : null, args);
+		data && $$.load($$.convertDataToTargets(data), args);
 	},
 
 	unload(rawTargetIds, customDoneCb) {


### PR DESCRIPTION
## Issue
#1031

## Details
<!-- Detailed description of the change/feature -->
- Fix headers values to be set after XHR request object is opened
- Add more descritive example and options for: 'data.mimeType' and '.load()'
- Fix .load()'s option 'done' to not be called twice