### PR TITLE
fix(axis): Fix axis tick rotate translate

### DIFF
--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -65,6 +65,16 @@ describe("AXIS", function() {
 			expect(ticks.size()).to.be.equal(3);
 			expect(ticks.data()).to.be.deep.equal([0,3,5]);
 		});
+
+		it("x Axis ticks should be positioned correctly", () => {
+			const expectedXPos = [50, 349, 549];
+
+			chart.$.main.selectAll(`.${CLASS.axisX} .tick`).each(function(d, i) {
+				expect(
+					util.parseNum(this.getAttribute("transform").split(",")[0])
+				).to.be.equal(expectedXPos[i]);
+			});
+		});
 	});
 
 	describe("axis.y.tick.count", () => {
@@ -1155,7 +1165,7 @@ describe("AXIS", function() {
 			it("should resize when all data hidden", () => {
 				chart.hide("data1");
 
-				compare(0, 6, 30, 0)
+				compare(args.axis.x.tick.rotate, 6, 57, 110);
 
 				chart.show("data1");
 			});
@@ -1222,6 +1232,18 @@ describe("AXIS", function() {
 					compareOverflow(37);
 				});
 			});
+
+			it("axis X should maintain its position on legend toggle", done => {
+				const axisXTransform = chart.$.main.select(`.${CLASS.axisX}`).attr("transform");
+
+				// when
+				chart.toggle();
+
+				setTimeout(() => {
+					expect(chart.$.main.select(`.${CLASS.axisX}`).attr("transform")).to.be.equal(axisXTransform);
+					done();
+				})
+			});
 		});
 
 		describe("`axis.x.type = timeseries`", () => {
@@ -1287,7 +1309,7 @@ describe("AXIS", function() {
 			it("should resize when all data hidden", () => {
 				chart.hide("Temperature");
 
-				compare(0, 6, 30, 0)
+				compare(args.axis.x.tick.rotate, 6, 70, 105);
 			});
 
 			it("should resize when show hidden data", () => {
@@ -1389,6 +1411,18 @@ describe("AXIS", function() {
 				it("should be defaultPadding if padding is set", () => {
 					compareOverflow(defaultPadding);
 				});
+			});
+
+			it("axis X should maintain its position on legend toggle", done => {
+				const axisXTransform = chart.$.main.select(`.${CLASS.axisX}`).attr("transform");
+
+				// when
+				chart.toggle();
+
+				setTimeout(() => {
+					expect(chart.$.main.select(`.${CLASS.axisX}`).attr("transform")).to.be.equal(axisXTransform);
+					done();
+				})
 			});
 		});
 	});

--- a/src/axis/Axis.js
+++ b/src/axis/Axis.js
@@ -230,7 +230,9 @@ export default class Axis {
 			}
 		}
 
-		config[`axis_${type}_tick_count`] && axis.ticks(config[`axis_${type}_tick_count`]);
+		const tickCount = config[`axis_${type}_tick_count`];
+
+		tickCount && axis.ticks(tickCount);
 
 		return axis;
 	}
@@ -469,7 +471,10 @@ export default class Axis {
 			const domain = scale.domain();
 
 			// do not compute if domain is same
-			if (isArray(currentTickMax.domain) && currentTickMax.domain.every((v, i) => v === domain[i])) {
+			if (
+				domain[0] === domain[1] ||
+				(isArray(currentTickMax.domain) && currentTickMax.domain[0] === currentTickMax.domain[1])
+			) {
 				return currentTickMax.size;
 			} else {
 				currentTickMax.domain = domain;

--- a/src/axis/AxisRenderer.js
+++ b/src/axis/AxisRenderer.js
@@ -50,7 +50,7 @@ export default class AxisRenderer {
 		const isTopBottom = /^(top|bottom)$/.test(orient);
 
 		// line/text enter and path update
-		const tickTransform = helperInst[isTopBottom ? "axisX" : "axisY"];
+		const tickTransform = helperInst.getTickTransformSetter(isTopBottom ? "x" : "y");
 		const axisPx = tickTransform === helperInst.axisX ? "y" : "x";
 		const sign = /^(top|left)$/.test(orient) ? -1 : 1;
 
@@ -186,7 +186,7 @@ export default class AxisRenderer {
 				const textUpdate = tick.select("text");
 
 				tickEnter.select("line").attr(`${axisPx}2`, innerTickSize * sign);
-				tickEnter.select("text").attr(`${axisPx}`, tickLength * sign);
+				tickEnter.select("text").attr(axisPx, tickLength * sign);
 
 				ctx.setTickLineTextPosition(lineUpdate, textUpdate);
 
@@ -207,11 +207,11 @@ export default class AxisRenderer {
 				} else if (scale0.bandwidth) {
 					scale0 = scale1;
 				} else {
-					tickTransform.call(helperInst, tickExit, scale1);
+					tickTransform(tickExit, scale1);
 				}
 
-				tickTransform.call(helperInst, tickEnter, scale0);
-				tickTransform.call(helperInst, helperInst.transitionise(tick).style("opacity", "1"), scale1);
+				tickTransform(tickEnter, scale0);
+				tickTransform(helperInst.transitionise(tick).style("opacity", "1"), scale1);
 			}
 		});
 

--- a/src/axis/AxisRendererHelper.js
+++ b/src/axis/AxisRendererHelper.js
@@ -58,12 +58,20 @@ export default class AxisRendererHelper {
 		return size;
 	}
 
-	axisX(selection, x) {
-		selection.attr("transform", d => `translate(${Math.ceil(x(d) + this.config.tickOffset)},0)`);
-	}
+	/**
+	 * Get tick transform setter function
+	 * @param {String} id Axis id
+	 * @private
+	 */
+	getTickTransformSetter(id) {
+		const {config} = this;
+		const fn = id === "x" ?
+			value => `translate(${value + config.tickOffset},0)` :
+			value => `translate(0,${value})`;
 
-	axisY(selection, y) {
-		selection.attr("transform", d => `translate(0,${Math.ceil(y(d))})`);
+		return (selection, scale) => {
+			selection.attr("transform", d => fn(Math.ceil(scale(d))));
+		};
 	}
 
 	scaleExtent(domain) {

--- a/src/internals/size.js
+++ b/src/internals/size.js
@@ -260,7 +260,9 @@ extend(ChartInternal.prototype, {
 		let rotate = config[`axis_${id}_tick_rotate`];
 
 		if (!$$.filterTargetsToShow($$.data.targets).length) {
-			return 0;
+			// When data is hidden, it should maintain rotate value
+			// https://github.com/naver/billboard.js/issues/1278
+			return rotate;
 		}
 
 		if (id === "x") {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1278

## Details
<!-- Detailed description of the change/feature -->
- Fix throwing error on setting axis tick translate when tick.rotate option is used
- Fix some side-effects caused by the merge of #1250