### PR TITLE
fix(options): Correct background element's position

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3103,6 +3103,11 @@ d3.select(".chart_area")
 					},
 					background: {
 						color: "lightcyan"
+					},
+					grid: {
+						y: {
+							show: true
+						}
 					}
 				}
 			},

--- a/spec/internals/bb-spec.js
+++ b/spec/internals/bb-spec.js
@@ -440,12 +440,23 @@ describe("Interface & initialization", () => {
 
 			const element = chart.$.main.select(".myBgClass");
 
+			expect(element.node().parentNode.getAttribute("class")).to.be.equal(CLASS.regions);
 			expect(element.empty()).to.be.false;
 			expect(element.attr("href")).to.be.equal(args.background.imgUrl);
 			expect(element.node().tagName).to.be.equal("image");
 		});
 
+		it("check for pie's image background", () => {
+			args.data.type = "pie";
+			chart = util.generate(args);
+
+			const element = chart.$.main.select(".myBgClass");
+
+			expect(element.node().parentNode.getAttribute("class")).to.be.equal(CLASS.chart);
+		});
+
 		it("set option background.color=red", () => {
+			args.data.type = "line";
 			args.background.color = "red";
 			delete args.background.imgUrl;
 		});
@@ -455,9 +466,19 @@ describe("Interface & initialization", () => {
 
 			const element = chart.$.main.select(".myBgClass");
 
+			expect(element.node().parentNode.getAttribute("class")).to.be.equal(CLASS.regions);
 			expect(element.empty()).to.be.false;
 			expect(element.style("fill")).to.be.equal(args.background.color);
 			expect(element.node().tagName).to.be.equal("rect");
+		});
+
+		it("check for pie's rect background", () => {
+			args.data.type = "pie";
+			chart = util.generate(args);
+
+			const element = chart.$.main.select(".myBgClass");
+
+			expect(element.node().parentNode.getAttribute("class")).to.be.equal(CLASS.chart);
 		});
 	});
 });

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -421,20 +421,16 @@ export default class ChartInternal {
 		const bg = $$.config.background;
 
 		if (notEmpty(bg)) {
-			const eventRect = $$.svg.select(`.${CLASS.eventRects}`);
-			let element;
+			const element = $$.svg.select(`.${CLASS[$$.hasArcType() ? "chart" : "regions"]}`)
+				.insert(bg.imgUrl ? "image" : "rect", ":first-child");
 
 			if (bg.imgUrl) {
-				element = eventRect
-					.insert("image")
-					.attr("href", bg.imgUrl);
-			} else {
-				element = eventRect
-					.insert("rect")
-					.style("fill", bg.color || null);
+				element.attr("href", bg.imgUrl);
+			} else if (bg.color) {
+				element.style("fill", bg.color);
 			}
 
-			element && element
+			element
 				.attr("class", bg.class || null)
 				.attr("width", "100%")
 				.attr("height", "100%");


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1132

## Details
<!-- Detailed description of the change/feature -->
- Fix the implementation of background option, making background element
to be positioned under the grid, region elements.
- Also make to work for arc types.