### PR TITLE
Document that the callback options are called without this

### DIFF
--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -81,6 +81,7 @@ export interface XAxisConfiguration {
 	 */
 	extent?: number[] | string[] | (
 		(
+			this: void,
 			domain: Date|string|number[],
 			scale: (value: any) => number
 		) => number[]
@@ -189,8 +190,8 @@ export interface XTickConfiguration {
 	 * A function to format tick value. Format string is also available for timeseries data.
 	 */
 	format?: string
-		| ((x: number | Date) => string | number)
-		| ((index: number, categoryName: string) => string);
+		| ((this: void, x: number | Date) => string | number)
+		| ((this: void, index: number, categoryName: string) => string);
 
 	/**
 	 * Setting for culling ticks.
@@ -315,7 +316,7 @@ export interface YTickConfiguration {
 	 * Set formatter for y axis tick text.
 	 * This option accepts d3.format object as well as a function you define.
 	 */
-	format?(x: number): string;
+	format?(this: void, x: number): string;
 
 	/**
 	 * Setting for culling ticks.
@@ -370,7 +371,7 @@ export interface AxesConfiguration {
 		/**
 		 * Set formatter for tick text
 		 */
-		format?: (x: string) => string;
+		format?: (this: void, x: string) => string;
 
 		/**
 		 * Set the number of y axis ticks

--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -337,7 +337,7 @@ export interface Chart {
 		type?: string;
 		types?: { [key: string]: string };
 		unload?: boolean | ArrayOrString;
-		done?: () => any;
+		done?: (this: void) => any;
 	}): void;
 
 	/**
@@ -352,7 +352,7 @@ export interface Chart {
 	 *   - If you call load API soon after/before unload, unload param of load should be used. Otherwise chart will not be rendered properly because of cancel of animation.
 	 *   - done will be called after data loaded, but it's not after rendering. It's because rendering will finish after some transition and there is some time lag between loading and rendering.
 	 */
-	unload(targetIds?: TargetIds, done?: () => any): any;
+	unload(targetIds?: TargetIds, done?: (this: void) => any): any;
 
 	/**
 	 * Flow data to the chart. By this API, you can append new data points to the chart.
@@ -383,7 +383,7 @@ export interface Chart {
 		to?: any;
 		length?: number;
 		duration?: number;
-		done?(): any;
+		done?(this: void): any;
 	}): void;
 
 	/**
@@ -446,7 +446,7 @@ export interface Chart {
 
 	/**
 	 * Get and set x values for the chart.
-	 * @param x If x is given, x values of every target will be updated. If no argument is given, current x values will be returned as an Object whose keys are the target ids.
+	 * @param xs If x is given, x values of every target will be updated. If no argument is given, current x values will be returned as an Object whose keys are the target ids.
 	 */
 	xs(xs?: {
 		[key: string]: PrimitiveArray;
@@ -482,7 +482,7 @@ export interface Chart {
 	 * @param mimeType The desired output image format. (ex. 'image/png' for png, 'image/jpeg' for jpeg format)
 	 * @param callback The callback to be invoked when export is ready.
 	 */
-	export(mimeType?: string, callback?: (dataUrl: string) => string): string;
+	export(mimeType?: string, callback?: (this: void, dataUrl: string) => string): string;
 
 	/**
 	 * Get or set single config option value.

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -126,12 +126,12 @@ export interface ChartOptions {
 		 *   - bb-colorize-pattern-red
 		 *   - bb-colorize-pattern-fff
 		 */
-		tiles?: () => SVGPathElement[];
+		tiles?: (this: void) => SVGPathElement[];
 
 		/**
 		 * Set the color value for each data point when mouse/touch onover event occurs.
 		 */
-		onover?: string | { [key: string]: string } | ((d: DataItem) => string);
+		onover?: string | { [key: string]: string } | ((this: void, d: DataItem) => string);
 	};
 
 	interaction?: {
@@ -319,7 +319,7 @@ export interface ChartOptions {
 		/**
 		 * Set the max bubble radius value
 		 */
-		maxR?: ((d: {}) => number) | number;
+		maxR?: ((this: void, d: {}) => number) | number;
 
 		/**
 		 * Set if min or max value will be 0 on bubble chart.
@@ -383,7 +383,7 @@ export interface ChartOptions {
 				/**
 				 * Set format function for the level value.
 				 */
-				format?: (x: string) => string;
+				format?: (this: void, x: string) => string;
 
 				/**
 				 * Show or hide level text.
@@ -415,12 +415,12 @@ export interface ChartOptions {
 			/**
 			 * Set formatter for the label on each pie piece.
 			 */
-			format?(value: number, ratio: number, id: string): string;
+			format?(this: void, value: number, ratio: number, id: string): string;
 
 			/**
 			 * Set ratio of labels position.
 			 */
-			ratio?: ((d: DataItem, radius: number, h: number) => void) | number
+			ratio?: ((this: void, d: DataItem, radius: number, h: number) => void) | number
 		};
 
 		/**
@@ -476,7 +476,7 @@ export interface ChartOptions {
 			/**
 			 * Set formatter for the label on each donut piece.
 			 */
-			format?(value: number, ratio: number, id: string): string;
+			format?(this: void, value: number, ratio: number, id: string): string;
 		};
 
 		/**
@@ -532,12 +532,12 @@ export interface ChartOptions {
 			/**
 			 * Set formatter for the label on gauge.
 			 */
-			format?(value: any, ratio: number): string;
+			format?(this: void, value: any, ratio: number): string;
 
 			/**
 			 * Set customized min/max label text.
 			 */
-			extents?(value: number, isMax: boolean): string | number;
+			extents?(this: void, value: number, isMax: boolean): string | number;
 		};
 
 		/**
@@ -626,42 +626,42 @@ export interface ChartOptions {
 	/**
 	 * Set a callback to execute when the chart is initialized.
 	 */
-	oninit?(ctx: Chart): void;
+	oninit?(this: void, ctx: Chart): void;
 
 	/**
 	 * Set a callback to execute after the chart is initialized
 	 */
-	onafterinit?(ctx: Chart): void;
+	onafterinit?(this: void, ctx: Chart): void;
 
 	/**
 	 * Set a callback to execute before the chart is initialized
 	 */
-	onbeforeinit?(ctx: Chart): void;
+	onbeforeinit?(this: void, ctx: Chart): void;
 
 	/**
 	 * Set a callback which is executed when the chart is rendered. Basically, this callback will be called in each time when the chart is redrawed.
 	 */
-	onrendered?(ctx: Chart): void;
+	onrendered?(this: void, ctx: Chart): void;
 
 	/**
 	 * Set a callback to execute when mouse/touch enters the chart.
 	 */
-	onover?(ctx: Chart): void;
+	onover?(this: void, ctx: Chart): void;
 
 	/**
 	 * Set a callback to execute when mouse/touch leaves the chart.
 	 */
-	onout?(ctx: Chart): void;
+	onout?(this: void, ctx: Chart): void;
 
 	/**
 	 * Set a callback to execute when user resizes the screen.
 	 */
-	onresize?(ctx: Chart): void;
+	onresize?(this: void, ctx: Chart): void;
 
 	/**
 	 * Set a callback to execute when screen resize finished.
 	 */
-	onresized?(ctx: Chart): void;
+	onresized?(this: void, ctx: Chart): void;
 
 	/**
 	 * Set 'clip-path' attribute for chart element.
@@ -747,7 +747,7 @@ export interface AreaLinearGradientOptions {
 		 * - setting 'null' for stop-color, will set its original data color
 		 * - setting 'function' for stop-color, will pass data id as argument. It should return color string or null value
 		 */
-		[number, string | null | ((id: string) => string), number]
+		[number, string | null | ((this: void, id: string) => string), number]
 	];
 }
 
@@ -812,17 +812,17 @@ export interface LegendOptions {
 		/**
 		 * Set click event handler to the legend item.
 		 */
-		onclick?(id: DataItem): void;
+		onclick?(this: void, id: DataItem): void;
 
 		/**
 		 * Set mouseover event handler to the legend item.
 		 */
-		onover?(id: DataItem): void;
+		onover?(this: void, id: DataItem): void;
 
 		/**
 		 * Set mouseout event handler to the legend item.
 		 */
-		onout?(id: DataItem): void;
+		onout?(this: void, id: DataItem): void;
 	};
 
 	/**
@@ -844,7 +844,7 @@ export interface LegendOptions {
 		 *  color {String}: color string
 		 *  data {Array}: data array
 		 */
-		template?: ((title: string, color: string, data: DataItem[]) => void) | string;
+		template?: ((this: void, title: string, color: string, data: DataItem[]) => void) | string;
 	};
 
 	/**
@@ -872,14 +872,14 @@ export interface TooltipOptions {
 		/**
 		 * Set format for the title of tooltip. Specified function receives x of the data point to show.
 		 */
-		title?(x: any): string;
+		title?(this: void, x: any): string;
 
 		/**
 		 * Set format for the name of each data in tooltip.
 		 * Specified function receives name, ratio, id and index of the data point to show.
 		 * ratio will be undefined if the chart is not donut/pie/gauge.
 		 */
-		name?(name: string, ratio: number, id: string, index: number): string;
+		name?(this: void, name: string, ratio: number, id: string, index: number): string;
 
 		/**
 		 * Set format for the value of each data in tooltip.
@@ -887,19 +887,20 @@ export interface TooltipOptions {
 		 * ratio will be undefined if the chart is not donut/pie/gauge.
 		 * If undefined returned, the row of that value will be skipped.
 		 */
-		value?(value: any, ratio: number, id: string, index: number): string;
+		value?(this: void, value: any, ratio: number, id: string, index: number): string;
 	};
 	/**
 	 * Set tooltip values order
 	 * Available Values: desc, asc, any[], function (data1, data2) { ... }, null
 	 */
