### PR TITLE
feat(grid): Intent to ship grid.focus.y

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2069,6 +2069,60 @@ var demos = {
 	},
 
 	Grid: {
+		FocusedGridLines: [
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 300, 350, 300, 120, 220, 250],
+							["data2", 130, 100, 140, 200, 150, 50]
+						],
+						axes: {
+							data1: "y",
+							data2: "y2"
+						}
+					},
+					axis: {
+						y2: {
+							show: true
+						}
+					},
+					tooltip: {
+						grouped: false
+					},
+					grid: {
+						focus: {
+							show: true,
+							y: true,
+							edge: true
+						}
+					}
+				},
+				style: [
+					"#focusedGridLines_1 line.bb-xgrid-focus, #focusedGridLines_1 line.bb-ygrid-focus { stroke: blue; stroke-dasharray: 2 2; }"
+				]
+			},
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 300, 350, 300, 120, 220, 250],
+							["data2", 130, 100, 140, 200, 150, 50]
+						],
+						type: "scatter"
+					},
+					tooltip: {
+						grouped: false
+					},
+					grid: {
+						focus: {
+							show: true,
+							y: true
+						}
+					}
+				}
+			}
+		],
 		GridLines: {
 			options: {
 				data: {

--- a/demo/simple-sidebar.css
+++ b/demo/simple-sidebar.css
@@ -371,3 +371,5 @@ div.row {
 /* Background */
 .myBgClass { transform: scale(0.9) translate(15px, -10px); opacity: 0.1; }
 
+/* FocusedGridLines */
+#focusedGridLines_1 line.bb-xgrid-focus, #focusedGridLines_1 line.bb-ygrid-focus { stroke: blue; stroke-dasharray: 2 2; }

--- a/spec/internals/grid-spec.js
+++ b/spec/internals/grid-spec.js
@@ -492,4 +492,158 @@ describe("GRID", function() {
 			});
 		});
 	});
