### PR TITLE
feat(bubble): expand bubble chart feature with plugin

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2528,6 +2528,43 @@ d3.select(".chart_area")
 					}
 				}]
 			}
+		},
+	 BubbleCompare: {
+						description: 'bubble chart expansion',
+						options: {
+										data: {
+														"type": "bubble",
+														"xs": {
+																		"United States": "x0",
+																		"Korea": "x1",
+																		"France": "x2",
+																		"Japan": "x3",
+																		"Andorra": "x4"
+														},
+														// value x: population density
+														// value y: Area
+														// value z: population
+														"columns": [
+																		["x0", 30],
+																		["x1", 515],
+																		["x2", 319],
+																		["x3", 337],
+																		["x4", 164],
+																		["United States", {"y": 9631418, "z": 295734134}],
+																		["Korea", {"y": 100210, "z": 51635256}],
+																		["France", {"y": 547030, "z": 67022000}],
+																		["Japan", {"y": 377835, "z": 127417244}],
+																		["Andorra", {"y": 464, "z": 76177}],
+														]
+										},
+										axis: {
+														x: {padding: {left: 100, right: 20}},
+														y: {padding: {top: 150, bottom: 100}},
+										},
+										_plugins: [{
+														bubblecompare: {minR: 11, maxR: 74, expandScale: 1.1}
+										}]
+						}
 		}
 	},
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2530,16 +2530,16 @@ d3.select(".chart_area")
 			}
 		},
 	 BubbleCompare: {
-						description: 'bubble chart expansion',
+						description: 'compare data 3-dimensional ways, x-axis, y-axis, bubble-size',
 						options: {
 										data: {
 														"type": "bubble",
 														"xs": {
-																		"United States": "x0",
-																		"Korea": "x1",
-																		"France": "x2",
-																		"Japan": "x3",
-																		"Andorra": "x4"
+																		"Country-A": "x0",
+																		"Country-B": "x1",
+																		"Country-C": "x2",
+																		"Country-D": "x3",
+																		"Country-E": "x4"
 														},
 														// value x: population density
 														// value y: Area
@@ -2550,11 +2550,11 @@ d3.select(".chart_area")
 																		["x2", 319],
 																		["x3", 337],
 																		["x4", 164],
-																		["United States", {"y": 9631418, "z": 295734134}],
-																		["Korea", {"y": 100210, "z": 51635256}],
-																		["France", {"y": 547030, "z": 67022000}],
-																		["Japan", {"y": 377835, "z": 127417244}],
-																		["Andorra", {"y": 464, "z": 76177}],
+																		["Country-A", {"y": 9631418, "z": 295734134}],
+																		["Country-B", {"y": 100210, "z": 51635256}],
+																		["Country-C", {"y": 547030, "z": 67022000}],
+																		["Country-D", {"y": 377835, "z": 127417244}],
+																		["Country-E", {"y": 464, "z": 76177}],
 														]
 										},
 										axis: {

--- a/demo/index.html
+++ b/demo/index.html
@@ -173,6 +173,9 @@ fallback.ready(function(e) {
         }),
         plugins_textoverlap: path.map(function(p) {
             return p + "plugin/billboardjs-plugin-textoverlap.js"
+        }),
+        plugins_bubblecompare: path.map(function(p) {
+            return p + "plugin/billboardjs-plugin-bubblecompare.js"
         })
     });
 

--- a/spec/plugin/bubble-compare/bubble-compare-spec.js
+++ b/spec/plugin/bubble-compare/bubble-compare-spec.js
@@ -1,0 +1,50 @@
+/* eslint-disable */
+import {select as d3Select} from "d3-selection";
+import BubbleCompare from "../../../src/plugin/bubblecompare";
+import util from "../../assets/util";
+
+describe("PLUGIN: BUBBLE-COMPARE", () => {
+	let chart;
+	const args = {
+		data: {
+			"type": "bubble",
+			"xs": {
+				"United States": "x0",
+				"Korea": "x1",
+				"France": "x2",
+				"Japan": "x3",
+				"Andorra": "x4"
+			},
+			// value x: population density
+			// value y: Area
+			// value z: population
+			"columns": [
+				["x0", 30],
+				["x1", 515],
+				["x2", 319],
+				["x3", 337],
+				["x4", 164],
+				["United States", {"y": 9631418, "z": 295734134}],
+				["Korea", {"y": 100210, "z": 51635256}],
+				["France", {"y": 547030, "z": 67022000}],
+				["Japan", {"y": 377835, "z": 127417244}],
+				["Andorra", {"y": 464, "z": 76177}],
+			]
+		},
+		plugins: [new BubbleCompare({minR: 11, maxR: 74, expandScale: 1.1})]
+	};
+
+	beforeEach(() => {
+		chart = util.generate(args);
+	});
+
+	it("Every bubble radius should be in given radius range", () => {
+		chart.$.main.selectAll("circle").each(function() {
+			const circle = d3Select(this);
+			const {minR, maxR} = chart.plugins[0].options;
+			const circleRadius = parseInt(circle.attr("r"), 10);
+
+			expect(circleRadius).to.be.within(minR, maxR);
+		});
+	});
+});

