### PR TITLE
docs(types): Add missing params for flush method

### DIFF
--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -463,8 +463,10 @@ export interface Chart {
 
 	/**
 	 * Force to redraw.
+	 * @param soft For soft redraw.
+	 * @param isFromResize For soft redraw.
 	 */
-	flush(): void;
+	flush(soft?: boolean, isFromResize?: boolean): void;
 
 	/**
 	 * Reset the chart object and remove element and events completely.


### PR DESCRIPTION
## Issue

## Details
Just updated the type definition for the flush() method