+
+	describe("Focus grid lines", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 300, 350, 300, 0, 0, 0],
+						["data2", 130, 100, 140, 200, 150, 50]
+					],
+					type: "area",
+					axes: {
+						data1: "y",
+						data2: "y2"
+					}
+				},
+				axis: {
+					y2: {
+						show: true
+					}
+				},
+				tooltip: {
+					grouped: false
+				},
+				grid: {
+					focus: {
+						show: true,
+						y: true,
+						edge: true
+					}
+				}
+			};
+		});
+
+		const checkFocusGridPosition = expectedPositions => {
+			chart.$.grid.selectAll("line").each(function(d, i) {
+				["x1", "y1", "x2", "y2"].forEach(v => {
+					expect(+this.getAttribute(v)).to.be.equal(expectedPositions[i][v]);
+				});
+			});
+		}
+
+		it("check for y Axis based edge focus grid line", () => {
+			// to show y Axis based focus grid line
+			chart.tooltip.show({
+				data: { index: 2, value: 300 }
+			});
+
+			checkFocusGridPosition([
+				{ x1: 226, y1: 95, x2: 226, y2: 426 }, // xgrid-focus
+				{ x1: 0, y1: 95, x2: 226, y2: 95 }, // ygrid-focus
+			]);
+		});
+
+		it("check for y2 Axis based edge focus grid line", () => {
+			// to show y2 Axis based focus grid line
+			chart.tooltip.show({
+				data: { index: 2, id: "data2", value: 140 }
+			});
+
+			checkFocusGridPosition([
+				{ x1: 226, y1: 156, x2: 226, y2: 426 }, // xgrid-focus
+				{ x1: 226, y1: 156, x2: 560, y2: 156 }, // ygrid-focus
+			]);
+		});
+
+		it("set options args.grid.focus.edge=false", () => {
+			args.grid.focus.edge = false;
+		});
+
+		it("check for y Axis based non-edge focus grid line", () => {
+			// to show y Axis based focus grid line
+			chart.tooltip.show({
+				data: { index: 2, value: 300 }
+			});
+
+			checkFocusGridPosition([
+				{ x1: 226, y1: 0, x2: 226, y2: 426 }, // xgrid-focus
+				{ x1: 0, y1: 95, x2: 560, y2: 95 }, // ygrid-focus
+			]);
+		});
+
+		it("check for y2 Axis based non-edge focus grid line", () => {
+			// to show y2 Axis based focus grid line
+			chart.tooltip.show({
+				data: { index: 2, id: "data2", value: 140 }
+			});
+
+			checkFocusGridPosition([
+				{ x1: 226, y1: 0, x2: 226, y2: 426 }, // xgrid-focus
+				{ x1: 0, y1: 156, x2: 560, y2: 156 }, // ygrid-focus
+			]);
+		});
+
+		it("set options axis.rotated=true", () => {
+			args.axis.rotated = true;
+			args.grid.focus.edge = true;
+		});
+
+		it("check for y Axis based edge focus grid line", () => {
+			// to show y Axis based focus grid line
+			chart.tooltip.show({
+				x: 2,
+				mouse: [375.5, 39.5]
+			});
+
+			checkFocusGridPosition([
+				{ x1: 0, y1: 162, x2: 376, y2: 162 }, // xgrid-focus
+				{ x1: 376, y1: 0, x2: 376, y2: 162 }, // ygrid-focus
+			]);
+		});
+
+		it("check for y2 Axis based edge focus grid line", () => {
+			// to show y2 Axis based focus grid line
+			chart.tooltip.show({
+				x: 2,
+				mouse: [459.5, 38.5]
+			});
+
+			checkFocusGridPosition([
+				{ x1: 0, y1: 162, x2: 460, y2: 162 }, // xgrid-focus
+				{ x1: 460, y1: 162, x2: 460, y2: 400 }, // ygrid-focus
+			]);
+		});
+
+		it("set options args.grid.focus.edge=false", () => {
+			args.grid.focus.edge = false;
+		});
+
+		it("check for y Axis based non-edge focus grid line", () => {
+			// to show y Axis based focus grid line
+			chart.tooltip.show({
+				x: 2,
+				mouse: [375.5, 39.5]
+			});
+
+			checkFocusGridPosition([
+				{ x1: 0, y1: 162, x2: 590, y2: 162 }, // xgrid-focus
+				{ x1: 376, y1: 0, x2: 376, y2: 400 }, // ygrid-focus
+			]);
+		});
+
+		it("check for y2 Axis based non-edge focus grid line", () => {
+			// to show y2 Axis based focus grid line
+			chart.tooltip.show({
+				x: 2,
+				mouse: [459.5, 38.5]
+			});
+
+			checkFocusGridPosition([
+				{ x1: 0, y1: 162, x2: 590, y2: 162 }, // xgrid-focus
+				{ x1: 460, y1: 0, x2: 460, y2: 400 }, // ygrid-focus
+			]);
+		});
+	});
 });