--- a/src/plugin/bubblecompare/Options.js
+++ b/src/plugin/bubblecompare/Options.js
@@ -1,0 +1,50 @@
+/**
+	* Copyright (c) 2017 ~ present NAVER Corp.
+	* billboard.js project is licensed under the MIT license
+	*/
+/**
+	* Bubble compare plugin option class
+	* @class BubblecompareOptions
+	* @param {Options} options Bubblecompare plugin options
+	* @extends Plugin
+	* @return {BubblecompareOptions}
+	* @private
+	*/
+export default class Options {
+	constructor() {
+		return {
+			/**
+													* Set minimum size of bubble radius. (px)
+													* @name minR
+													* @memberof plugin-bubblecompare
+													* @type {number}
+													* @default 11
+													* @example
+													*   minR: 11
+													*/
+			minR: 11,
+
+			/**
+													* Set maximum size of bubble radius. (px)
+													* @name maxR
+													* @memberof plugin-bubblecompare
+													* @type {number}
+													* @default 11
+													* @example
+													*   maxR: 74
+													*/
+			maxR: 11,
+
+			/**
+													* Specify bubble expand ratio when focused
+													* @name expandScale
+													* @memberof plugin-bubblecompare
+													* @type {number}
+													* @default 1
+													* @example
+													*   expandScale: 1.2
+													*/
+			expandScale: 1
+		};
+	}
+}

--- a/src/plugin/bubblecompare/index.js
+++ b/src/plugin/bubblecompare/index.js
@@ -1,6 +1,31 @@
 import {select} from "d3-selection";
 import Plugin from "../Plugin";
 
+/**
+	* Bubble compare diagram plugin
+	* - **NOTE:**
+	*   - Plugins aren't built-in. Need to be loaded or imported to be used.
+	* @class plugin-bubblecompare
+	* @param {Object} options bubble compare plugin options
+	* @extends Plugin
+	* @return {BubbleCompare}
+	* @example
+	*  var chart = bb.generate({
+	*     data: {
+	*        columns: [ ... ],
+	*        type: "bubble"
+	*     }
+	*     ...
+	*     plugins: [
+	*        new bb.plugin.bubblecompare({
+	*          minR: 11,
+	*          maxR: 74,
+	*          expandScale: 1.1
+	*        }),
+	*     ]
+	*  });
+	*/
+
 export default class BubbleCompare extends Plugin {
 				static version = `0.0.1`;
 
@@ -20,12 +45,12 @@ export default class BubbleCompare extends Plugin {
 
 				pointExpandedR(d) {
 					const baseR = this.getBubbleR(d);
-					const {expandScale} = this.options;
+					const {expandScale = 1} = this.options;
 
 					BubbleCompare.raiseFocusedBubbleLayer(d);
 					this.changeCursorPoint();
 
-					return baseR * (expandScale || 1);
+					return baseR * expandScale;
 				}
 
 				static raiseFocusedBubbleLayer(d) {

--- a/types/plugin/bubblecompare/index.d.ts
+++ b/types/plugin/bubblecompare/index.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+import { Plugin } from "../plugin";
+import { BubblecompareOptions } from "./options";
+
+export default class Stanford extends Plugin {
+    /**
+     * Generate stanford diagram
+     */
+    constructor(options: BubblecompareOptions);
+}

--- a/types/plugin/bubblecompare/options.d.ts
+++ b/types/plugin/bubblecompare/options.d.ts
@@ -1,0 +1,14 @@
+export interface BubblecompareOptions {
+    /**
+     * Minimum bubble radius (px, default: 11)
+     */
+    minR?: number;
+    /**
+     * Maximum bubble radius (px, default: 11)
+     */
+    maxR?: number;
+    /**
+     * expand ratio when bubble focused (default: 1)
+     */
+    expandScale?: number;
+}


### PR DESCRIPTION
- set bubble min/max radius, focus expand scale
- implement new feature with plugin

## Issue
none

## Details
improve bubble chart feature
- specify min / max radius
- focus bubble when mouse over
- override internal functions using plugin hook.
- added demo page & test code
