### PR TITLE
perf: more efficient shape offset calculation

### DIFF
--- a/src/shape/bar.js
+++ b/src/shape/bar.js
@@ -177,7 +177,8 @@ extend(ChartInternal.prototype, {
 		const barW = $$.getBarW(axis, barTargetsNum);
 		const barX = $$.getShapeX(barW, barTargetsNum, barIndices, !!isSub);
 		const barY = $$.getShapeY(!!isSub);
-		const barOffset = $$.getShapeOffset($$.isBarType, barIndices, !!isSub);
+		const shapeOffsetData = $$.getShapeOffsetData($$.isBarType);
+		const barOffset = $$.getShapeOffset(shapeOffsetData, barIndices, !!isSub);
 		const yScale = isSub ? $$.getSubYScale : $$.getYScale;
 
 		return (d, i) => {

--- a/src/shape/line.js
+++ b/src/shape/line.js
@@ -208,7 +208,8 @@ extend(ChartInternal.prototype, {
 		const isSub = !!isSubValue;
 		const x = $$.getShapeX(0, lineTargetsNum, lineIndices, isSub);
 		const y = $$.getShapeY(isSub);
-		const lineOffset = $$.getShapeOffset($$.isLineType, lineIndices, isSub);
+		const shapeOffsetData = $$.getShapeOffsetData($$.isLineType);
+		const lineOffset = $$.getShapeOffset(shapeOffsetData, lineIndices, isSub);
 		const yScale = isSub ? $$.getSubYScale : $$.getYScale;
 
 		return (d, i) => {
@@ -499,7 +500,8 @@ extend(ChartInternal.prototype, {
 		const areaTargetsNum = areaIndices.__max__ + 1;
 		const x = $$.getShapeX(0, areaTargetsNum, areaIndices, !!isSub);
 		const y = $$.getShapeY(!!isSub);
-		const areaOffset = $$.getShapeOffset($$.isAreaType, areaIndices, !!isSub);
+		const shapeOffsetData = $$.getShapeOffsetData($$.isAreaType);
+		const areaOffset = $$.getShapeOffset(shapeOffsetData, areaIndices, !!isSub);
 		const yScale = isSub ? $$.getSubYScale : $$.getYScale;
 
 		return function(d, i) {
@@ -586,12 +588,13 @@ extend(ChartInternal.prototype, {
 
 	updateCircleY() {
 		const $$ = this;
+		const getPoints = $$.generateGetLinePoints($$.getShapeIndices($$.isLineType), false);
 
 		$$.circleY = (d, i) => {
 			const id = d.id;
 
 			return $$.isGrouped(id) ?
-				$$.generateGetLinePoints($$.getShapeIndices($$.isLineType))(d, i)[0][1] :
+				getPoints(d, i)[0][1] :
 				$$.getYScale(id)($$.getBaseValue(d));
 		};
 	},

--- a/src/shape/shape.js
+++ b/src/shape/shape.js
@@ -113,44 +113,85 @@ extend(ChartInternal.prototype, {
 		};
 	},
 
-	getShapeOffset(typeFilter, indices, isSub) {
+	/**
+	 * @typedef {object} ShapeOffsetTarget
+	 * @property {string} id - target id
+	 * @property {object[]} rowValues - data point for each row (scaled as necessary)
+	 * @property {object<number, object>} rowValueMapByXValue - each x value is a key,
+	 *   mapped to the rowValue for that x value
+   * @property {number[]} values - value for each rowValue (normalized as necessary)
+	 */
+
+	/**
+	 * @param {function(Object): boolean} typeFilter
+	 * @return {{shapeOffsetTargets: ShapeOffsetTarget[], indexMapByTargetId: object}}
+	 */
+	getShapeOffsetData(typeFilter) {
 		const $$ = this;
 		const targets = $$.orderTargets($$.filterTargetsToShow($$.data.targets.filter(typeFilter, $$)));
-		const targetIds = targets.map(t => t.id);
+		const shapeOffsetTargets = targets.map(target => {
+			let rowValues = target.values;
+
+			if ($$.isStepType(target)) {
+				rowValues = $$.convertValuesToStep(rowValues);
+			}
+			const rowValueMapByXValue = rowValues.reduce((out, value) => {
+				out[Number(value.x)] = value;
+				return out;
+			}, {});
+
+			let values;
+
+			if ($$.isStackNormalized()) {
+				values = rowValues.map(v => $$.getRatio("index", v, true));
+			} else {
+				values = rowValues.map(({value}) => value);
+			}
+
+			return {
+				id: target.id,
+				rowValues,
+				rowValueMapByXValue,
+				values,
+			};
+		});
+		const indexMapByTargetId = targets.reduce((out, {id}, index) => {
+			out[id] = index;
+			return out;
+		}, {});
+
+		return {indexMapByTargetId, shapeOffsetTargets};
+	},
+
+	getShapeOffset(shapeOffsetData, indices, isSub) {
+		const $$ = this;
+		const {shapeOffsetTargets, indexMapByTargetId} = shapeOffsetData;
 
 		return (d, idx) => {
 			const scale = isSub ? $$.getSubYScale(d.id) : $$.getYScale(d.id);
 			const y0 = scale(0);
+			const dataXAsNumber = Number(d.x);
 			let offset = y0;
-			let i = idx;
 
-			targets
+			shapeOffsetTargets
 				.forEach(t => {
-					const rowValues = $$.isStepType(d) ? $$.convertValuesToStep(t.values) : t.values;
-					const values = rowValues.map(v => ($$.isStackNormalized() ? $$.getRatio("index", v, true) : v.value));
+					const rowValues = t.rowValues;
+					const values = t.values;
 
 					if (t.id === d.id || indices[t.id] !== indices[d.id]) {
 						return;
 					}
 
-					if (targetIds.indexOf(t.id) < targetIds.indexOf(d.id)) {
+					if (indexMapByTargetId[t.id] < indexMapByTargetId[d.id]) {
+						let rowValue = rowValues[idx];
+
 						// check if the x values line up
-						if (isUndefined(rowValues[i]) || +rowValues[i].x !== +d.x) { // "+" for timeseries
-							// if not, try to find the value that does line up
-							i = -1;
-
-							rowValues.forEach((v, j) => {
-								const x1 = v.x.constructor === Date ? +v.x : v.x;
-								const x2 = d.x.constructor === Date ? +d.x : d.x;
-
-								if (x1 === x2) {
-									i = j;
-								}
-							});
+						if (!rowValue || Number(rowValue.x) !== dataXAsNumber) {
+							rowValue = t.rowValueMapByXValue[dataXAsNumber];
 						}
 
-						if (i in rowValues && rowValues[i].value * d.value >= 0) {
-							offset += scale(values[i]) - y0;
+						if (rowValue && rowValue.value * d.value >= 0) {
+							offset += scale(values[rowValue.index]) - y0;
 						}
 					}
 				});


### PR DESCRIPTION
## Issue
`getShapeOffset` drives the shape calculations for nearly every chart type. It also did a lot of unnecessary looping over data points. In stacked charts, this was especially obvious as it meant it was re-calculating the stacking many extra times.

## Details
The changes here move the data around smarter so that re-calculation doesn't occur, significantly increasing speed.

The biggest culprit is a function nested inside of `getShapeOffset` [here](https://github.com/naver/billboard.js/blob/d4c8eb1bee366098bd4867fe04c441a87af409b8/src/shape/shape.js#L127-L159) - for these profile sessions, I have named it `checkOffsetForTarget` for visibility.

### Original code (`master`):
![checkOffsetForTarget-pre](https://user-images.githubusercontent.com/931325/67240890-598c2b80-f420-11e9-884d-00941b00dc8a.png)

### This PR:
![checkOffsetForTarget-post](https://user-images.githubusercontent.com/931325/67240856-5002c380-f420-11e9-9676-9654f58bb960.png)

Related to #757