### PR TITLE
fix(axis): Fix text being left behind if getBBox fails

### DIFF
--- a/src/axis/AxisRendererHelper.js
+++ b/src/axis/AxisRendererHelper.js
@@ -48,9 +48,10 @@ export default class AxisRendererHelper {
 						size.w = width;
 						size.h = height;
 					}
-
+				} catch (e) {
+				} finally {
 					el.text("");
-				} catch (e) {}
+				}
 			});
 
 		this.getSizeFor1Char = () => size;


### PR DESCRIPTION
## Issue
#1283 

## Details
This just moves clearing the text to a `finally` so it always gets cleaned up.