### PR TITLE
feat(gauge): add Multi-Arc-Gauge as gauge type 'multi'

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3666,7 +3666,70 @@ d3.select(".chart_area")
 					}
 				}
 			}
-		]
+		],
+		GaugeTypeMulti: {
+			options: {
+				data: {
+					columns: [
+						["data0", -100],
+						["data1", -50],
+						["data2", -25],
+						["data3", 0],
+						["data4", 25],
+						["data5", 50],
+						["data6", 100]
+					],
+					type: "gauge",
+					onclick: function(d, i) {
+						console.log("onclick", d, i);
+					},
+					onover: function(d, i) {
+						console.log("onover", d, i);
+					},
+					onout: function(d, i) {
+						console.log("onout", d, i);
+					}
+				},
+				gauge: {
+					type: "multi",
+					max: 100, // 100 is default
+					min: -100, // 0 is default, //can handle negative min e.g. vacuum / voltage / current flow / rate of change
+
+					//        label: {
+					//            format: function(value, ratio) {
+					//                return value;
+					//            },
+					//            show: false // to turn off the min/max labels.
+					//        },
+					//    units: ' %',
+					//    width: 39, // for adjusting arc thickness
+					arcs: {
+						minWidth: 5
+					},
+				},
+				color: {
+					pattern: ["#FF0000", "#FFA500", "#FFFF00", "#008000", "#0000FF", "#4B0082", "#EE82EE"],
+					threshold: {
+						values: [-50, -25, 0, 25, 50, 75, 100]
+					}
+				},
+				size: {
+					height: 300
+				}
+			},
+			func: function(chart) {
+				chart.timer = [
+					setTimeout(function() {
+						chart.load({
+							columns: [
+								["data7", -48],
+								["data8", 52],
+							]
+						});
+					}, 2000),
+				];
+			}
+		},
 	},
 	LineChartOptions: {
 		HidePoints: {

--- a/spec/internals/legend-spec.js
+++ b/spec/internals/legend-spec.js
@@ -476,4 +476,77 @@ describe("LEGEND", () => {
 			expect(nodes.size()).to.be.equal(chart.data().length);
 		});
 	});
+
+	describe('legend item tile coloring with color_treshold', () => {
+		before(function () {
+			args = {
+				data: {
+					columns: [
+						["padded1", 100],
+						["padded2", 90],
+						["padded3", 50],
+						["padded4", 20]
+					]
+				},
+				color: {
+					pattern: ["#FF0000", "#F97600", "#F6C600", "#60B044"],
+					threshold: {
+						values: [30, 80, 95]
+					}
+				},
+				type: "gauge",
+				gauge: {
+					type: "multi"
+				},
+			};
+		});
+
+		// espacially for gauges with multiple arcs to have the same coloring between legend tiles, tooltip tiles and arc
+		it('selects the color from color_pattern if color_treshold is given', function () {
+			const tileColor = [];
+
+			chart.internal.svg.selectAll(".bb-legend-item-tile").each(function () {
+				tileColor.push(d3Select(this).style('stroke'));
+			});
+
+			expect(tileColor[0]).to.be.equal('rgb(96, 176, 68)');
+			expect(tileColor[1]).to.be.equal('rgb(246, 198, 0)');
+			expect(tileColor[2]).to.be.equal('rgb(249, 118, 0)');
+			expect(tileColor[3]).to.be.equal('rgb(255, 0, 0)');
+		});
+	});
+
+	describe("legend item tile coloring without color_treshold", () => {
+		before(function() {
+			args = {
+				data: {
+					columns: [
+						["padded1", 100],
+						["padded2", 90],
+						["padded3", 50],
+						["padded4", 20]
+					],
+					colors: {
+						"padded1": "#60b044",
+						"padded4": "#8b008b"
+					}
+				}
+			};
+		});
+
+		it("selects the color from data_colors, data_color or default", function() {
+			const tileColor = [];
+
+			chart.internal.svg.selectAll(".bb-legend-item-tile")
+				.each(function() {
+					tileColor.push(d3Select(this)
+						.style("stroke"));
+				});
+
+			expect(tileColor[0]).to.be.equal("rgb(96, 176, 68)");
+			expect(tileColor[1]).to.be.equal("rgb(0, 199, 60)");
+			expect(tileColor[2]).to.be.equal("rgb(250, 113, 113)");
+			expect(tileColor[3]).to.be.equal("rgb(139, 0, 139)");
+		});
+	});
 });

--- a/spec/shape/shape.arc-spec.js
+++ b/spec/shape/shape.arc-spec.js
@@ -3,6 +3,8 @@
  * billboard.js project is licensed under the MIT license
  */
 /* eslint-disable */
+/* global describe, beforeEach, it, expect */
+import {select as d3Select} from "d3-selection";
 import {selectAll as d3SelectAll} from "d3-selection";
 import CLASS from "../../src/config/classes";
 import util from "../assets/util";
