### PR TITLE
fix: don't redraw event rect twice

### DIFF
--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -679,7 +679,6 @@ export default class ChartInternal {
 
 		// event rects will redrawn when flow called
 		if (config.interaction_enabled && !flow && wth.EventRect) {
-			$$.redrawEventRect();
 			$$.bindZoomEvent();
 		}
 


### PR DESCRIPTION
## Issue
I was doing some performance profiling and noticed that `redrawEventRect` is called twice each redraw.

## Details
`redrawEventRect` is called before `bindZoomEvent`, but `bindZoomEvent` needs to redraw the rect each time it is called so also calls `redrawEventRect`. Removing the former call drastically speeds up drawing charts.

Related to #757