### PR TITLE
feat(axis): Intent to ship axis.x.min/max.fit

### DIFF
--- a/spec/interactions/zoom-spec.js
+++ b/spec/interactions/zoom-spec.js
@@ -921,11 +921,6 @@ describe("ZOOM", function() {
 			const tickTexts = chart.$.main.selectAll(`.${CLASS.axisY} .tick text`)
 				.filter(function() { return this.style.display === "block"});
 
-			tickTexts.each(function() {
-				console.log(this);
-			})
-
-
 			expect(tickTexts.size()).to.be.equal(args.axis.y.tick.culling.max);
 		});
 	});

--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -7,6 +7,7 @@ import {select as d3Select} from "d3-selection";
 import {format as d3Format} from "d3-format";
 import {timeMinute as d3TimeMinute} from "d3-time";
 import util from "../assets/util";
+import {getBoundingRect} from "../../src/internals/util";
 import bb from "../../src/core";
 import CLASS from "../../src/config/classes";
 import AxisRendererHelper from "../../src/axis/AxisRendererHelper";
@@ -1856,6 +1857,85 @@ describe("AXIS", function() {
 
 			expect(tickValues.every(v => v % 1 === 0)).to.be.true;
 			expect(translateX).to.be.closeTo(30.5, 1);
+		});
+	});
+
+	describe("axis min/max", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 100, 100],
+						["data2", 50, 20, 10, 50, 60]
+					]			
+				},
+				axis: {
+					x: {
+						min: {
+							fit: true,
+							value: -1
+						},
+						max: {
+							fit: true,
+							value: 10
+						}
+					}
+				}
+			}
+		});
+
+		it("check if x axis min/max is fitten.", () => {
+			const yAxisRect = getBoundingRect(chart.$.main.select(`.${CLASS.axisY}`).node());
+			const lineRect = getBoundingRect(chart.$.line.lines.node());
+
+			// check min
+			expect(lineRect.left).to.be.closeTo(yAxisRect.right, 10);
+
+			// check max
+			expect(lineRect.right).to.be.closeTo(chart.internal.currentWidth, 10);
+		});
+
+		it("set option axis.min/max.fit=false", () => {
+			args.axis.x.max.fit = args.axis.x.min.fit = false;
+		});
+
+		it("check if x axis min/max is not fitten.", () => {
+			const yAxisRect = getBoundingRect(chart.$.main.select(`.${CLASS.axisY}`).node());
+			const lineRect = getBoundingRect(chart.$.line.lines.node());
+
+			// check min
+			expect(lineRect.left - yAxisRect.right > 50).to.be.true;
+
+			// check max
+			expect(chart.internal.currentWidth - lineRect.right > 300).to.be.true;
+		});
+
+		it("set option axis.min/max.value", () => {
+			args.axis.x.min = {
+				fit: true,
+				value: 1
+			};
+
+			args.axis.x.max = {
+				fit: true,
+				value: 3
+			}
+		});
+
+		it("check if x axis min/max is not fitten.", () => {
+			const currWidth = chart.internal.currentWidth;
+
+			chart.$.main.selectAll(`.${CLASS.axisX} .tick`).each(function(d, i) {
+				const xPos = +util.parseNum(this.getAttribute("transform")) / 10;
+
+				if (i === 0) { // check min
+					expect(xPos).to.be.below(0);
+				} else if (i === 4) { // check max 
+					expect(xPos).to.be.above(currWidth);
+				} else {
+					expect(xPos > 0 && xPos < currWidth).to.be.true;
+				}
+			});
 		});
 	});
 });

