### PR TITLE
feat(tooltip): Enhancement on callback options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.log
 *.iml
+*.ts
 /*.css
 /*.html
 /*.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 *.log
 *.iml
-*.ts
 /*.css
 /*.html
 /*.js

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -3777,13 +3777,40 @@ export default class Options {
 			 *      },
 			 *
 			 *      // fires prior tooltip is shown
-			 *      onshow: function() { ...},
+			 *      onshow: function(ctx, selectedData) {
+			 *      	ctx; // current chart instance
+			 *
+			 *      	// current dataset selected
+			 *      	// ==> [{x: 4, value: 150, id: "data2", index: 4, name: "data2"}, ...]
+			 *      	selectedData;
+			 *      },
+			 *
 			 *      // fires prior tooltip is hidden
-			 *      onhide: function() { ... },
+			 *      onhide: function(ctx, selectedData) {
+			 *      	ctx; // current chart instance
+			 *
+			 *      	// current dataset selected
+			 *      	// ==> [{x: 4, value: 150, id: "data2", index: 4, name: "data2"}, ...]
+			 *      	selectedData;
+			 *      },
+			 *
 			 *      // fires after tooltip is shown
-			 *      onshown: function() { ... },
+			 *      onshown: function(ctx, selectedData) {
+			 *      	ctx; // current chart instance
+			 *
+			 *      	// current dataset selected
+			 *      	// ==> [{x: 4, value: 150, id: "data2", index: 4, name: "data2"}, ...]
+			 *      	selectedData;
+			 *      },
+			 *
 			 *      // fires after tooltip is hidden
-			 *      onhidden: function() { ... },
+			 *      onhidden: function(ctx, selectedData) {
+			 *      	ctx; // current chart instance
+			 *
+			 *      	// current dataset selected
+			 *      	// ==> [{x: 4, value: 150, id: "data2", index: 4, name: "data2"}, ...]
+			 *      	selectedData;
+			 *      },
 			 *
 			 *      // Link any tooltips when multiple charts are on the screen where same x coordinates are available
 			 *      // Useful for timeseries correlation

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -301,7 +301,7 @@ extend(ChartInternal.prototype, {
 		if (!datum || datum.current !== dataStr) {
 			const index = selectedData.concat().sort()[0].index;
 
-			callFn(config.tooltip_onshow, $$);
+			callFn(config.tooltip_onshow, $$, $$.api, selectedData);
 
 			// set tooltip content
 			$$.tooltip
@@ -320,7 +320,7 @@ extend(ChartInternal.prototype, {
 					height: height = $$.tooltip.property("offsetHeight")
 				});
 
-			callFn(config.tooltip_onshown, $$);
+			callFn(config.tooltip_onshown, $$, $$.api, selectedData);
 			$$._handleLinkedCharts(true, index);
 		}
 
@@ -344,8 +344,10 @@ extend(ChartInternal.prototype, {
 		const $$ = this;
 		const config = $$.config;
 
-		if (!config.tooltip_doNotHide || force) {
-			callFn(config.tooltip_onhide, $$);
+		if (this.tooltip.style("display") !== "none" && (!config.tooltip_doNotHide || force)) {
+			const selectedData = JSON.parse(this.tooltip.datum().current);
+
+			callFn(config.tooltip_onhide, $$, $$.api, selectedData);
 
 			// hide tooltip
 			this.tooltip
@@ -353,7 +355,7 @@ extend(ChartInternal.prototype, {
 				.style("visibility", "hidden") // for IE9
 				.datum(null);
 
-			callFn(config.tooltip_onhidden, $$);
+			callFn(config.tooltip_onhidden, $$, $$.api, selectedData);
 		}
 	},
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -930,22 +930,22 @@ export interface TooltipOptions {
 	/**
 	 * Set a callback that will be invoked before the tooltip is shown.
 	 */
-	onshow?(): void;
+	onshow?(ctx: Chart, selectedData: DataItem): void;
 
 	/**
 	 * Set a callback that will be invoked before the tooltip is hidden.
 	 */
-	onhide?(): void;
+	onhide?(ctx: Chart, selectedData: DataItem): void;
 
 	/**
 	 * Set a callback that will be invoked after the tooltip is shown
 	 */
-	onshown?(): void;
+	onshown?(ctx: Chart, selectedData: DataItem): void;
 
 	/**
 	 * Set a callback that will be invoked after the tooltip is hidden.
 	 */
-	onhidden?(): void;
+	onhidden?(ctx: Chart, selectedData: DataItem): void;
 
 	/**
 	 * Set if tooltips on all visible charts with like x points are shown together when one is shown.


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1216

## Details
<!-- Detailed description of the change/feature -->
Pass 2 arguments to callbacks:
- ctx: current chart instance
- selectedData: current dataset object

```js
tooltip: {
	// fires prior tooltip is shown
	[onshow | onshown | onhide | onhidden]: function(ctx, selectedData) {
		ctx; // current chart instance
	
		// current dataset selected
		// ==> [{x: 4, value: 150, id: "data2", index: 4, name: "data2"}, ...]
		selectedData;
	},
}
```