### PR TITLE
fix(axis): Correct y Axis tick padding

### DIFF
--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -1826,4 +1826,36 @@ describe("AXIS", function() {
 			checkTickValues();
 		});
 	});
+	
+	describe("Axes tick padding", () => {
+		before(() => {
+			args = {
+				data: {      
+					columns: [
+						["data1", 4, 4, 3, 3]
+					]
+				},
+				axis: {      
+					y: {
+						max: 5,
+						tick: {
+							values: [0, 1, 2, 3, 4, 5],
+							count: 5
+						},
+						padding: {
+							top: 20
+						}
+					}
+				}
+			};
+		});
+
+		it("using both tick.values & count option not to make spaced left padding", () => {
+			const tickValues = chart.internal.axis.getTickValues("y");
+			const translateX = +(chart.$.main.attr("transform").match(/(\d+[\.\d]*)/) || [0])[0];
+
+			expect(tickValues.every(v => v % 1 === 0)).to.be.true;
+			expect(translateX).to.be.closeTo(30.5, 1);
+		});
+	});
 });

--- a/src/axis/Axis.js
+++ b/src/axis/Axis.js
@@ -518,10 +518,13 @@ export default class Axis {
 
 			const axis = this.getAxis(id, scale, false, false, true);
 			const tickCount = config[`axis_${id}_tick_count`];
+			const tickValues = config[`axis_${id}_tick_values`];
 
 			// Make to generate the final tick text to be rendered
 			// https://github.com/naver/billboard.js/issues/920
-			if (tickCount) {
+			// Do not generate if 'tick values' option is given
+			// https://github.com/naver/billboard.js/issues/1251
+			if (!tickValues && tickCount) {
 				axis.tickValues(
 					this.generateTickValues(
 						domain,

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -2470,7 +2470,9 @@ export default class Options {
 			 * You can set padding for y axis to create more space on the edge of the axis.
 			 * This option accepts object and it can include top and bottom. top, bottom will be treated as pixels.
 			 *
-			 * - **NOTE:** For area and bar type charts, [area.zerobased](#.area) or [bar.zerobased](#.bar) options should be set to 'false` to get padded bottom.
+			 * - **NOTE:**
+			 *   - Given values are translated relative to the y Axis domain value for padding
+			 *   - For area and bar type charts, [area.zerobased](#.area) or [bar.zerobased](#.bar) options should be set to 'false` to get padded bottom.
 			 * @name axis․y․padding
 			 * @memberof Options
 			 * @type {Object|Number}
@@ -2879,8 +2881,13 @@ export default class Options {
 			axis_y2_tick_text_position: {x: 0, y: 0},
 
 			/**
-			 * Set the number of y2 axis ticks.
-			 * - **NOTE:** This works in the same way as axis.y.tick.count.
+			 * Set padding for y2 axis.<br><br>
+			 * You can set padding for y2 axis to create more space on the edge of the axis.
+			 * This option accepts object and it can include top and bottom. top, bottom will be treated as pixels.
+			 *
+			 * - **NOTE:**
+			 *   - Given values are translated relative to the y2 Axis domain value for padding
+			 *   - For area and bar type charts, [area.zerobased](#.area) or [bar.zerobased](#.bar) options should be set to 'false` to get padded bottom.
 			 * @name axis․y2․padding
 			 * @memberof Options
 			 * @type {Object|Number}

--- a/src/internals/domain.js
+++ b/src/internals/domain.js
@@ -69,6 +69,7 @@ extend(ChartInternal.prototype, {
 	getYDomain(targets, axisId, xDomain) {
 		const $$ = this;
 		const config = $$.config;
+		const pfx = `axis_${axisId}`;
 
 		if ($$.isStackNormalized()) {
 			return [0, 100];
@@ -85,15 +86,15 @@ extend(ChartInternal.prototype, {
 				$$.getYDomain(targets, "y2", xDomain);
 		}
 
-		const yMin = config[`axis_${axisId}_min`];
-		const yMax = config[`axis_${axisId}_max`];
+		const yMin = config[`${pfx}_min`];
+		const yMax = config[`${pfx}_max`];
 		let yDomainMin = $$.getYDomainMin(yTargets);
 		let yDomainMax = $$.getYDomainMax(yTargets);
 
-		const center = config[`axis_${axisId}_center`];
+		const center = config[`${pfx}_center`];
 		let isZeroBased = ["area", "bar", "bubble", "line", "scatter"]
 			.some(v => $$.hasType(v, yTargets) && config[`${v}_zerobased`]);
-		const isInverted = config[`axis_${axisId}_inverted`];
+		const isInverted = config[`${pfx}_inverted`];
 		const showHorizontalDataLabel = $$.hasDataLabel() && config.axis_rotated;
 		const showVerticalDataLabel = $$.hasDataLabel() && !config.axis_rotated;
 
@@ -156,14 +157,15 @@ extend(ChartInternal.prototype, {
 			});
 		}
 
-		if (/^y2?$/.test(axisId)) {
-			const p = config[`axis_${axisId}_padding`];
 
-			if (notEmpty(p)) {
-				["bottom", "top"].forEach(v => {
-					padding[v] = $$.axis.getPadding(p, v, padding[v], domainLength);
-				});
-			}
+		// if padding is set, the domain will be updated relative the current domain value
+		// ex) $$.height=300, padding.top=150, domainLength=4  --> domain=6
+		const p = config[`${pfx}_padding`];
+
+		if (notEmpty(p)) {
+			["bottom", "top"].forEach(v => {
+				padding[v] = $$.axis.getPadding(p, v, padding[v], domainLength);
+			});
 		}
 
 		// Bar/Area chart should be 0-based if all positive|negative


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1251

## Details
<!-- Detailed description of the change/feature -->
- Evaluate y tick width when tick.values option isn't set
- Update API doc adding more info for y Axis tick padding