### PR TITLE
fix(tooltip): Fix tooltip work on touch zoom

### DIFF
--- a/spec/interactions/interaction-spec.js
+++ b/spec/interactions/interaction-spec.js
@@ -798,6 +798,28 @@ describe("INTERACTION", () => {
 					done();
 				});
 			});
+
+			it("set options zoom.enabled=true", () => {
+				args.zoom = {enabled: true};
+			});
+
+			it("showed each data points tooltip?", done => {
+				chart.tooltip.show({x:1});
+
+				chart.$.tooltip.selectAll(".value").each(function(d, i) {
+					expect(+this.innerHTML).to.be.equal(args.data.columns[i][2]);
+				});
+
+				util.simulator(chart.$.svg.node(), {
+					pos: [250,150],
+					deltaX: -200,
+					deltaY: 0,
+					duration: 500,
+				}, () => {
+					expect(selection).to.deep.equal([5, 4, 3, 2, 1, 0]);
+					done();
+				});
+			});
 		});
 	});
 

--- a/src/interactions/interaction.js
+++ b/src/interactions/interaction.js
@@ -158,19 +158,21 @@ extend(ChartInternal.prototype, {
 		$$.svg
 			.on("touchstart.eventRect touchmove.eventRect", function() {
 				const eventRect = getEventRect();
+				const event = d3Event;
 
 				if (!eventRect.empty() && eventRect.classed(CLASS.eventRect)) {
-					if ($$.dragging || $$.flowing || $$.hasArcType()) {
+					// if touch points are > 1, means doing zooming interaction. In this case do not execute tooltip codes.
+					if ($$.dragging || $$.flowing || $$.hasArcType() || event.touches.length > 1) {
 						return;
 					}
 
-					preventEvent(d3Event);
+					preventEvent(event);
 					selectRect(this);
 				} else {
 					$$.unselectRect();
 					$$.callOverOutForTouch();
 				}
-			})
+			}, true)
 			.on("touchend.eventRect", () => {
 				const eventRect = getEventRect();
 
@@ -179,7 +181,7 @@ extend(ChartInternal.prototype, {
 						$$.cancelClick && ($$.cancelClick = false);
 					}
 				}
-			});
+			}, true);
 	},
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1056

## Details
<!-- Detailed description of the change/feature -->
- Make tooltip touch event binding to be 'capture', because d3-zoom stops event propagation.
- Fix on event rect element redraw for touch environment.