### PR TITLE
fix(callbacks): Fix triggering in lazy rendering

### DIFF
--- a/src/api/api.chart.js
+++ b/src/api/api.chart.js
@@ -22,13 +22,15 @@ extend(Chart.prototype, {
 	 */
 	resize(size) {
 		const $$ = this.internal;
-		const {config, resizeFunction} = $$;
+		const {config} = $$;
 
-		config.size_width = size ? size.width : null;
-		config.size_height = size ? size.height : null;
+		if ($$.rendered) {
+			config.size_width = size ? size.width : null;
+			config.size_height = size ? size.height : null;
 
-		this.flush(false, true);
-		resizeFunction();
+			this.flush(false, true);
+			$$.resizeFunction();
+		}
 	},
 
 	/**

--- a/src/internals/Chart.js
+++ b/src/internals/Chart.js
@@ -73,7 +73,6 @@ export default class Chart {
 		$$.loadConfig(config);
 		$$.beforeInit(config);
 		$$.init();
-		$$.afterInit(config);
 
 		// bind "this" to nested API
 		(function bindThis(fn, target, argThis) {

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -114,6 +114,7 @@ export default class ChartInternal {
 			const convertedData = $$.convertData(config, $$.initWithData);
 
 			convertedData && $$.initWithData(convertedData);
+			$$.afterInit();
 		}
 	}
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1254

## Details
<!-- Detailed description of the change/feature -->
- Correct onafterinit callback to not be triggered when chart isn't fully rendered.
- Fix .resize() to not rendere when the chart isn't fully rendered
