### PR TITLE
fix(grid): Fix possible error when grid.focus.show set false

### DIFF
--- a/spec/interactions/interaction-spec.js
+++ b/spec/interactions/interaction-spec.js
@@ -998,6 +998,18 @@ describe("INTERACTION", () => {
 				done();
 			}, 300);
 		});
+
+		it("set option grid.focus.show=false", () => {
+			args.grid = {
+				focus: {
+					show: false
+				}
+			};
+		});
+
+		it("should not throwing error when grid focus is not shown", () => {
+			expect(chart.tooltip.show({x:2})).to.not.throw;
+		});
 	});
 
 	describe("check for data.over/out", () => {

--- a/src/internals/grid.js
+++ b/src/internals/grid.js
@@ -386,9 +386,13 @@ extend(ChartInternal.prototype, {
 		const $$ = this;
 
 		if ($$.inputType === "touch") {
-			const d = $$.grid.select(`line.${CLASS.xgridFocus}`).datum();
+			const xgridFocus = $$.grid.select(`line.${CLASS.xgridFocus}`);
 
-			d && $$.showGridFocus([d]);
+			if (!xgridFocus.empty()) {
+				const d = xgridFocus.datum();
+
+				d && $$.showGridFocus([d]);
+			}
 		} else {
 			const isRotated = $$.config.axis_rotated;
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1306

## Details
<!-- Detailed description of the change/feature -->
Add condition to prevent selecting non-existence node to show grid focus.