### PR TITLE
fix(gauge): fixed wrong text size and wrong ratio calculation in 'gauge.type = "single"

### DIFF
--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -29,7 +29,7 @@
 .bb-chart-arc {
 	.bb-gauge-value {
 		fill: #000;
-		font-size: 12px;
+		font-size: 13px;
 	}
 
 	path {

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -769,13 +769,14 @@ extend(ChartInternal.prototype, {
 				.call($$.textForArcLabel.bind($$))
 				.attr("transform", $$.transformForArcLabel.bind($$))
 				.style("font-size", d => (
-					$$.isGaugeType(d.data) && $$.data.targets.length === 1 && !$$.hasMultiArcGauge() ?
+					$$.isGaugeType(d.data) && $$.data.targets.length === 1 && !hasMultiArcGauge ?
 						`${Math.round($$.radius / 5)}px` : null
 				))
-				.attr("dy", hasGauge && !$$.hasMultiTargets() && !config.gauge_fullCircle ? "-.1em" : null)
 				.transition()
 				.duration(duration)
 				.style("opacity", d => ($$.isTargetToShow(d.data.id) && $$.isArcType(d.data) ? "1" : "0"));
+
+			hasMultiArcGauge && text.attr("dy", "-.1em");
 		}
 
 		main.select(`.${CLASS.chartArcsTitle}`)

--- a/src/shape/arc.js
+++ b/src/shape/arc.js
@@ -95,13 +95,10 @@ extend(ChartInternal.prototype, {
 			return null;
 		}
 
-		const hasMultiArcGauge = $$.hasMultiArcGauge();
 		const radius = Math.PI * (config.gauge_fullCircle ? 2 : 1);
-		const gMin = config.gauge_min;
-		const gMax = config.gauge_max;
 		const gStart = config.gauge_startingAngle;
 
-		if (d.data && $$.hasType("gauge") && !hasMultiArcGauge) {
+		if (d.data && $$.isGaugeType(d.data)) {
 			const totalSum = $$.getTotalDataSum();
 
 			// if gauge_max less than totalSum, make totalSum to max value
@@ -109,7 +106,7 @@ extend(ChartInternal.prototype, {
 				config.gauge_max = totalSum;
 			}
 
-			const gEnd = radius * (totalSum / (gMax - gMin));
+			const gEnd = radius * (totalSum / (config.gauge_max - config.gauge_min));
 
 			pie = pie
 				.startAngle(gStart)
@@ -133,7 +130,7 @@ extend(ChartInternal.prototype, {
 			d.endAngle = d.startAngle;
 		}
 
-		if (d.data && hasMultiArcGauge) {
+		if (d.data && $$.hasMultiArcGauge()) {
 			const maxValue = $$.getMinMaxData().max[0].value;
 
 			// if gauge_max less than maxValue, make maxValue to max value
@@ -141,6 +138,8 @@ extend(ChartInternal.prototype, {
 				config.gauge_max = maxValue;
 			}
 
+			const gMin = config.gauge_min;
+			const gMax = config.gauge_max;
 			const gTic = radius / (gMax - gMin);
 			const gValue = d.value < gMin ? 0 : d.value < gMax ? d.value - gMin : (gMax - gMin);
 


### PR DESCRIPTION
## Issue
#1163 
especially [this](https://github.com/naver/billboard.js/pull/1163#issuecomment-572910247) comment

## Details
Fixed wrong texts placement.
Fixed wrong ratio calculation in 'gauge.type = "single"' for more than 1 value within a column. (Compare 'data1' values before and after PR)

The **left** gauge is the implementation **before PR** and the **right** one is **after PR**.
![Screenshot_2020-01-10 billboard js - examples](https://user-images.githubusercontent.com/42860868/72133860-c27da280-3382-11ea-8091-1448c805a281.png) ![Screenshot_2020-01-10 billboard js - examples(1)](https://user-images.githubusercontent.com/42860868/72133862-c3aecf80-3382-11ea-9326-ecdfeae5b289.png) 