### PR TITLE
fix(axis): Correct on tick count display

### DIFF
--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -23,6 +23,11 @@ describe("AXIS", function() {
 			]
 		},
 		axis: {
+			x: {
+				tick: {
+					count: undefined
+				}
+			},
 			y: {
 				tick: {
 					values: null,
@@ -40,6 +45,25 @@ describe("AXIS", function() {
 
 	beforeEach(() => {
 		chart = util.generate(args);
+	});
+
+	describe("axis.x.tick.count", () => {
+		after(() => {
+			args.axis.x.type = "indexed";
+			args.axis.x.tick.count = undefined;
+		});
+
+		it("set options axis.x.tick.count=3", () => {
+			args.axis.x.type = "category";
+			args.axis.x.tick.count = 3;
+		});
+
+		it("should have only 3 tick on x axis", () => {
+			const ticks = chart.$.main.select(`.${CLASS.axisX}`).selectAll("g.tick");
+
+			expect(ticks.size()).to.be.equal(3);
+			expect(ticks.data()).to.be.deep.equal([0,3,5]);
+		});
 	});
 
 	describe("axis.y.tick.count", () => {

--- a/src/axis/Axis.js
+++ b/src/axis/Axis.js
@@ -605,6 +605,8 @@ export default class Axis {
 			} else if (targetCount === 2) {
 				tickValues = [values[0], values[values.length - 1]];
 			} else if (targetCount > 2) {
+				const isCategorized = this.owner.isCategorized();
+
 				count = targetCount - 2;
 				start = values[0];
 				end = values[values.length - 1];
@@ -615,7 +617,11 @@ export default class Axis {
 
 				for (i = 0; i < count; i++) {
 					tickValue = +start + interval * (i + 1);
-					tickValues.push(forTimeSeries ? new Date(tickValue) : tickValue);
+					tickValues.push(
+						forTimeSeries ? new Date(tickValue) : (
+							isCategorized ? Math.round(tickValue) : tickValue
+						)
+					);
 				}
 
 				tickValues.push(end);


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1077

## Details
<!-- Detailed description of the change/feature -->
Make the interval of tick value to be rounded for x Axis category type.

The interval value is determined based on below equation,

```js
// to exclude the first and the last tick
count = tickCount - 2;
interval = (end - start) / (count + 1);
```

ex)
### Given condition
- x Axis scale:  0 ~ 6.
  > [0, 1, 2, 3, 4, 5]

- Given tick count: 3

### Interval
```
(5 - 0) / (1 + 1) = 2.5
```
Resulting a float value, which for 'category' type axis will result to omit displaying ticks.
To fix, the interval should be an integer value for 'category' x Axis.