### PR TITLE
Optimize build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,7 +16,7 @@
         ]
     ],
     "plugins": [
-        "@babel/plugin-transform-runtime",
+        ["@babel/plugin-transform-runtime", { "useESModules": true }],
         "@babel/plugin-proposal-class-properties",
         "add-module-exports",
         "transform-inline-consecutive-adds",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,7 @@ const config = {
 		new Stylish(),
 		new WebpackBar()
 	],
+	node: false,
 	stats: "minimal",
 	mode: "none",
 	devServer: {


### PR DESCRIPTION
## Issue
Closes #1081 

## Details
The situation is actually already better than what I thought when opening the issue. The module concatenation plugin is already applied and most of the modules are concatenated already.
I got tricked by the fact that the dist file starts with a bunch of modules escaping the concatenation:

- babel helpers were not concatenated, because `@babel/plugin-transform-runtime` imports the CommonJS version of helpers by default (and concatenation is done only for ES modules). Fortunately, the plugin has an option to use the ESM version of helpers in imports instead, which allows webpack to optimize them.
- the usage of `global` in `src/internals/browser.js` was triggering the injection of the webpack polyfill for this node API, which is incompatible with concatenation. but the library does not need the webpack polyfills for node APIs (note that webpack 5 will make them opt-in rather than opt-out by making `false` the default).

After this change, the only non-concatenated modules remaining are the small wrappers created by webpack around external dependencies, the empty module generated by the SCSS file and the entrypoint module importing core.js (the big concatenated module) and the empty SCSS module. So going further would involve changing the way the SCSS file is processed (using a separate webpack entry probably)