### PR TITLE
fix(tooltip): Remove 'pointer-events:none' inline set

### DIFF
--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -29,7 +29,6 @@ extend(ChartInternal.prototype, {
 				.append("div")
 				.attr("class", CLASS.tooltipContainer)
 				.style("position", "absolute")
-				.style("pointer-events", "none")
 				.style("display", "none");
 		}
 

--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -161,6 +161,7 @@
 /*-- Tooltip --*/
 .bb-tooltip-container {
   z-index: 10;
+	user-select: none;
 }
 
 .bb-tooltip {

--- a/src/scss/theme/graph.scss
+++ b/src/scss/theme/graph.scss
@@ -191,7 +191,7 @@ rect.bb-circle, use.bb-circle {
 .bb-tooltip-container {
     z-index: 10;
     font-family: $font-family;
-    position: absolute;
+	user-select: none;
 }
 
 .bb-tooltip {

--- a/src/scss/theme/insight.scss
+++ b/src/scss/theme/insight.scss
@@ -183,7 +183,7 @@ rect.bb-circle, use.bb-circle {
 .bb-tooltip-container {
     z-index: 10;
     font-family: $font-family;
-    position: absolute;
+	user-select: none;
 }
 
 .bb-tooltip {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1124

## Details
<!-- Detailed description of the change/feature -->
- Remove setting 'pointer-events:none' which makes not to respond on click event.
- Add 'user-select:none' prop on default css file for tooltip element.