### PR TITLE
perf: speed up updateDataIndexByX

### DIFF
--- a/src/data/data.js
+++ b/src/data/data.js
@@ -840,20 +840,18 @@ extend(ChartInternal.prototype, {
 	updateDataIndexByX(tickValues) {
 		const $$ = this;
 
+		const tickValueMap = tickValues.reduce((out, tick) => {
+			out[Number(tick.x)] = tick.index;
+			return out;
+		}, {});
+
 		$$.data.targets.forEach(t => {
-			t.values.forEach((v, i) => {
-				tickValues.some((d, j) => {
-					if (+d.x === +v.x) {
-						v.index = j;
-						return true;
-					}
-
-					return false;
-				});
-
-				if (!isNumber(v.index) || v.index === -1) {
-					v.index = i;
+			t.values.forEach((value, valueIndex) => {
+				let index = tickValueMap[Number(value.x)];
+				if (index === undefined) {
+					index = valueIndex
 				}
+				value.index = index;
 			});
 		});
 	}

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -848,8 +848,9 @@ extend(ChartInternal.prototype, {
 		$$.data.targets.forEach(t => {
 			t.values.forEach((value, valueIndex) => {
 				let index = tickValueMap[Number(value.x)];
+
 				if (index === undefined) {
-					index = valueIndex
+					index = valueIndex;
 				}
 				value.index = index;
 			});

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -840,8 +840,8 @@ extend(ChartInternal.prototype, {
 	updateDataIndexByX(tickValues) {
 		const $$ = this;
 
-		const tickValueMap = tickValues.reduce((out, tick) => {
-			out[Number(tick.x)] = tick.index;
+		const tickValueMap = tickValues.reduce((out, tick, index) => {
+			out[Number(tick.x)] = index;
 			return out;
 		}, {});
 


### PR DESCRIPTION
## Issue
`updateDataIndexByX` was doing a lot of extra unnecessary churning.

## Details
Used a map instead of multiple nested loops to drastically increase speed (on my machine, nearly 100x faster).

### Code in `master`:
![updateDataIndexByX-pre](https://user-images.githubusercontent.com/931325/66962060-11df5b80-f03e-11e9-8cee-d24175cd0cce.png)

### This branch:
![updateDataIndexByX-post](https://user-images.githubusercontent.com/931325/66962084-24f22b80-f03e-11e9-88ae-3a9cf6444ff0.png)

Related to #757