### PR TITLE
fix(gauge): fixed 'getTranslation()' not working in IE and Edge

### DIFF
--- a/src/internals/util.js
+++ b/src/internals/util.js
@@ -225,16 +225,18 @@ const getCssRules = styleSheets => {
 };
 
 /**
- * Gets the SVGMatrix of an SVGElement
- * @param {SVGElement} element
+ * Gets the SVGMatrix of an SVGGElement
+ * @param {SVGGraphicsElement} node
  * @return {SVGMatrix} matrix
  * @private
  */
 const getTranslation = node => {
 	const transform = node ? node.transform : null;
-	const baseVal = transform ? transform.baseVal : [];
+	const baseVal = transform && transform.baseVal;
 
-	return baseVal.length ? baseVal.getItem(0).matrix : {a: 0, b: 0, c: 0, d: 0, e: 0, f: 0};
+	return baseVal && baseVal.numberOfItems ?
+		baseVal.getItem(0).matrix :
+		{a: 0, b: 0, c: 0, d: 0, e: 0, f: 0};
 };
 
 /**


### PR DESCRIPTION
## Issue
#1329

## Details
- 'baseVal.length' property is not standardized (more info at https://developer.mozilla.org/en-US/docs/Web/API/SVGTransformList)
- use 'baseVal.numberOfItems' instead