-	order?: string | any[] | ((data1: any, data2: any) => number) | null;
+	order?: string | any[] | ((this: void, data1: any, data2: any) => number) | null;
 
 	/**
 	 * Set custom position function for the tooltip.
 	 * This option can be used to modify the tooltip position by returning object that has top and left.
 	 */
 	position?: ((
+		this: void,
 		data: any,
 		width: number,
 		height: number,
@@ -912,6 +913,7 @@ export interface TooltipOptions {
 	 * If tooltip.grouped is true, data includes multiple data points.
 	 */
 	contents?: ((
+		this: void,
 		data: any,
 		defaultTitleFormat: string,
 		defaultValueFormat: string,
@@ -965,22 +967,22 @@ export interface TooltipOptions {
 	/**
 	 * Set a callback that will be invoked before the tooltip is shown.
 	 */
-	onshow?(ctx: Chart, selectedData: DataItem): void;
+	onshow?(this: void, ctx: Chart, selectedData: DataItem): void;
 
 	/**
 	 * Set a callback that will be invoked before the tooltip is hidden.
 	 */
-	onhide?(ctx: Chart, selectedData: DataItem): void;
+	onhide?(this: void, ctx: Chart, selectedData: DataItem): void;
 
 	/**
 	 * Set a callback that will be invoked after the tooltip is shown
 	 */
-	onshown?(ctx: Chart, selectedData: DataItem): void;
+	onshown?(this: void, ctx: Chart, selectedData: DataItem): void;
 
 	/**
 	 * Set a callback that will be invoked after the tooltip is hidden.
 	 */
-	onhidden?(ctx: Chart, selectedData: DataItem): void;
+	onhidden?(this: void, ctx: Chart, selectedData: DataItem): void;
 
 	/**
 	 * Set if tooltips on all visible charts with like x points are shown together when one is shown.
@@ -1031,7 +1033,7 @@ export interface SubchartOptions {
 	 * Set callback for brush event.
 	 * Specified function receives the current zoomed x domain.
 	 */
-	onbrush?(domain: any): void;
+	onbrush?(this: void, domain: any): void;
 }
 
 export interface ZoomOptions {
@@ -1072,19 +1074,19 @@ export interface ZoomOptions {
 	 * Set callback that is called when zooming starts.
 	 * Specified function receives the zoom event.
 	 */
-	onzoomstart?(event: Event): void;
+	onzoomstart?(this: void, event: Event): void;
 
 	/**
 	 * Set callback that is called when the chart is zooming.
 	 * Specified function receives the zoomed domain.
 	 */
-	onzoom?(domain: any): void;
+	onzoom?(this: void, domain: any): void;
 
 	/**
 	 * Set callback that is called when zooming ends.
 	 * Specified function receives the zoomed domain.
 	 */
-	onzoomend?(domain: any): void;
+	onzoomend?(this: void, domain: any): void;
 
 	/**
 	 * Set to display zoom reset button for 'drag' type zoom
@@ -1093,7 +1095,7 @@ export interface ZoomOptions {
 		/**
 		 * Set callback when clicks the reset button. The callback will receive reset button element reference as argument.
 		 */
-		onclick?(button: HTMLElement): void;
+		onclick?(this: void, button: HTMLElement): void;
 
 		/**
 		 * Text value for zoom reset button.
@@ -1111,7 +1113,7 @@ export interface PointOptions {
 	/**
 	 * The radius size of each point.
 	 */
-	r?: number | ((d: DataItem) => number);
+	r?: number | ((this: void, d: DataItem) => number);
 
 	focus?: {
 		expand: {
@@ -1272,7 +1274,7 @@ export interface Data {
 	/**
 	 * Converts data id value
 	 */
-	idConverter?: (id: string) => string;
+	idConverter?: (this: void, id: string) => string;
 
 	/**
 	 * Parse a JSON object for data.
@@ -1407,10 +1409,10 @@ export interface Data {
 	/**
 	 * Define the order of the data.
 	 * This option changes the order of stacking the data and pieces of pie/donut. If null specified, it will be the order the data loaded.
-	 * If function specified, it will be used to sort the data and it will recieve the data as argument.
+	 * If function specified, it will be used to sort the data and it will receive the data as argument.
 	 * Available Values: desc, asc, function (data1, data2) { ... }, null
 	 */
-	order?: string | ((...data: string[]) => void) | null;
+	order?: string | ((this: void, ...data: string[]) => void) | null;
 
 	/**
 	 * Define regions for each data.
@@ -1433,13 +1435,13 @@ export interface Data {
 	 * This option should a function and the specified function receives color (e.g. '#ff0000') and d that has data parameters like id, value, index, etc.
 	 * And it must return a string that represents color (e.g. '#00ff00').
 	 */
-	color?(color: string, d: DataItem): string;
+	color?(this: void, color: string, d: DataItem): string;
 
 	/**
 	 * Set color for each data.
 	 */
 	colors?: {
-		[key: string]: string | ((d: DataItem) => string);
+		[key: string]: string | ((this: void, d: DataItem) => string);
 	};
 
 	/**
@@ -1479,10 +1481,10 @@ export interface Data {
 		 * The callback will receive d as an argument and it has some parameters like id, value, index. This callback should return boolean.
 		 * @param d Data object
 		 */
-		isselectable?(d?: any): boolean;
+		isselectable?(this: void, d?: any): boolean;
 	};
 
-	filter?: (v: Array<{
+	filter?: (this: void, v: Array<{
 		id: string;
 		id_org: string;
 		values: Array<{
@@ -1508,43 +1510,43 @@ export interface Data {
 	 * This callback will be called when each data point clicked and will receive d and element as the arguments.
 	 * - d is the data clicked and element is the element clicked. In this callback, this will be the Chart object.
 	 */
-	onclick?(d: DataItem, element: SVGElement): void;
+	onclick?(this: void, d: DataItem, element: SVGElement): void;
 
 	/**
 	 * Set a callback for mouse/touch over event on each data point.
 	 * This callback will be called when mouse cursor or via touch moves onto each data point and will receive d as the argument.
 	 * - d is the data where mouse cursor moves onto. In this callback, this will be the Chart object.
 	 */
-	onover?(d: DataItem, element?: SVGElement): void;
+	onover?(this: void, d: DataItem, element?: SVGElement): void;
 
 	/**
 	 * Set a callback for mouse/touch event on each data point.
 	 * This callback will be called when mouse cursor moves out each data point and will receive d as the argument.
 	 * - d is the data where mouse cursor moves out. In this callback, this will be the Chart object.
 	 */
-	onout?(d: DataItem, element?: SVGElement): void;
+	onout?(this: void, d: DataItem, element?: SVGElement): void;
 
 	/**
 	 * Set a callback for on data selection.
 	 */
-	onselected?(d: DataItem, element?: SVGElement): void;
+	onselected?(this: void, d: DataItem, element?: SVGElement): void;
 
 	/**
 	 * Set a callback for on data un-selection.
 	 */
-	onunselected?(d: DataItem, element?: SVGElement): void;
+	onunselected?(this: void, d: DataItem, element?: SVGElement): void;
 
 	/**
 	 * Set a callback for minimum data
 	 * - NOTE: For 'area-line-range' and 'area-spline-range', mid data will be taken for the comparison
 	 */
-	onmin?(d: DataItem[]): void;
+	onmin?(this: void, d: DataItem[]): void;
 
 	/**
 	 * Set a callback for maximum data
 	 * - NOTE: For 'area-line-range' and 'area-spline-range', mid data will be taken for the comparison
 	 */
-	onmax?(d: DataItem[]): void;
+	onmax?(this: void, d: DataItem[]): void;
 }
 
 export type FormatFunction = (

--- a/types/plugin/bubblecompare/index.d.ts
+++ b/types/plugin/bubblecompare/index.d.ts
@@ -9,5 +9,5 @@ export default class Stanford extends Plugin {
     /**
      * Generate stanford diagram
      */
-    constructor(options: BubblecompareOptions);
+    constructor(options: BubblecompareOptions)
 }

--- a/types/plugin/plugin.d.ts
+++ b/types/plugin/plugin.d.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
- export interface Plugin {
+export interface Plugin {
 	/**
 	 * Version info string for plugin
 	 */

--- a/types/plugin/stanford/index.d.ts
+++ b/types/plugin/stanford/index.d.ts
@@ -9,5 +9,5 @@ export default class Stanford extends Plugin {
 	/**
 	 * Generate stanford diagram
      */
-	constructor(options: StanfordOptions);
+	constructor(options: StanfordOptions)
 }

--- a/types/plugin/stanford/options.d.ts
+++ b/types/plugin/stanford/options.d.ts
@@ -2,11 +2,11 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
- export interface StanfordOptions {
+export interface StanfordOptions {
 	/**
 	 * Set the color of the color scale.
 	 */
-	colors?: (value: number) => string;
+	colors?: (this: void, value: number) => string;
 
 	/**
 	 * Specify the key of epochs values in the data.
@@ -65,7 +65,7 @@
 		/**
 		 * Format of the axis of the color scale. Use 'pow10' to format as powers of 10 or a custom function.
 		 */
-		format?: string | ((x: number) => string);
+		format?: string | ((this: void, x: number) => string);
 	};
 }
 
@@ -105,7 +105,7 @@ export interface StanfordRegionOptions {
 	 * This function receives a value and percentage of the number of epochs in this region.
 	 * Return a string to place text in the middle of the region.
 	 */
-	text?: (value: number, percentage: number) => string;
+	text?: (this: void, value: number, percentage: number) => string;
 	/**
 	 * Set a custom css class to this region, use the fill property in css to set a background color.
 	 */

--- a/types/plugin/textoverlap/index.d.ts
+++ b/types/plugin/textoverlap/index.d.ts
@@ -9,5 +9,5 @@ export default class TextOverlap extends Plugin {
 	/**
 	 * Prevents label overlap using [Voronoi layout](https://en.wikipedia.org/wiki/Voronoi_diagram).
      */
-	constructor(options: TextOverlapOptions);
+	constructor(options: TextOverlapOptions)
 }


### PR DESCRIPTION
## Issue
Refs #1246 

## Details
Previous types would make typescript think that the callback is called with this being the TooltipOptions object, and so will not report errors related to it. By specifying the type of this as void, we tell the type checker that callbacks must not use `this`. See https://www.typescriptlang.org/docs/handbook/functions.html#this-parameters for the typescript doc about it.
The implementation is actually calling the callback with the ChartInternal object as context, but this is considered an implementation detail coming from the fork of C3, not as a supported feature.


For now, I only changed this for a single callback, to trigger the discussion. If you agree on applying this to other callbacks, I can update my PR to change other callback options too.