--- a/src/api/api.flow.js
+++ b/src/api/api.flow.js
@@ -294,7 +294,7 @@ extend(ChartInternal.prototype, {
 			scaleX = (diffDomain(orgDomain) / diffDomain(domain));
 			const transform = `translate(${translateX},0) scale(${scaleX},1)`;
 
-			$$.hideXGridFocus();
+			$$.hideGridFocus();
 
 			const gt = d3Transition().ease(d3EaseLinear)
 				.duration(durationForFlow);

--- a/src/api/api.tooltip.js
+++ b/src/api/api.tooltip.js
@@ -21,8 +21,8 @@ const tooltip = extend(() => {}, {
 	 *    | --- | --- | --- |
 	 *    | index | Number | Determine focus by index |
 	 *    | x | Number &vert; Date | Determine focus by x Axis index |
-	 *    | mouse | Array | Determine x and y coordinate value relative the targeted x Axis element.<br>It should be used along with `data`, `index` or `x` value. The default value is set as `[0,0]` |
-	 *    | data | Object | When [data.xs](Options.html#.data%25E2%2580%25A4xs) option is used or [tooltip.grouped](Options.html#.tooltip) set to 'false', `should be used giving this param`.<br><br>**Key:**<br>- x {Number &verbar; Date}: x Axis value<br>- index {Number}: x Axis index (useless for data.xs)<br>- id {String}: Axis id. 'y' or 'y2'(default 'y')<br>- value {Number}: The corresponding value for tooltip. |
+	 *    | mouse | Array | Determine x and y coordinate value relative the targeted '.bb-event-rect' x Axis.<br>It should be used along with `data`, `index` or `x` value. The default value is set as `[0,0]` |
+	 *    | data | Object | When [data.xs](Options.html#.data%25E2%2580%25A4xs) option is used or [tooltip.grouped](Options.html#.tooltip) set to 'false', `should be used giving this param`.<br><br>**Key:**<br>- x {Number &verbar; Date}: x Axis value<br>- index {Number}: x Axis index (useless for data.xs)<br>- id {String}: data id<br>- value {Number}: The corresponding value for tooltip. |
 	 *
 	 * @example
 	 *  // show the 2nd x Axis coordinate tooltip
@@ -30,9 +30,9 @@ const tooltip = extend(() => {}, {
 	 *    index: 1
 	 *  });
 	 *
-	 *  // show tooltip for the 3rd x Axis in x:50 and y:100 coordinate relative the x Axis element.
+	 *  // show tooltip for the 3rd x Axis in x:50 and y:100 coordinate of '.bb-event-rect' of the x Axis.
 	 *  chart.tooltip.show({
-	 *    data: {x: 2},
+	 *    x: 2,
 	 *    mouse: [50, 100]
 	 *  });
 	 *
@@ -45,7 +45,7 @@ const tooltip = extend(() => {}, {
 	 *  chart.tooltip.show({
 	 *    data: {
 	 *        x: 3,  // x Axis value
-	 *        id: "y",  // axis id. 'y' or 'y2' (default 'y')
+	 *        id: "data1",  // data id
 	 *        value: 500  // data value
 	 *    }
 	 *  });
@@ -54,7 +54,7 @@ const tooltip = extend(() => {}, {
 	 *  chart.tooltip.show({
 	 *    data: {
 	 *        index: 3,  // or 'x' key value
-	 *        id: "y",  // axis id. 'y' or 'y2' (default 'y')
+	 *        id: "data1",  // data id
 	 *        value: 500  // data value
 	 *    }
 	 *  });
@@ -107,7 +107,7 @@ const tooltip = extend(() => {}, {
 		const $$ = this.internal;
 
 		$$.hideTooltip(true);
-		$$.hideXGridFocus();
+		$$.hideGridFocus();
 		$$.unexpandCircles();
 		$$.unexpandBars();
 	}

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -2858,7 +2858,9 @@ export default class Options {
 			 * @property {Array} [y.lines=[]] Show additional grid lines along y axis.<br>
 			 *  This option accepts array including object that has value, text, position and class.
 			 * @property {Number} [y.ticks=10] Number of y grids to be shown.
-			 * @property {Boolean} [focus.show=true] Show grids when focus.
+			 * @property {Boolean} [focus.edge=false] Show edged focus grid line.<br>**NOTE:** Available when [`tooltip.grouped=false`](#.tooltip) option is set.
+			 * @property {Boolean} [focus.show=true] Show grid line when focus.
+			 * @property {Boolean} [focus.y=false] Show y coordinate focus grid line.<br>**NOTE:** Available when [`tooltip.grouped=false`](#.tooltip) option is set.
 			 * @property {Boolean} [lines.front=true] Set grid lines to be positioned over chart elements.
 			 * @default undefined
 			 * @see [Demo](https://naver.github.io/billboard.js/demo/#Grid.GridLines)
@@ -2885,7 +2887,11 @@ export default class Options {
 			 *   },
 			 *   front: true,
 			 *   focus: {
-			 *      show: false
+			 *      show: false,
+			 *
+			 *      // Below options are available when 'tooltip.grouped=false' option is set
+			 *      edge: true,
+			 *      y: true
 			 *   },
 			 *   lines: {
 			 *      front: false
@@ -2898,7 +2904,9 @@ export default class Options {
 			grid_y_show: false,
 			grid_y_lines: [],
 			grid_y_ticks: 10,
+			grid_focus_edge: false,
 			grid_focus_show: true,
+			grid_focus_y: false,
 			grid_front: false,
 			grid_lines_front: true,
 
@@ -2917,21 +2925,21 @@ export default class Options {
 			 * @property {Number} [point.select.r=point.r*4] The radius size of each point on selected.
 			 * @property {String} [point.type="circle"] The type of point to be drawn
 			 * - **NOTE:**
-			 *  - If chart has 'bubble' type, only circle can be used.
-			 *  - For IE, non circle point expansions are not supported due to lack of transform support.
+			 *   - If chart has 'bubble' type, only circle can be used.
+			 *   - For IE, non circle point expansions are not supported due to lack of transform support.
 			 * - **Available Values:**
-			 *  - circle
-			 *  - rectangle
+			 *   - circle
+			 *   - rectangle
 			 * @property {Array} [point.pattern=[]] The type of point or svg shape as string, to be drawn for each line
 			 * - **NOTE:**
-			 *  - This is an `experimental` feature and can have some unexpected behaviors.
-			 *  - If chart has 'bubble' type, only circle can be used.
-			 *  - For IE, non circle point expansions are not supported due to lack of transform support.
+			 *   - This is an `experimental` feature and can have some unexpected behaviors.
+			 *   - If chart has 'bubble' type, only circle can be used.
+			 *   - For IE, non circle point expansions are not supported due to lack of transform support.
 			 * - **Available Values:**
-			 *  - circle
-			 *  - rectangle
-			 *  - svg shape tag interpreted as string<br>
-			 *    (ex. `<polygon points='2.5 0 0 5 5 5'></polygon>`)
+			 *   - circle
+			 *   - rectangle
+			 *   - svg shape tag interpreted as string<br>
+			 *     (ex. `<polygon points='2.5 0 0 5 5 5'></polygon>`)
 			 * @see [Demo: point type](https://naver.github.io/billboard.js/demo/#Point.RectanglePoints)
 			 * @example
 			 *  point: {

--- a/src/config/classes.js
+++ b/src/config/classes.js
@@ -90,6 +90,7 @@ export default {
 	xgridLines: "bb-xgrid-lines",
 	xgrids: "bb-xgrids",
 	ygrid: "bb-ygrid",
+	ygridFocus: "bb-ygrid-focus",
 	ygridLine: "bb-ygrid-line",
 	ygridLines: "bb-ygrid-lines",
 	ygrids: "bb-ygrids",

--- a/src/interactions/interaction.js
+++ b/src/interactions/interaction.js
@@ -282,7 +282,7 @@ extend(ChartInternal.prototype, {
 
 		if (isTooltipGrouped) {
 			$$.showTooltip(selectedData, context);
-			$$.showXGridFocus(selectedData);
+			$$.showGridFocus(selectedData);
 
 			if (!isSelectionEnabled || isSelectionGrouped) {
 				return;
@@ -298,7 +298,7 @@ extend(ChartInternal.prototype, {
 				}
 
 				if (!isTooltipGrouped) {
-					$$.hideXGridFocus();
+					$$.hideGridFocus();
 					$$.hideTooltip();
 
 					!isSelectionGrouped && $$.expandCirclesBars(index);
@@ -316,7 +316,7 @@ extend(ChartInternal.prototype, {
 
 				if (!isTooltipGrouped) {
 					$$.showTooltip(d, context);
-					$$.showXGridFocus(d);
+					$$.showGridFocus(d);
 
 					$$.unexpandCircles();
 					selected.each(d => $$.expandCirclesBars(index, d.id));
@@ -370,7 +370,7 @@ extend(ChartInternal.prototype, {
 		$$.expandCirclesBars(closest.index, closest.id, true);
 
 		// Show xgrid focus line
-		$$.showXGridFocus(selectedData);
+		$$.showGridFocus(selectedData);
 
 		// Show cursor as pointer if point is close to mouse position
 		if ($$.isBarType(closest.id) || $$.dist(closest, mouse) < config.point_sensitivity) {
@@ -391,7 +391,7 @@ extend(ChartInternal.prototype, {
 		const $$ = this;
 
 		$$.svg.select(`.${CLASS.eventRect}`).style("cursor", null);
-		$$.hideXGridFocus();
+		$$.hideGridFocus();
 		$$.hideTooltip();
 		$$._handleLinkedCharts(false);
 		$$.unexpandCircles();
@@ -658,7 +658,9 @@ extend(ChartInternal.prototype, {
 		const selector = `.${isMultipleX ? CLASS.eventRect : `${CLASS.eventRect}-${index}`}`;
 		const eventRect = $$.main.select(selector).node();
 		const {width, left, top} = eventRect.getBoundingClientRect();
-		const x = left + (mouse ? mouse[0] : 0) + (isMultipleX ? 0 : (width / 2));
+		const x = left + (mouse ? mouse[0] : 0) + (
+			isMultipleX || $$.config.axis_rotated ? 0 : (width / 2)
+		);
 		const y = top + (mouse ? mouse[1] : 0);
 		const params = {
 			screenX: x,

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -436,10 +436,9 @@ export default class ChartInternal {
 		if (type === "grid") {
 			el.each(function() {
 				const g = d3Select(this);
-				const [x1, x2, y1, y2] = ["x1", "x2", "y1", "y2"]
-					.map(v => Math.ceil(g.attr(v)));
 
-				g.attr({x1, x2, y1, y2});
+				["x1", "x2", "y1", "y2"]
+					.forEach(v => g.attr(v, Math.ceil(g.attr(v))));
 			});
 		}
 	}
@@ -659,7 +658,7 @@ export default class ChartInternal {
 		$$.updateCircleY();
 
 		// xgrid focus
-		$$.updateXgridFocus();
+		$$.updategridFocus();
 
 		// Data empty label positioning and text.
 		config.data_empty_label_text && main.select(`text.${CLASS.text}.${CLASS.empty}`)

--- a/src/plugin/stanford/index.js
+++ b/src/plugin/stanford/index.js
@@ -88,7 +88,7 @@ export default class Stanford extends Plugin {
 		// override on config values & methods
 		$$.config.data_xSort = false;
 		$$.isMultipleX = () => true;
-		$$.showXGridFocus = () => {};
+		$$.showGridFocus = () => {};
 		$$.labelishData = d => d.values;
 		$$.opacityForCircle = () => 1;
 

--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -19,6 +19,7 @@
 
 .bb-legend-item-tile,
 .bb-xgrid-focus,
+.bb-ygrid-focus,
 .bb-ygrid,
 .bb-event-rect,
 .bb-bars path {
@@ -64,8 +65,6 @@
 .bb-xgrid, .bb-ygrid {
   stroke-dasharray: 3 3;
 }
-
-.bb-xgrid-focus {}
 
 /*-- Text on Chart --*/
 .bb-text {

--- a/src/scss/theme/graph.scss
+++ b/src/scss/theme/graph.scss
@@ -37,6 +37,7 @@ $axis-color: #8c8c8c;
 
 .bb-legend-item-title,
 .bb-xgrid-focus,
+.bb-ygrid-focus,
 .bb-ygrid,
 .bb-event-rect,
 .bb-bars path {
@@ -80,7 +81,7 @@ $axis-color: #8c8c8c;
     }
 }
 
-.bb-xgrid-focus line {
+.bb-xgrid-focus line, .bb-ygrid-focus line {
     stroke: #ffb6b6;
     stroke-dasharray: 3px;
 }

--- a/src/scss/theme/insight.scss
+++ b/src/scss/theme/insight.scss
@@ -32,6 +32,7 @@ $font-family: "Meiryo", sans-serif, Arial, "nanumgothic", "Dotum";
 
 .bb-legend-item-title,
 .bb-xgrid-focus,
+.bb-ygrid-focus,
 .bb-ygrid,
 .bb-event-rect,
 .bb-bars path {
@@ -75,7 +76,7 @@ $font-family: "Meiryo", sans-serif, Arial, "nanumgothic", "Dotum";
     }
 }
 
-.bb-xgrid-focus line {
+.bb-xgrid-focus line, .bb-ygrid-focus line {
     stroke: #ddd;
 }
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1100,9 +1100,21 @@ export interface Grid {
 
 	focus?: {
 		/**
+		 * Show edged focus grid line.
+		 * **NOTE:** Available when [`tooltip.grouped=false`](#.tooltip) option is set.
+		 */
+		edge?: boolean;
+
+		/**
 		 * Show grids when focus.
 		 */
 		show?: boolean;
+
+		/**
+		 * Show y coordinate focus grid line.
+		 * **NOTE:** Available when [`tooltip.grouped=false`](#.tooltip) option is set.
+		 */
+		y?: boolean;
 	};
 
 	lines?: {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1154

## Details
<!-- Detailed description of the change/feature -->
- Implementation of new grid.focus.x and edge option.
- Fix `.dispatchEvent()` x coordination value to be 0, when axis is rotated.

![grid-focus](https://user-images.githubusercontent.com/2178435/70701048-0b542400-1d0f-11ea-8a34-b67bb839ddb5.gif)

```js
bb.generate({
  data: {
    columns: [
		["data1", 300, 350, 300, 0, 0, 0],
		["data2", 130, 100, 140, 200, 150, 50]
    ],
	axes: {
		data1: "y",
		data2: "y2"
	}
  },
  axis: {
	  y2: {
		  show: true
	  }
  },
  tooltip: {
	  grouped: false
  },
  grid: {
	  focus: {
		  show: true,
		   y: true,
		   edge: true
	  }
  }
});
```