### PR TITLE
refactor(plugin): Remove the use of d3-array

### DIFF
--- a/config/webpack.config.plugin.js
+++ b/config/webpack.config.plugin.js
@@ -34,7 +34,7 @@ const config = {
 		umdNamedDefine: true,
 		globalObject: "this"
 	},
-	devtool: false,
+	devtool: "inline-source-map",
 	plugins: [
 		new webpack.BannerPlugin({
 			banner: banner.production + banner.plugin,

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "coveralls": "^3.0.11",
     "cross-env": "^7.0.2",
     "css-loader": "^3.4.2",
-    "d3-array": "^2.4.0",
     "d3-format": "^1.4.4",
     "d3-polygon": "^1.0.6",
     "d3-voronoi": "^1.1.4",

--- a/src/internals/util.js
+++ b/src/internals/util.js
@@ -340,14 +340,16 @@ const getMinMax = (type, data) => {
  * Get range
  * @param {Number} start Start number
  * @param {Number} end End number
+ * @param {Number} step Step number
  * @return {Array}
  * @private
  */
-const getRange = (start, end) => {
+const getRange = (start, end, step = 1) => {
 	const res = [];
+	const n = Math.max(0, Math.ceil((end - start) / step)) | 0;
 
-	for (let i = start; i < end; i++) {
-		res.push(i);
+	for (let i = start; i < n; i++) {
+		res.push(start + i * step);
 	}
 
 	return res;

--- a/src/plugin/stanford/ColorScale.js
+++ b/src/plugin/stanford/ColorScale.js
@@ -2,12 +2,11 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {range as d3Range} from "d3-array";
 import {axisRight as d3AxisRight} from "d3-axis";
 import {format as d3Format} from "d3-format";
 import {scaleSequential as d3ScaleSequential, scaleLog as d3ScaleLog} from "d3-scale";
 import CLASS from "./classes";
-import {isFunction} from "../../internals/util";
+import {isFunction, getRange} from "../../internals/util";
 
 /**
  * Stanford diagram plugin color scale class
@@ -27,7 +26,7 @@ export default class ColorScale {
 		const height = $$.height - config.padding_bottom - config.padding_top;
 		const barWidth = config.scale_width;
 		const barHeight = 5;
-		const points = d3Range(config.padding_bottom, height, barHeight);
+		const points = getRange(config.padding_bottom, height, barHeight);
 
 		const inverseScale = d3ScaleSequential(target.colors)
 			.domain([points[points.length - 1], points[0]]);

--- a/src/plugin/stanford/index.js
+++ b/src/plugin/stanford/index.js
@@ -2,10 +2,6 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {
-	min as d3Min,
-	max as d3Max
-} from "d3-array";
 import {interpolateHslLong as d3InterpolateHslLong} from "d3-interpolate";
 import {hsl as d3Hsl} from "d3-color";
 import {scaleSequentialLog as d3ScaleSequentialLog} from "d3-scale";
@@ -203,8 +199,8 @@ export default class Stanford extends Plugin {
 		// Get array of epochs
 		const epochs = target.values.map(a => a.epochs);
 
-		target.minEpochs = !isNaN(config.scale_min) ? config.scale_min : d3Min(epochs);
-		target.maxEpochs = !isNaN(config.scale_max) ? config.scale_max : d3Max(epochs);
+		target.minEpochs = !isNaN(config.scale_min) ? config.scale_min : Math.min(...epochs);
+		target.maxEpochs = !isNaN(config.scale_max) ? config.scale_max : Math.max(...epochs);
 
 		target.colors = isFunction(config.colors) ?
 			config.colors : d3InterpolateHslLong(d3Hsl(250, 1, 0.5), d3Hsl(0, 1, 0.5));

--- a/src/plugin/stanford/index.js
+++ b/src/plugin/stanford/index.js
@@ -21,7 +21,6 @@ import {pointInRegion, compareEpochs} from "./util";
  *   - Is preferable use `scatter` as data.type
  * - **Required modules:**
  *   - [d3-selection](https://github.com/d3/d3-selection)
- *   - [d3-array](https://github.com/d3/d3-array)
  *   - [d3-interpolate](https://github.com/d3/d3-interpolate)
  *   - [d3-color](https://github.com/d3/d3-color)
  *   - [d3-scale](https://github.com/d3/d3-scale)
@@ -30,7 +29,6 @@ import {pointInRegion, compareEpochs} from "./util";
  *   - [d3-format](https://github.com/d3/d3-format)
  * @class plugin-stanford
  * @requires d3-selection
- * @requires d3-array
  * @requires d3-interpolate
  * @requires d3-color
  * @requires d3-scale

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,7 +3656,7 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-"d3-array@1.2.0 - 2", d3-array@^2.4.0:
+"d3-array@1.2.0 - 2":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
   integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1310

## Details
<!-- Detailed description of the change/feature -->
- Remove the use of d3-array, replacing to use internal implementaion
- Update webpack plugin devtool option, to debug w/sourcemap