### PR TITLE
fix(core): Fix onrendered firing time

### DIFF
--- a/spec/internals/core-spec.js
+++ b/spec/internals/core-spec.js
@@ -103,6 +103,65 @@ describe("CORE", function() {
 		});
 	});
 
+	describe("onrendered callbacks", () => {
+		const spy = sinon.spy(function(ctx) {
+			const type = args.data.type;
+			let d;
+
+			if (type === "radar") {
+				d = ctx.$.main.select("polygon").attr("points");
+			} else {
+				d = ctx.$.main.select("path").attr("d");
+			}
+
+		  return d;
+		});
+
+		before(() => {
+			args = {
+				data: {
+				  columns: [
+					  ["data1", 330, 350, 200, 380, 150],
+					  ["data2", 130, 100, 30, 200, 80]
+				  ],
+				  type: "radar",
+				  labels: true
+				},
+				onrendered: spy
+			}
+		});
+
+		it("check radar type", () => {
+			expect(spy.returnValues).to.be.not.empty;
+		});
+
+		it("set options data.type='donut'", () => {
+			args.data.type = "donut";
+			spy.resetHistory();
+		});
+
+		// Note: Arc types are rendered with transition
+		it("check donut type", done => {
+			setTimeout(() => {
+				expect(spy.returnValues).to.be.not.empty;
+				done();
+			}, 300);
+		});
+
+		it("set options data.type='line'", () => {
+			args.data.type = "line";
+			spy.resetHistory();
+		});
+
+		// Note: Arc types are rendered with transition
+		it("check donut type", done => {
+			setTimeout(() => {
+				expect(spy.returnValues).to.be.not.empty;
+				done();
+			}, 300);
+		});
+	});
+
 	describe("size", () => {
 		it("should have same width", () => {
 			const svg = d3Select("#chart svg");

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -747,7 +747,7 @@ export default class ChartInternal {
 
 		if (afterRedraw) {
 			// Only use transition when current tab is visible.
-			if (isTransition) {
+			if (isTransition && redrawList.length) {
 				// Wait for end of transitions for callback
 				const waitForDraw = $$.generateWait();
 
@@ -759,7 +759,7 @@ export default class ChartInternal {
 							.forEach(t => waitForDraw.add(t));
 					})
 					.call(waitForDraw, afterRedraw);
-			} else {
+			} else if (!$$.transiting) {
 				afterRedraw();
 			}
 		}

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -14,7 +14,7 @@ import {interpolate as d3Interpolate} from "d3-interpolate";
 import ChartInternal from "../internals/ChartInternal";
 import {document} from "../internals/browser";
 import CLASS from "../config/classes";
-import {extend, isFunction, isNumber, isUndefined, setTextValue} from "../internals/util";
+import {callFn, extend, isFunction, isNumber, isUndefined, setTextValue} from "../internals/util";
 
 extend(ChartInternal.prototype, {
 	initPie() {
@@ -532,6 +532,7 @@ extend(ChartInternal.prototype, {
 				}
 
 				$$.transiting = false;
+				callFn(config.onrendered, $$, $$.api);
 			});
 
 		// bind arc events

--- a/src/shape/radar.js
+++ b/src/shape/radar.js
@@ -370,8 +370,6 @@ extend(ChartInternal.prototype, {
 		areasEnter
 			.append("polygon")
 			.merge(areas)
-			.transition()
-			.duration(duration)
 			.style("fill", d => $$.color(d))
 			.style("stroke", d => $$.color(d))
 			.attr("points", d => points[d.id].join(" "));


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1194

## Details
<!-- Detailed description of the change/feature -->
- Remove transition on radar's polygon definition
- Make onrendered callback for Arcs to be fired after the transitions ends
- Assure .generateRedrawList() to work when redraw list aren't empty or not in transiting state