@@ -246,7 +248,7 @@ describe("SHAPE ARC", () => {
 
 			setTimeout(() => {
 				expect(data.attr("d"))
-					.to.match(/M-304,-3\..+A304,304,0,0,1,245\..+,-178\..+L237\..+,-172\..+A294,294,0,0,0,-294,-3\..+Z/);
+					.to.match(/M-258.*?,-3\..+A258.*?,258.*?,0,0,1,209.*?,-151.*?L200.*?,-146.*?A248.*?,248.*?,0,0,0,-248.*?,-3.*?Z/);
 
 				expect(chartArc.select(`.${CLASS.gaugeValue}`).attr("dy")).to.be.equal("-.1em");
 
@@ -278,7 +280,7 @@ describe("SHAPE ARC", () => {
 			setTimeout(() => {
 				// This test has bee updated to make tests pass. @TODO double-check this test is accurate.
 				expect(data.attr("d"))
-					.to.equal("M-211.85,-2.5944142439936676e-14A211.85,211.85,0,1,1,-65.46525025833259,201.4813229771283L-62.375080314583116,191.97075781417675A201.85,201.85,0,1,0,-201.85,-2.4719495640789325e-14Z");
+					.to.equal("M-180.07249999999996,-2.2052521073946173e-14A180.07249999999996,180.07249999999996,0,1,1,-55.645462719582696,171.259124530559L-52.55529277583322,161.74855936760747A170.07249999999996,170.07249999999996,0,1,0,-170.07249999999996,-2.0827874274798818e-14Z");
 
 				done();
 			}, 500);
@@ -371,7 +373,7 @@ describe("SHAPE ARC", () => {
 				expect(+chartArc.select(`.${CLASS.gaugeValue}`).attr("dy")).to.be.above(0);
 
 				// check background height
-				expect(chartArc.select(`.${CLASS.chartArcsBackground}`).node().getBBox().height).to.be.above(400);
+				expect(chartArc.select(`.${CLASS.chartArcsBackground}`).node().getBBox().height).to.be.above(300);
 
 				// with fullCircle option, only min text is showed
 				expect(min.empty()).to.be.false;
@@ -401,11 +403,11 @@ describe("SHAPE ARC", () => {
 			});
 
 			const expected = [
-				"M-304,-3.7229262694079536e-14A304,304,0,0,1,-275.25626419791655,-129.03483645824778L-165.15375851874995,-77.42090187494867A182.4,182.4,0,0,0,-182.4,-2.2337557616447722e-14Z",
-				"M-275.25626419791655,-129.03483645824778A304,304,0,0,1,98.15564305051961,-287.71769103991323L58.893385830311765,-172.63061462394796A182.4,182.4,0,0,0,-165.15375851874995,-77.42090187494867Z",
-				"M98.15564305051961,-287.71769103991323A304,304,0,0,1,226.41074355410964,-202.86491861156082L135.8464461324658,-121.7189511669365A182.4,182.4,0,0,0,58.893385830311765,-172.63061462394796Z",
-				"M226.41074355410964,-202.86491861156082A304,304,0,0,1,283.9408970546946,-108.59819049954442L170.36453823281676,-65.15891429972665A182.4,182.4,0,0,0,135.8464461324658,-121.7189511669365Z",
-				"M283.9408970546946,-108.59819049954442A304,304,0,0,1,304,-6.750155989720952e-14L182.4,-4.050093593832571e-14A182.4,182.4,0,0,0,170.36453823281676,-65.15891429972665Z"
+				"M-258.4,-3.16448732899676e-14A258.4,258.4,0,0,1,-233.96782456822908,-109.6796109895106L-140.38069474093746,-65.80776659370636A155.04,155.04,0,0,0,-155.04,-1.8986923973980563e-14Z",
+				"M-233.96782456822908,-109.6796109895106A258.4,258.4,0,0,1,83.43229659294165,-244.56003738392624L50.059377955765,-146.73602243035575A155.04,155.04,0,0,0,-140.38069474093746,-65.80776659370636Z",
+				"M83.43229659294165,-244.56003738392624A258.4,258.4,0,0,1,192.4491320209932,-172.43518081982668L115.46947921259591,-103.46110849189601A155.04,155.04,0,0,0,50.059377955765,-146.73602243035575Z",
+				"M192.4491320209932,-172.43518081982668A258.4,258.4,0,0,1,241.34976249649037,-92.30846192461274L144.80985749789423,-55.38507715476765A155.04,155.04,0,0,0,115.46947921259591,-103.46110849189601Z",
+				"M241.34976249649037,-92.30846192461274A258.4,258.4,0,0,1,258.4,-5.737632591262808e-14L155.04,-3.442579554757685e-14A155.04,155.04,0,0,0,144.80985749789423,-55.38507715476765Z"
 		  	];
 
 			setTimeout(() => {
@@ -440,8 +442,8 @@ describe("SHAPE ARC", () => {
 			const chart = util.generate(args);
 
 			const expected = [
-				"M-93.941166289984,-289.1211809537267A304,304,0,0,1,1.8614631347039768e-14,-304L1.1168778808223861e-14,-182.4A182.4,182.4,0,0,0,-56.364699773990395,-173.47270857223603Z",
-				"M-304,-3.7229262694079536e-14A304,304,0,0,1,-93.941166289984,-289.1211809537267L-56.364699773990395,-173.47270857223603A182.4,182.4,0,0,0,-182.4,-2.2337557616447722e-14Z"
+				"M-79.84999134648639,-245.75300381066768A258.4,258.4,0,0,1,1.58224366449838e-14,-258.4L9.493461986990282e-15,-155.04A155.04,155.04,0,0,0,-47.909994807891835,-147.4518022864006Z",
+				"M-258.4,-3.16448732899676e-14A258.4,258.4,0,0,1,-79.84999134648639,-245.75300381066768L-47.909994807891835,-147.4518022864006A155.04,155.04,0,0,0,-155.04,-1.8986923973980563e-14Z"
 			];
 
 			setTimeout(() => {
@@ -476,13 +478,139 @@ describe("SHAPE ARC", () => {
 			// gauge backgound shouldn't be aligned with the 'startingAngle' option
 			expect(
 				getBoundingRect(arc.select(`.${CLASS.chartArcsBackground}`).node()).width
-			).to.be.above(600);
+			).to.be.above(500);
 
 			expect(
 				arc.select(`.${CLASS.arc}-data`).datum().startAngle
 			).to.be.equal(
 				chart.config("gauge.startingAngle")
 			);
+		});
+	});
+
+	describe("show multi-arc-gauge", () => {
+		const args = {
+			data: {
+				columns: [
+					["padded1", 100],
+					["padded2", 90],
+					["padded3", 50],
+					["padded4", 20]
+				],
+				type: "gauge"
+			},
+			gauge: {
+				type: "multi",
+				label: {
+					format: function(value) {
+						return `${value}%`;
+					}
+				}
+			},
+			color: {
+				pattern: ["rgb(255,0,0)", "rgb(249,118,0)", "rgb(246,198,0)", "rgb(96,176,68)"],
+				threshold: {
+					values: [30, 80, 95]
+				}
+			}
+		};
+		const arcColor = ["rgb(96, 176, 68)", "rgb(246, 198, 0)", "rgb(249, 118, 0)", "rgb(255, 0, 0)"];
+		let chart;
+
+		beforeEach(() => {
+			chart = util.generate(args);
+		});
+
+		it("each data_column should have one arc", () => {
+			const arc = chart.$.arc;
+			const chartArcs = arc.selectAll(`.${CLASS.chartArc} .${CLASS.arc}`);
+
+			chartArcs.each(function(d, i) {
+				expect(d3Select(this).classed(`${CLASS.shape} ${CLASS.arc} ${CLASS.arc}-${args.data.columns[i][0]}`)).to.be.true;
+			});
+		});
+
+		it("each arc should have the color from color_pattern if color_treshold is given ", done => {
+			setTimeout(() => {
+				const arc = chart.$.arc;
+				const chartArcs = arc.selectAll(`.${CLASS.chartArc} .${CLASS.arc}`);
+
+				chartArcs.each(function(d, i) {
+					expect(d3Select(this).style("fill")).to.be.equal(arcColor[i]);
+				});
+
+				done();
+			}, 100);
+		});
+
+		it("each data_column should have one background", () => {
+			const arc = chart.$.arc;
+			const chartArcBackgrounds = arc.selectAll(`.${CLASS.chartArcs} path.${CLASS.chartArcsBackground}`);
+
+			chartArcBackgrounds.each(function(d, i) {
+				expect(d3Select(this).classed(`${CLASS.chartArcsBackground}-${i}`)).to.be.true;
+			});
+		});
+
+		it("each background should have the same color", () => {
+			const arc = chart.$.arc;
+			const chartArcBackgrounds = arc.selectAll(`.${CLASS.chartArcs} path.${CLASS.chartArcsBackground}`);
+
+			chartArcBackgrounds.each(function(d, i) {
+				expect(d3Select(this).style("fill")).to.be.equal("rgb(224, 224, 224)");
+			});
+		});
+
+		it("each data_column should have a label", done => {
+			setTimeout(() => {
+				const arc = chart.$.arc;
+				const gaugeValues = arc.selectAll(`${selector.arc} text.${CLASS.gaugeValue}`);
+
+				gaugeValues.each(function(d, i) {
+					expect(d3Select(this).text()).to.be.equal(`${args.data.columns[i][1]}%`);
+				});
+
+				done();
+			}, 100);
+		});
+
+		it("each label should have the same color", () => {
+			const arc = chart.$.arc;
+			const gaugeValues = arc.selectAll(`${selector.arc} text.${CLASS.gaugeValue}`);
+
+			gaugeValues.each(function(d, i) {
+				expect(d3Select(this).style("fill")).to.be.equal("rgb(0, 0, 0)");
+			});
+		});
+
+		it("if only one data_column is visible the label transform should be empty", done => {
+			const arc = chart.$.main;
+			const textBeforeHide = arc.select(`${selector.arc}-padded4 text`);
+			expect(textBeforeHide.attr("transform")).not.to.be.equal("");
+			chart.hide(["padded1", "padded2", "padded3"]);
+			setTimeout(function() {
+				const textAfterHide = chart.internal.main.select(`${selector.arc}-padded4 text`);
+				expect(textAfterHide.attr("transform")).to.be.equal("");
+				done();
+			}, 1000);
+		});
+
+		it("each data_column should have a labelline", () => {
+			const arc = chart.$.arc;
+			const arcLabelLines = arc.selectAll(`.${CLASS.chartArc} .${CLASS.arcLabelLine}`);
+
+			arcLabelLines.each(function(d, i) {
+				expect(d3Select(this).classed(`${CLASS.arcLabelLine} ${CLASS.target} ${CLASS.target}-${args.data.columns[i][0]}`)).to.be.true;
+			});
+		});
+
+		it("each labelline should have the color from color_pattern if color_treshold is given", () => {
+			const arc = chart.$.arc;
+			const arcLabelLines = arc.selectAll(`.${CLASS.chartArc} .${CLASS.arcLabelLine}`);
+
+			arcLabelLines.each(function(d, i) {
+				expect(d3Select(this).style("fill")).to.be.equal(arcColor[i]);
+			});
 		});
 	});
 

--- a/spec/shape/shape.arc-spec.js
+++ b/spec/shape/shape.arc-spec.js
@@ -612,6 +612,40 @@ describe("SHAPE ARC", () => {
 				expect(d3Select(this).style("fill")).to.be.equal(arcColor[i]);
 			});
 		});
+
+		it("set new columns", () => {
+			args.data.columns = [
+				["padded1", 1],
+				["padded2", 14],
+				["padded3", 15],
+				["padded4", 16],
+				["padded5", 50],
+			];
+			expect(args.data.columns[1][1]).to.be.equal(14);
+		});
+
+		it("each overlapped text should be hidden", () => {
+			const arc = chart.$.arc;
+
+			chart.focus("padded3");
+
+			const gaugeValues = arc.selectAll(`${selector.arc} text.${CLASS.gaugeValue}`);
+			const gaugeValuesNodes = gaugeValues.nodes();
+
+			expect(gaugeValuesNodes[0].className.baseVal).to.be.equal("bb-gauge-value");
+			expect(gaugeValuesNodes[1].className.baseVal).to.be.equal("bb-gauge-value text-overlapping");
+			expect(gaugeValuesNodes[2].className.baseVal).to.be.equal("bb-gauge-value");
+			expect(gaugeValuesNodes[3].className.baseVal).to.be.equal("bb-gauge-value text-overlapping");
+			expect(gaugeValuesNodes[4].className.baseVal).to.be.equal("bb-gauge-value");
+
+			chart.focus("padded4");
+
+			expect(gaugeValuesNodes[0].className.baseVal).to.be.equal("bb-gauge-value");
+			expect(gaugeValuesNodes[1].className.baseVal).to.be.equal("bb-gauge-value");
+			expect(gaugeValuesNodes[2].className.baseVal).to.be.equal("bb-gauge-value text-overlapping");
+			expect(gaugeValuesNodes[3].className.baseVal).to.be.equal("bb-gauge-value");
+			expect(gaugeValuesNodes[4].className.baseVal).to.be.equal("bb-gauge-value");
+		});
 	});
 
 	describe("check for interaction", () => {

--- a/spec/shape/shape.arc-spec.js
+++ b/spec/shape/shape.arc-spec.js
@@ -250,7 +250,7 @@ describe("SHAPE ARC", () => {
 				expect(data.attr("d"))
 					.to.match(/M-258.*?,-3\..+A258.*?,258.*?,0,0,1,209.*?,-151.*?L200.*?,-146.*?A248.*?,248.*?,0,0,0,-248.*?,-3.*?Z/);
 
-				expect(chartArc.select(`.${CLASS.gaugeValue}`).attr("dy")).to.be.equal("");
+				expect(chartArc.select(`.${CLASS.gaugeValue}`).attr("dy")).to.be.equal(".35em");
 
 				done();
 			}, 500);

--- a/spec/shape/shape.arc-spec.js
+++ b/spec/shape/shape.arc-spec.js
@@ -250,7 +250,7 @@ describe("SHAPE ARC", () => {
 				expect(data.attr("d"))
 					.to.match(/M-258.*?,-3\..+A258.*?,258.*?,0,0,1,209.*?,-151.*?L200.*?,-146.*?A248.*?,248.*?,0,0,0,-248.*?,-3.*?Z/);
 
-				expect(chartArc.select(`.${CLASS.gaugeValue}`).attr("dy")).to.be.equal("-.1em");
+				expect(chartArc.select(`.${CLASS.gaugeValue}`).attr("dy")).to.be.equal("");
 
 				done();
 			}, 500);

--- a/src/api/api.focus.js
+++ b/src/api/api.focus.js
@@ -38,6 +38,9 @@ extend(Chart.prototype, {
 		candidates.classed(CLASS.focused, true).classed(CLASS.defocused, false);
 
 		$$.hasArcType() && $$.expandArc(targetIds);
+		if ($$.hasType("gauge")) {
+			$$.markOverlapped(targetIdsValue, $$, `.${CLASS.gaugeValue}`);
+		}
 		$$.toggleFocusLegend(targetIds, true);
 
 		$$.focusedTargetIds = targetIds;
@@ -70,6 +73,9 @@ extend(Chart.prototype, {
 
 		candidates.classed(CLASS.focused, false).classed(CLASS.defocused, true);
 		$$.hasArcType() && $$.unexpandArc(targetIds);
+		if ($$.hasType("gauge")) {
+			$$.undoMarkOverlapped($$, `.${CLASS.gaugeValue}`);
+		}
 		$$.toggleFocusLegend(targetIds, false);
 
 		$$.focusedTargetIds = $$.focusedTargetIds.filter(id => targetIds.indexOf(id) < 0);

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -3295,7 +3295,7 @@ export default class Options {
 			 * @property {String} [gauge.title=""] Set title of gauge chart. Use `\n` character to enter line break.
 			 * @property {String} [gauge.units] Set units of the gauge.
 			 * @property {Number} [gauge.width] Set width of gauge chart.
-			 * @property {GaugeTypes} [gauge.type] Set type of gauge to be displayed.
+			 * @property {String} [gauge.type="single"] Set type of gauge to be displayed.
 			 * @example
 			 *  gauge: {
 			 *      fullCircle: false,

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -3320,7 +3320,10 @@ export default class Options {
 			 *      max: 200,
 			 *      title: "Title Text",
 			 *      units: "%",
-			 *      width: 10
+			 *      width: 10,
+				*      arcs: {
+				*          minWidth: 5
+				*      }
 			 *  }
 			 */
 			gauge_fullCircle: false,
@@ -3333,6 +3336,7 @@ export default class Options {
 			gauge_title: "",
 			gauge_units: undefined,
 			gauge_width: undefined,
+			gauge_arcs_minWidth: 5,
 			gauge_expand: {},
 			gauge_expand_duration: 50,
 

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -3295,6 +3295,7 @@ export default class Options {
 			 * @property {String} [gauge.title=""] Set title of gauge chart. Use `\n` character to enter line break.
 			 * @property {String} [gauge.units] Set units of the gauge.
 			 * @property {Number} [gauge.width] Set width of gauge chart.
+			 * @property {GaugeTypes} [gauge.type] Set type of gauge to be displayed.
 			 * @example
 			 *  gauge: {
 			 *      fullCircle: false,
@@ -3318,6 +3319,7 @@ export default class Options {
 			 *      },
 			 *      min: -100,
 			 *      max: 200,
+				*      type: "single"
 			 *      title: "Title Text",
 			 *      units: "%",
 			 *      width: 10,
@@ -3331,6 +3333,7 @@ export default class Options {
 			gauge_label_format: undefined,
 			gauge_min: 0,
 			gauge_max: 100,
+			gauge_type: "single",
 			gauge_startingAngle: -1 * Math.PI / 2,
 			gauge_label_extents: undefined,
 			gauge_title: "",

--- a/src/config/classes.js
+++ b/src/config/classes.js
@@ -8,6 +8,7 @@
  */
 export default {
 	arc: "bb-arc",
+	arcLabelLine: "bb-arc-label-line",
 	arcs: "bb-arcs",
 	area: "bb-area",
 	areas: "bb-areas",

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -946,7 +946,8 @@ export default class ChartInternal {
 			y = isRotated ? 0 : $$.height2;
 		} else if (target === "arc") {
 			x = $$.arcWidth / 2;
-			y = $$.arcHeight / 2;
+			// to prevent wrong display of min and max label in case when legend is not at the bottom
+			y = $$.arcHeight / 2 - (($$.hasType("gauge") && this.config.legend_position === "bottom") ? 0 : 6);
 		} else if (target === "radar") {
 			const [width] = $$.getRadarSize();
 

--- a/src/internals/legend.js
+++ b/src/internals/legend.js
@@ -670,7 +670,7 @@ extend(ChartInternal.prototype, {
 				.data(targetIdz);
 
 			(withTransition ? tiles.transition() : tiles)
-				.style("stroke", $$.color)
+				.style("stroke", $$.levelColor ? id => $$.levelColor($$.cache[id].values[0].value) : $$.color)
 				.attr("x1", x1ForLegendTile)
 				.attr("y1", yForLegendTile)
 				.attr("x2", x2ForLegendTile)

--- a/src/internals/legend.js
+++ b/src/internals/legend.js
@@ -374,12 +374,19 @@ extend(ChartInternal.prototype, {
 				.on("mouseout", function(id) {
 					if (!callFn(config.legend_item_onout, $$, id)) {
 						d3Select(this).classed(CLASS.legendItemFocused, false);
+						if ($$.hasType("gauge")) {
+							$$.undoMarkOverlapped($$, `.${CLASS.gaugeValue}`);
+						}
 						$$.api.revert();
 					}
 				})
 				.on("mouseover", function(id) {
 					if (!callFn(config.legend_item_onover, $$, id)) {
 						d3Select(this).classed(CLASS.legendItemFocused, true);
+
+						if ($$.hasType("gauge")) {
+							$$.markOverlapped(id, $$, `.${CLASS.gaugeValue}`);
+						}
 
 						if (!$$.transiting && $$.isTargetToShow(id)) {
 							$$.api.focus(id);

--- a/src/internals/title.js
+++ b/src/internals/title.js
@@ -75,15 +75,16 @@ extend(ChartInternal.prototype, {
 		const $$ = this;
 		const config = $$.config;
 		const position = config.title_position || "left";
+		const textRectWidth = $$.getTextRect($$.title, CLASS.title).width;
 		let x;
 
 		if (/(right|center)/.test(position)) {
-			x = $$.currentWidth - $$.getTextRect($$.title, CLASS.title).width;
+			x = $$.currentWidth - textRectWidth;
 
 			if (position.indexOf("right") >= 0) {
-				x -= (config.title_padding.right || 0);
+				x = $$.currentWidth - textRectWidth - config.title_padding.right;
 			} else if (position.indexOf("center") >= 0) {
-				x /= 2;
+				x = ($$.currentWidth - textRectWidth) / 2;
 			}
 		} else { // left
 			x = (config.title_padding.left || 0);

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -240,7 +240,7 @@ extend(ChartInternal.prototype, {
 			const raw = $$.inputType === "touch" || $$.hasType("radar");
 
 			if (!raw) {
-				top += $$.height / 2;
+				top += $$.hasType("gauge") ? $$.height : $$.height / 2;
 				left += ($$.width - ($$.isLegendRight ? $$.getLegendWidth() : 0)) / 2;
 			}
 		} else {
@@ -264,7 +264,7 @@ extend(ChartInternal.prototype, {
 		}
 
 		if (top + tHeight > $$.currentHeight) {
-			top -= tHeight + 30;
+			top -= $$.hasType("gauge") ? tHeight * 3 : tHeight + 30;
 		}
 
 		if (top < 0) {

--- a/src/internals/type.js
+++ b/src/internals/type.js
@@ -97,6 +97,10 @@ extend(ChartInternal.prototype, {
 		return this.hasTypeOf("Arc", targets, exclude);
 	},
 
+	hasMultiArcGauge() {
+		return this.config.gauge_type === "multi";
+	},
+
 	isLineType(d) {
 		const id = isString(d) ? d : d.id;
 

--- a/src/internals/type.js
+++ b/src/internals/type.js
@@ -98,7 +98,7 @@ extend(ChartInternal.prototype, {
 	},
 
 	hasMultiArcGauge() {
-		return this.config.gauge_type === "multi";
+		return this.hasType("gauge") && this.config.gauge_type === "multi";
 	},
 
 	isLineType(d) {

--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -121,6 +121,10 @@
   }
 }
 
+.bb-defocused .text-overlapping {
+  opacity: .05 !important;
+}
+
 /*-- Region --*/
 .bb-region {
   fill: steelblue;

--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -229,7 +229,7 @@
 .bb-chart-arcs {
   .bb-chart-arcs-background {
     fill: #e0e0e0;
-    stroke: none;
+    stroke: #FFF;
   }
 
   .bb-chart-arcs-gauge-unit {
@@ -248,6 +248,7 @@
 
 .bb-chart-arc .bb-gauge-value {
   fill: #000;
+  font-size: 12px;
 }
 
 /*-- Radar --*/

--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -252,7 +252,7 @@
 
 .bb-chart-arc .bb-gauge-value {
   fill: #000;
-  font-size: 12px;
+  font-size: 13px;
 }
 
 /*-- Radar --*/

--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -31,6 +31,11 @@
     stroke: #fff;
   }
 
+  rect {
+    stroke: white;
+    stroke-width: 1;
+  }
+
   text {
     fill: #fff;
     font-size: 13px;

--- a/src/scss/theme/graph.scss
+++ b/src/scss/theme/graph.scss
@@ -298,7 +298,7 @@ rect.bb-circle, use.bb-circle {
 .bb-chart-arcs {
     .bb-chart-arcs-background {
         fill: #e0e0e0;
-        stroke: none;
+        stroke: #FFF;
     }
 
     .bb-chart-arcs-gauge-unit {

--- a/src/scss/theme/graph.scss
+++ b/src/scss/theme/graph.scss
@@ -332,6 +332,11 @@ rect.bb-circle, use.bb-circle {
         stroke: #fff;
     }
 
+    rect {
+        stroke: white;
+        stroke-width: 1;
+    }
+
     text {
         fill: #fff;
         font-size: 13px;

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -154,14 +154,12 @@ extend(ChartInternal.prototype, {
 
 	getSvgArc() {
 		const $$ = this;
-		const hasGaugeType = $$.hasType("gauge");
-		const hasMultiArcGauge = hasGaugeType && $$.hasMultiArcGauge();
 		const ir = $$.getInnerRadius();
 		const singleArcWidth = $$.gaugeArcWidth / $$.filterTargetsToShow($$.data.targets).length;
 
 		let arc = d3Arc()
-			.outerRadius(d => (hasMultiArcGauge ? ($$.radius - singleArcWidth * d.index) : $$.radius))
-			.innerRadius(d => (hasMultiArcGauge ? $$.radius - singleArcWidth * (d.index + 1) :
+			.outerRadius(d => ($$.hasMultiArcGauge() ? ($$.radius - singleArcWidth * d.index) : $$.radius))
+			.innerRadius(d => ($$.hasMultiArcGauge() ? $$.radius - singleArcWidth * (d.index + 1) :
 				isNumber(ir) ? ir : 0));
 
 		const newArc = function(d, withoutUpdate) {
@@ -193,17 +191,15 @@ extend(ChartInternal.prototype, {
 	getSvgArcExpanded(rate) {
 		const $$ = this;
 		const newRate = rate || 1;
-		const hasGaugeType = $$.hasType("gauge");
-		const hasMultiArcGauge = hasGaugeType && $$.hasMultiArcGauge();
 		const singleArcWidth = $$.gaugeArcWidth / $$.filterTargetsToShow($$.data.targets).length;
 		const expandWidth = Math.min($$.radiusExpanded * newRate - $$.radius,
 			singleArcWidth * 0.8 - (1 - newRate) * 100
 		);
 
 		const arc = d3Arc()
-			.outerRadius(d => (hasMultiArcGauge ?
+			.outerRadius(d => ($$.hasMultiArcGauge() ?
 				$$.radius - singleArcWidth * d.index + expandWidth : $$.radiusExpanded * newRate))
-			.innerRadius(d => (hasMultiArcGauge ?
+			.innerRadius(d => ($$.hasMultiArcGauge() ?
 				$$.radius - singleArcWidth * (d.index + 1) : $$.innerRadius));
 
 		return function(d) {
@@ -226,12 +222,10 @@ extend(ChartInternal.prototype, {
 	transformForArcLabel(d) {
 		const $$ = this;
 		const config = $$.config;
-		const hasGauge = $$.hasType("gauge");
-		const hasMultiArcGauge = hasGauge && $$.hasMultiArcGauge();
 		const updated = $$.updateAngle(d);
 		let translate = "";
 
-		if (updated && (!hasMultiArcGauge && $$.hasMultiTargets())) {
+		if (updated && (!$$.hasMultiArcGauge() && $$.hasMultiTargets())) {
 			const c = this.svgArc.centroid(updated);
 			const x = isNaN(c[0]) ? 0 : c[0];
 			const y = isNaN(c[1]) ? 0 : c[1];
@@ -248,7 +242,7 @@ extend(ChartInternal.prototype, {
 			}
 
 			translate = `translate(${x * ratio},${y * ratio})`;
-		} else if (updated && hasMultiArcGauge && $$.hasMultiTargets()) {
+		} else if (updated && $$.hasMultiArcGauge() && $$.hasMultiTargets()) {
 			const y1 = Math.sin(updated.endAngle - Math.PI / 2);
 
 			const x = Math.cos(updated.endAngle - Math.PI / 2) * ($$.radiusExpanded + 25);
@@ -493,8 +487,6 @@ extend(ChartInternal.prototype, {
 		const config = $$.config;
 		const main = $$.main;
 		const hasInteraction = config.interaction_enabled;
-		const hasGaugeType = $$.hasType("gauge");
-		const hasMultiArcGauge = hasGaugeType && $$.hasMultiArcGauge();
 		let mainArcLabelLine;
 		let arcLabelLines;
 
@@ -522,7 +514,7 @@ extend(ChartInternal.prototype, {
 			})
 			.merge(mainArc);
 
-		if (hasMultiArcGauge) {
+		if ($$.hasMultiArcGauge()) {
 			arcLabelLines = main.selectAll(`.${CLASS.arcs}`)
 				.selectAll(`.${CLASS.arcLabelLine}`)
 				.data($$.arcData.bind($$));

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -96,13 +96,10 @@ extend(ChartInternal.prototype, {
 			return null;
 		}
 
-		const hasGauge = $$.hasType("gauge");
 		const radius = Math.PI * (config.gauge_fullCircle ? 2 : 1);
-		const gMin = config.gauge_min;
-		const gMax = config.gauge_max;
 		const gStart = config.gauge_startingAngle;
 
-		if (d.data && hasGauge && !$$.hasMultiArcGauge()) {
+		if (d.data && $$.isGaugeType(d.data)) {
 			const totalSum = $$.getTotalDataSum();
 
 			// if gauge_max less than totalSum, make totalSum to max value
@@ -110,7 +107,7 @@ extend(ChartInternal.prototype, {
 				config.gauge_max = totalSum;
 			}
 
-			const gEnd = radius * (totalSum / (gMax - gMin));
+			const gEnd = radius * (totalSum / (config.gauge_max - config.gauge_min));
 
 			pie = $$.pie
 				.startAngle(gStart)
@@ -134,7 +131,7 @@ extend(ChartInternal.prototype, {
 			d.endAngle = d.startAngle;
 		}
 
-		if (d.data && hasGauge && $$.hasMultiArcGauge()) {
+		if (d.data && $$.hasMultiArcGauge()) {
 			const maxValue = $$.getMinMaxData().max[0].value;
 
 			// if gauge_max less than maxValue, make maxValue to max value
@@ -142,6 +139,8 @@ extend(ChartInternal.prototype, {
 				config.gauge_max = maxValue;
 			}
 
+			const gMin = config.gauge_min;
+			const gMax = config.gauge_max;
 			const gTic = radius / (gMax - gMin);
 			const gValue = d.value < gMin ? 0 : d.value < gMax ? d.value - gMin : (gMax - gMin);
 

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -102,8 +102,6 @@ extend(ChartInternal.prototype, {
 		const gMax = config.gauge_max;
 		const gStart = config.gauge_startingAngle;
 
-		let index = 0;
-
 		if (d.data && hasGauge && !$$.hasMultiArcGauge()) {
 			const totalSum = $$.getTotalDataSum();
 
@@ -120,13 +118,12 @@ extend(ChartInternal.prototype, {
 		}
 
 		pie($$.filterTargetsToShow())
-			.forEach(t => {
+			.forEach((t, i) => {
 				if (!found && t.data.id === d.data.id) {
 					found = true;
 					d = t;
-					d.index = index;
+					d.index = i;
 				}
-				index++;
 			});
 
 		if (isNaN(d.startAngle)) {

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -212,10 +212,12 @@ extend(ChartInternal.prototype, {
 		return function(d) {
 			const updated = $$.updateAngle(d);
 
-			if (hasMultiArcGauge) {
-				return updated ? arc(updated) : "M 0 0";
+			if (updated) {
+				return (
+					$$.hasMultiArcGauge() ? arc : arc.innerRadius($$.getInnerRadius(d))
+				)(updated);
 			} else {
-				return updated ? arc.innerRadius($$.getInnerRadius(d))(updated) : "M 0 0";
+				return "M 0 0";
 			}
 		};
 	},

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -46,7 +46,7 @@ extend(ChartInternal.prototype, {
 		const padding = config.pie_padding;
 		const w = config.gauge_width || config.donut_width;
 		const gaugeArcWidth = $$.filterTargetsToShow($$.data.targets).length *
-			5;
+			config.gauge_arcs_minWidth;
 
 		$$.radiusExpanded = Math.min($$.arcWidth, $$.arcHeight) / 2 * ($$.hasType("gauge") ? 0.85 : 1);
 		$$.radius = $$.radiusExpanded * 0.95;

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -748,7 +748,7 @@ extend(ChartInternal.prototype, {
 				.call($$.textForArcLabel.bind($$))
 				.attr("transform", $$.transformForArcLabel.bind($$))
 				.style("font-size", d => ($$.isGaugeType(d.data) && !$$.hasMultiTargets() ? `${Math.round($$.radius / 5)}px` : null))
-				.attr("dy", $$.hasMultiArcGauge() && !$$.hasMultiTargets() ? "-.1em" : "")
+				.attr("dy", $$.hasMultiArcGauge() ? "-.1em" : ".35em")
 				.transition()
 				.duration(duration)
 				.style("opacity", d => ($$.isTargetToShow(d.data.id) && $$.isArcType(d.data) ? "1" : "0"));

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -748,7 +748,7 @@ extend(ChartInternal.prototype, {
 				.call($$.textForArcLabel.bind($$))
 				.attr("transform", $$.transformForArcLabel.bind($$))
 				.style("font-size", d => ($$.isGaugeType(d.data) && !$$.hasMultiTargets() ? `${Math.round($$.radius / 5)}px` : null))
-				.attr("dy", hasGauge && !$$.hasMultiTargets() ? "-.1em" : "")
+				.attr("dy", $$.hasMultiArcGauge() && !$$.hasMultiTargets() ? "-.1em" : "")
 				.transition()
 				.duration(duration)
 				.style("opacity", d => ($$.isTargetToShow(d.data.id) && $$.isArcType(d.data) ? "1" : "0"));

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -716,22 +716,37 @@ extend(ChartInternal.prototype, {
 			.style("opacity", $$.hasType("donut") || hasGauge ? "1" : "0");
 
 		if (hasGauge) {
+			let index = 0;
 			const isFullCircle = config.gauge_fullCircle;
 			const startAngle = -1 * Math.PI / 2;
 			const endAngle = (isFullCircle ? -4 : -1) * startAngle;
 
 			isFullCircle && text && text.attr("dy", `${Math.round($$.radius / 14)}`);
 
-			$$.arcs.select(`.${CLASS.chartArcsBackground}`)
-				.attr("d", () => {
+			const backgroundArc = $$.arcs.select(`g.${CLASS.chartArcsBackground}`)
+				.selectAll(`path.${CLASS.chartArcsBackground}`)
+				.data($$.data.targets);
+
+			backgroundArc.enter()
+				.append("path")
+				.attr("class", (d, i) => `${CLASS.chartArcsBackground} ${CLASS.chartArcsBackground}-${i}`)
+				.merge(backgroundArc)
+				.attr("d", d1 => {
+					if ($$.hiddenTargetIds.indexOf(d1.id) >= 0) {
+						return "M 0 0";
+					}
 					const d = {
 						data: [{value: config.gauge_max}],
 						startAngle,
-						endAngle
+						endAngle,
+						index: index++
 					};
 
 					return $$.getArc(d, true, true);
 				});
+
+			backgroundArc.exit()
+				.remove();
 
 			$$.arcs.select(`.${CLASS.chartArcsGaugeUnit}`)
 				.attr("dy", ".75em")

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -323,7 +323,7 @@ extend(ChartInternal.prototype, {
 
 		$$.svg.selectAll($$.selectorTargets(newTargetIds, `.${CLASS.chartArc}`))
 			.each(function(d) {
-				if (!$$.shouldExpand(d.data.id) || d.value === 0) {
+				if (!$$.shouldExpand(d.data.id)) {
 					return;
 				}
 
@@ -830,7 +830,7 @@ extend(ChartInternal.prototype, {
 		};
 
 		if ($$.hasType("gauge")) {
-			arcs.append("path")
+			arcs.append("g")
 				.attr("class", CLASS.chartArcsBackground);
 
 			config.gauge_units && appendText(CLASS.chartArcsGaugeUnit);

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -155,7 +155,7 @@ extend(ChartInternal.prototype, {
 	getSvgArc() {
 		const $$ = this;
 		const ir = $$.getInnerRadius();
-		const singleArcWidth = $$.gaugeArcWidth / $$.filterTargetsToShow($$.data.targets).length;
+		const singleArcWidth = $$.gaugeArcWidth / ($$.filterTargetsToShow($$.data.targets).length || 1);
 
 		let arc = d3Arc()
 			.outerRadius(d => ($$.hasMultiArcGauge() ? ($$.radius - singleArcWidth * d.index) : $$.radius))
@@ -774,7 +774,7 @@ extend(ChartInternal.prototype, {
 				.attr("class", (d, i) => `${CLASS.chartArcsBackground} ${CLASS.chartArcsBackground}-${i}`)
 				.merge(backgroundArc)
 				.attr("d", d1 => {
-					if ($$.hiddenTargetIds.indexOf(d1.id) >= 0) {
+					if ($$.hasMultiArcGauge() && $$.hiddenTargetIds.indexOf(d1.id) > -1 && index > 0) {
 						return "M 0 0";
 					}
 					const d = {

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import { Axis } from "./axis";
-import { ChartTypes, d3Selection, DataItem, PrimitiveArray } from "./types";
+import { ChartTypes, d3Selection, DataItem, GaugeTypes, PrimitiveArray } from "./types";
 import Stanford from "./plugin/stanford/index";
 import { Chart } from "./chart";
 
@@ -533,6 +533,11 @@ export interface ChartOptions {
 			 */
 			duration?: number
 		};
+
+		/**
+		 * Set type of the gauge.
+		 */
+		type?: GaugeTypes;
 
 		/**
 		 * Set min value of the gauge.

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -563,6 +563,13 @@ export interface ChartOptions {
 		 * Set width of gauge chart.
 		 */
 		width?: number;
+
+		/**
+		 * Set minimal width of gauge arcs until the innerRadius disappears.
+		 */
+		arcs?: {
+			minWidth: number;
+		}
 	};
 
 	spline?: {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import { Selection } from "d3-selection";  /* tslint:disable-line */
+import {Selection} from "d3-selection"; /* tslint:disable-line */
 
 export type PrimitiveArray = Array<string | boolean | number | Date | null>;
 export type ArrayOrString = string[] | string;
@@ -22,6 +22,8 @@ export type ChartTypes = "area"
 	| "scatter"
 	| "spline"
 	| "step";
+export type GaugeTypes = "single"
+	| "multi";
 
 export interface TargetIds {
 	ids: string[] | string;


### PR DESCRIPTION
## Issues
#787 #1071

If you have any suggestions to make anything better, feel free to discuss in this pull request.
I think there are still many things the gauge could do better, and with this pull request as a basis I hope there will be some people willing to contribute.
Just for your information, this multi arc gauge got developed by my former co-worker who made a pull request in [c3](https://github.com/c3js/c3/pull/1355). I just updated it and improved it a bit for better integration in billboard.

## Details
Now it is possible to dispaly negative values in gauge with 
`  gauge: {
    type: "multi"
  }
`
![gauge-type-multi](https://user-images.githubusercontent.com/42860868/70708449-cf06d080-1cda-11ea-9c52-2189bb2e2872.png)

It will display for each data_column one arc, the related background arc and arc label. Each arc has a line to highlight the relation from arc to label. 
If the highest value in gauge is higher than '_gauge_max_' than '_gauge_max_' will be overwritten with the highest value.

Added new config property '_gauge_arcs_minWidth_' to set the min width of each arc.
Example: `gauge: {
    type: "multi",
    max: 100,
    min: -100,
    arcs: {
      minWidth: 20
    }
  }`
![gauge-type-multi_arcs-min-width](https://user-images.githubusercontent.com/42860868/70708688-65d38d00-1cdb-11ea-9f5c-4541cf341221.png)

Optimized x position for title.
Tooltip got updated for gauge as there was a little bug with the tooltip position when there were to many elements in the chart container under the chart.
Added and updated existing tests for gauge and legend.
Added demo for 'GaugeTypeMulti'.
Added function to mark overlapped gauge values. It hides the overlapped values on focus for better visibility of the highlighted value (as you can see in the second chart below).
![gauge-type-multi_overlapping_1](https://user-images.githubusercontent.com/42860868/70712636-818f6100-1ce4-11ea-94f9-ca7d571a197f.png)
![gauge-type-multi_overlapping_2](https://user-images.githubusercontent.com/42860868/70712638-818f6100-1ce4-11ea-9742-b22de36e2c20.png)

Here are some other examples:
`gauge: {
    type: "multi",
    max: 300,
    min: -100,
    startingAngle: 0
  }`
![gauge-type-multi_startingAngle](https://user-images.githubusercontent.com/42860868/70712794-dd59ea00-1ce4-11ea-8d87-92b49a1da716.png)

`gauge: {
    type: "multi",
    max: 100,
    min: -100
  }` with only one visible data_column (same bahaviour for only one data_column)
![gauge-type-multi_1_column](https://user-images.githubusercontent.com/42860868/70712809-e5b22500-1ce4-11ea-9e9a-4a5a25cf3373.png)

Example with all data_columns hidden
![Screenshot_2020-01-09 billboard js - examples(2)](https://user-images.githubusercontent.com/42860868/72081098-2c079d80-32fe-11ea-97d5-fd5d68743e8b.png)

Example with 20 data_columns
![gauge-type-multi2](https://user-images.githubusercontent.com/42860868/70712801-df23ad80-1ce4-11ea-82d9-50000ad9923f.png)