### PR TITLE
fix(shape): Fix non-grouped area/bar to be drawn from bottom of x Axis

### DIFF
--- a/spec/shape/shape.bar-spec.js
+++ b/spec/shape/shape.bar-spec.js
@@ -516,6 +516,51 @@ describe("SHAPE BAR", () => {
 				expect(this.getAttribute("d")).to.be.equal(expectedPath[i]);
 			});
 		});
+
+		// check non-grouped bar path position
+		const checkBarPathPos = type => {
+			// Get x Axis pos
+			let xAxisYPos = chart.$.main.select(`.${CLASS.axisX} path`).node().getBoundingClientRect();
+
+			xAxisYPos = type === "y" ? xAxisYPos[type] : xAxisYPos[type] + xAxisYPos.width;
+	
+			chart.$.bar.bars.each(function() {
+				const rect = this.getBoundingClientRect();
+			
+				expect(rect[type] + (type === "y" ? rect.height : 0)).to.be.closeTo(xAxisYPos, 1);
+			});
+		}
+
+		it("set options", () => {
+			args = {
+				data: {
+					columns: [
+						["data1", 20000, 35000, 30000]
+					],
+					type: "bar"
+				  },
+				  axis: {
+					y: {
+						min: 10000,
+						padding: {
+							bottom: 0
+						}
+					}
+				}
+			};
+		});
+
+		it("check bar path node position: non rotated Axis", () => {
+			checkBarPathPos("y");
+		});
+
+		it("set option axis.rotated=true", () => {
+			args.axis.rotated = true;
+		});
+
+		it("check bar path node position: rotated Axis", () => {
+			checkBarPathPos("x");
+		});
 	});
 
 	describe("bar sensitivity", () => {

--- a/spec/shape/shape.line-spec.js
+++ b/spec/shape/shape.line-spec.js
@@ -239,6 +239,54 @@ describe("SHAPE LINE", () => {
 		});
 	});
 
+	describe("area path generation", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 20000, 35000, 30000]
+					],
+					type: "area"
+				},
+				axis: {
+					y: {
+						min: 10000,
+						padding: {
+							bottom: 0
+						}
+					}
+				}
+			};
+		});
+
+		// check non-grouped bar path position
+		const checkBarPathPos = type => {
+			// Get x Axis pos
+			let xAxisYPos = chart.$.main.select(`.${CLASS.axisX} path`).node().getBoundingClientRect();
+
+			xAxisYPos = type === "y" ? xAxisYPos[type] : xAxisYPos[type] + xAxisYPos.width;
+
+			chart.$.line.areas.each(function() {
+				const rect = this.getBoundingClientRect();
+			
+				expect(rect[type] + (type === "y" ? rect.height : 0)).to.be.closeTo(xAxisYPos, 1);
+			});
+		}
+
+
+		it("check bar path node position: non rotated Axis", () => {
+			checkBarPathPos("y");
+		});
+
+		it("set option axis.rotated=true", () => {
+			args.axis.rotated = true;
+		});
+
+		it("check bar path node position: rotated Axis", () => {
+			checkBarPathPos("x");
+		});
+	});
+
 	describe("area-range type generation", () => {
 		const min = 120;
 		const max = 220;

--- a/src/shape/bar.js
+++ b/src/shape/bar.js
@@ -183,7 +183,7 @@ extend(ChartInternal.prototype, {
 		const yScale = isSub ? $$.getSubYScale : $$.getYScale;
 
 		return (d, i) => {
-			const y0 = yScale.call($$, d.id)(0);
+			const y0 = yScale.call($$, d.id)($$.getShapeYMin(d.id));
 			const offset = barOffset(d, i) || y0; // offset is for stacked bar chart
 			const width = isNumber(barW) ? barW : barW[d.id] || barW.width;
 			const posX = barX(d);

--- a/src/shape/line.js
+++ b/src/shape/line.js
@@ -449,7 +449,7 @@ extend(ChartInternal.prototype, {
 			getPoints(d, i)[0][1] :
 			yScaleGetter.call($$, d.id)(
 				$$.isAreaRangeType(d) ?
-					$$.getAreaRangeData(d, "high") : 0
+					$$.getAreaRangeData(d, "high") : ($$.getShapeYMin(d.id))
 			));
 		const value1 = (d, i) => ($$.isGrouped(d.id) ?
 			getPoints(d, i)[1][1] :

--- a/src/shape/shape.js
+++ b/src/shape/shape.js
@@ -155,6 +155,18 @@ extend(ChartInternal.prototype, {
 	},
 
 	/**
+	 * Get shape based y Axis min value
+	 * @param {String} id Data id
+	 * @return {Number}
+	 * @private
+	 */
+	getShapeYMin(id) {
+		const $$ = this;
+
+		return (!$$.isGrouped(id) && $$.config[`axis_${$$.axis.getId(id)}_min`]) || 0;
+	},
+
+	/**
 	 * Get Shape's offset data
 	 * @param {function(Object): boolean} typeFilter
 	 * @return {{shapeOffsetTargets: ShapeOffsetTarget[], indexMapByTargetId: object}}
@@ -204,7 +216,8 @@ extend(ChartInternal.prototype, {
 		return (d, idx) => {
 			const ind = $$.getIndices(indices, d.id);
 			const scale = isSub ? $$.getSubYScale(d.id) : $$.getYScale(d.id);
-			const y0 = scale(0);
+			const y0 = scale($$.getShapeYMin(d.id));
+
 			const dataXAsNumber = Number(d.x);
 			let offset = y0;
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1302

## Details
<!-- Detailed description of the change/feature -->
Make area/bar path draw to not surpass x Axis position, if axis.y/y2.min option is set.

<img width="539" src="https://user-images.githubusercontent.com/2178435/78333664-37006000-75c5-11ea-85f0-1fbfb4a69c5f.png">
