### PR TITLE
fix(zoom): Correct Axis culling on zoom

### DIFF
--- a/spec/interactions/zoom-spec.js
+++ b/spec/interactions/zoom-spec.js
@@ -653,7 +653,7 @@ describe("ZOOM", function() {
 				rotated: true
 			},
 				zoom: {
-				rescale: true,
+					rescale: true,
 					enabled: {
 						type: "drag"
 					}
@@ -872,6 +872,46 @@ describe("ZOOM", function() {
 			chart.toggle();
 
 			checkDomain(chart.internal.zoomScale);
+		});
+	});
+
+	describe("zoom rescale culling", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 300, 350, 300, 0, 0, 0],
+						["data2", 130, 100, 140, 200, 150, 50]
+					],
+				},
+				axis: {
+					y: {
+						tick: {
+							culling: {
+								max: 3
+							}
+						}
+					}
+				},
+				zoom: {
+					rescale: true,
+					enabled: true
+				}
+			};
+		});
+
+		it("check y Axis culling after zoom", () => {
+			chart.zoom([4,5]);
+
+			const tickTexts = chart.$.main.selectAll(`.${CLASS.axisY} .tick text`)
+				.filter(function() { return this.style.display === "block"});
+
+			tickTexts.each(function() {
+				console.log(this);
+			})
+
+
+			expect(tickTexts.size()).to.be.equal(args.axis.y.tick.culling.max);
 		});
 	});
 });

--- a/src/axis/Axis.js
+++ b/src/axis/Axis.js
@@ -737,7 +737,7 @@ export default class Axis {
 		this.updateLabels(wth.Transition);
 
 		// show/hide if manual culling needed
-		if ((wth.UpdateXDomain || wth.UpdateXAxis) && targetsToShow.length) {
+		if ((wth.UpdateXDomain || wth.UpdateXAxis || wth.Y) && targetsToShow.length) {
 			this.setCulling();
 		}
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1106

## Details
<!-- Detailed description of the change/feature -->
Make to call .setCulling() when y Axis zoom.rescale is set.