--- a/src/config/Options.js
+++ b/src/config/Options.js
@@ -1887,12 +1887,22 @@ export default class Options {
 			 * Set max value of x axis range.
 			 * @name axis․x․max
 			 * @memberof Options
-			 * @type {Number}
-			 * @default undefined
+			 * @property {Number} max Set the max value
+			 * @property {Boolean} [max.fit=false] When specified `max.value` is greater than the bound data value, setting `true` will make x axis max to be fitted to the bound data max value.
+			 * - **NOTE:** If the bound data max value is greater than the `max.value`, the x axis max will be limited as the given `max.value`.
+			 * @property {Number} [max.value] Set the max value
 			 * @example
 			 * axis: {
 			 *   x: {
-			 *     max: 100
+			 *     max: 100,
+			 *
+			 *     max: {
+			 *       // 'fit=true' will make x axis max to be limited as the bound data value max when 'max.value' is greater.
+			 *       // - when bound data max is '10' and max.value: '100' ==>  x axis max will be '10'
+			 *       // - when bound data max is '1000' and max.value: '100' ==> x axis max will be '100'
+			 *       fit: true,
+			 *       value: 100
+			 *     }
 			 *   }
 			 * }
 			 */
@@ -1902,12 +1912,22 @@ export default class Options {
 			 * Set min value of x axis range.
 			 * @name axis․x․min
 			 * @memberof Options
-			 * @type {Number}
-			 * @default undefined
+			 * @property {Number} min Set the min value
+			 * @property {Boolean} [min.fit=false] When specified `min.value` is lower than the bound data value, setting `true` will make x axis min to be fitted to the bound data min value.
+			 * - **NOTE:** If the bound data min value is lower than the `min.value`, the x axis min will be limited as the given `min.value`.
+			 * @property {Number} [min.value] Set the min value
 			 * @example
 			 * axis: {
 			 *   x: {
-			 *     min: -100
+			 *     min: -100,
+			 *
+			 *     min: {
+			 *       // 'fit=true' will make x axis min to be limited as the bound data value min when 'min.value' is lower.
+			 *       // - when bound data min is '-10' and min.value: '-100' ==>  x axis min will be '-10'
+			 *       // - when bound data min is '-1000' and min.value: '-100' ==> x axis min will be '-100'
+			 *       fit: true,
+			 *       value: -100
+			 *     }
 			 *   }
 			 * }
 			 */

--- a/src/internals/domain.js
+++ b/src/internals/domain.js
@@ -181,11 +181,19 @@ extend(ChartInternal.prototype, {
 
 	getXDomainMinMax(targets, type) {
 		const $$ = this;
-		const value = $$.config[`axis_x_${type}`];
+		const configValue = $$.config[`axis_x_${type}`];
+		const dataValue = getMinMax(type, targets.map(t => getMinMax(type, t.values.map(v => v.x))));
+		let value = isObject(configValue) ? configValue.value : configValue;
 
-		return isDefined(value) ?
-			($$.isTimeSeries() ? $$.parseDate(value) : value) :
-			getMinMax(type, targets.map(t => getMinMax(type, t.values.map(v => v.x))));
+		value = isDefined(value) && $$.isTimeSeries() ? $$.parseDate(value) : value;
+
+		if (isObject(configValue) && configValue.fit && (
+			(type === "min" && value < dataValue) || (type === "max" && value > dataValue)
+		)) {
+			value = undefined;
+		}
+
+		return isDefined(value) ? value : dataValue;
 	},
 
 	getXDomainMin(targets) {

--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -40,13 +40,23 @@ export interface XAxisConfiguration {
 
 	/**
 	 * Set max value of x axis range.
+	 *
+	 * When specified `max.value` is greater than the bound data value, setting `max.fit=true` will make x axis max to be fitted to the bound data max value.
 	 */
-	max?: string | number | Date;
+	max?: string | number | Date | ({
+		fit?: boolean;
+		value?: string | number | Date;
+	});
 
 	/**
 	 * Set min value of x axis range.
+	 *
+	 * When specified `min.value` is lower than the bound data value, setting `min.fit=true` will make x axis min to be fitted to the bound data min value.
 	 */
-	min?: string | number | Date;
+	min?: string | number | Date | ({
+		fit?: boolean;
+		value?: string | number | Date;
+	});
 
 	/**
 	 * Set padding for x axis.

--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -172,13 +172,17 @@ export interface Chart {
 		 * Get and set axis min value.
 		 * @param min If min is given, specified axis' min value will be updated. If no argument is given, the current min values for each axis will be returned.
 		 */
-		min(min?: number | { [key: string]: number }): number | { [key: string]: number };
+		min(min?: number | { [key: string]: number }): number | {
+			[key: string]: number | { fit?: boolean; value?: number; }
+		};
 
 		/**
 		 * Get and set axis max value.
 		 * @param max If max is given, specified axis' max value will be updated. If no argument is given, the current max values for each axis will be returned.
 		 */
-		max(max?: number | { [key: string]: number }): number | { [key: string]: number };
+		max(max?: number | { [key: string]: number }): number | {
+			[key: string]: number | { fit?: boolean; value?: number; }
+		};
 
 		/**
 		 * Get and set axis min and max value.


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#7

## Details
<!-- Detailed description of the change/feature -->
Implementation of axis.x.min/max.fit option.

Given `axis.x.min/max` option as below, will make a spaced area on left & right side.
```js
var chart = bb.generate({
  data: {
    columns: [
      ["data1", 30, 200, 100, 100, 100],
      ["data2", 50, 20, 10, 50, 60]
    ]
  },
  axis: {
    x: {
      min: -1,
      max: 10
    }
  }
});
```

![image](https://user-images.githubusercontent.com/2178435/75660921-bdb4db00-5caf-11ea-9246-29e1de0c75f9.png)

The newly implemented `axis.x.min/max.fit` option, will make to fit on bound data range.

```js
axis: {
    x: {
      min: {
        fit: true,
        value: -1
      },
      max: {
        fit: true,
        value: 10
      }
    }
  }
```

![image](https://user-images.githubusercontent.com/2178435/75661338-7418c000-5cb0-11ea-9fc5-1293aa77d4ca.png)

But, in a case that bound data is greater than the min/max value, it will behave as before.
```js
axis: {
    x: {
      min: {
        fit: true,
        value: 1
      },
      max: {
        fit: true,
        value: 3
      }
    }
  }
```

![image](https://user-images.githubusercontent.com/2178435/75661520-d245a300-5cb0-11ea-9603-b190dea3c9b3.png)
