### PR TITLE
fix(core): Fix handling transition tasks

### DIFF
--- a/spec/internals/core-spec.js
+++ b/spec/internals/core-spec.js
@@ -131,8 +131,16 @@ describe("CORE", function() {
 			}
 		});
 
-		it("check radar type", () => {
+		it("check radar type", done => {
 			expect(spy.returnValues).to.be.not.empty;
+
+			// when
+			chart.toggle("data1");
+
+			setTimeout(() => {
+				expect(spy.calledTwice).to.be.true;
+				done();
+			}, 300);
 		});
 
 		it("set options data.type='donut'", () => {
@@ -140,7 +148,7 @@ describe("CORE", function() {
 			spy.resetHistory();
 		});
 
-		// Note: Arc types are rendered with transition
+		// Note: Arc types are rendered with tra3nsition
 		it("check donut type", done => {
 			setTimeout(() => {
 				expect(spy.returnValues).to.be.not.empty;
@@ -150,13 +158,15 @@ describe("CORE", function() {
 
 		it("set options data.type='line'", () => {
 			args.data.type = "line";
-			spy.resetHistory();
+			args.onrendered = sinon.spy;
 		});
 
 		// Note: Arc types are rendered with transition
-		it("check donut type", done => {
+		it("check line type", done => {
+			expect(spy.calledOnce).to.be.true;
+
 			setTimeout(() => {
-				expect(spy.returnValues).to.be.not.empty;
+				expect(spy.calledTwice).to.be.true;
 				done();
 			}, 300);
 		});

--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -838,7 +838,7 @@ export default class ChartInternal {
 			}
 
 			$$.hasType("bar") && list.push($$.redrawBar(bar, isTransition));
-			!flow && list.push($$.updategridFocus());
+			!flow && list.push($$.updateGridFocus());
 		}
 
 		if (!hasArcType || $$.hasType("radar")) {
@@ -1200,7 +1200,7 @@ export default class ChartInternal {
 				let done = 0;
 
 				for (let i = 0, t; (t = transitionsToWait[i]); i++) {
-					if (t.empty()) {
+					if (t === true || (t.empty && t.empty())) {
 						done++;
 						continue;
 					}

--- a/src/internals/grid.js
+++ b/src/internals/grid.js
@@ -382,12 +382,11 @@ extend(ChartInternal.prototype, {
 			.style("visibility", "hidden");
 	},
 
-	updategridFocus() {
+	updateGridFocus() {
 		const $$ = this;
+		const xgridFocus = $$.grid.select(`line.${CLASS.xgridFocus}`);
 
 		if ($$.inputType === "touch") {
-			const xgridFocus = $$.grid.select(`line.${CLASS.xgridFocus}`);
-
 			if (!xgridFocus.empty()) {
 				const d = xgridFocus.datum();
 
@@ -396,12 +395,16 @@ extend(ChartInternal.prototype, {
 		} else {
 			const isRotated = $$.config.axis_rotated;
 
-			$$.main.select(`line.${CLASS.xgridFocus}`)
+			xgridFocus
 				.attr("x1", isRotated ? 0 : -10)
 				.attr("x2", isRotated ? $$.width : -10)
 				.attr("y1", isRotated ? -10 : 0)
 				.attr("y2", isRotated ? -10 : $$.height);
 		}
+
+		// need to return 'true' as of being pushed to the redraw list
+		// ref: getRedrawList()
+		return true;
 	},
 
 	generateGridData(type, scale) {

--- a/src/internals/text.js
+++ b/src/internals/text.js
@@ -108,18 +108,20 @@ extend(ChartInternal.prototype, {
 		const t = getRandom();
 		const opacityForText = forFlow ? 0 : $$.opacityForText.bind($$);
 
-		return [
-			$$.mainText.each(function(d, i) {
-				const text = d3Select(this);
+		$$.mainText.each(function(d, i) {
+			const text = d3Select(this);
 
-				// do not apply transition for newly added text elements
-				(withTransition && text.attr("x") ? text.transition(t) : text)
-					.attr("x", x.bind(this)(d, i))
-					.attr("y", y.bind(this)(d, i))
-					.style("fill", $$.updateTextColor.bind($$))
-					.style("fill-opacity", opacityForText);
-			})
-		];
+			// do not apply transition for newly added text elements
+			(withTransition && text.attr("x") ? text.transition(t) : text)
+				.attr("x", x.bind(this)(d, i))
+				.attr("y", y.bind(this)(d, i))
+				.style("fill", $$.updateTextColor.bind($$))
+				.style("fill-opacity", opacityForText);
+		});
+
+		// need to return 'true' as of being pushed to the redraw list
+		// ref: getRedrawList()
+		return true;
 	},
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1276
#1343

## Details
<!-- Detailed description of the change/feature -->
- Fix the side-effect caused by #1276
- Make functions added to ‘generateWait()’ to be determined as ‘done’ when return true
- rename ‘.updategridFocus()’ to ‘updateGridFocus()’