### PR TITLE
Linear gradient stops type fix

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -747,7 +747,7 @@ export interface AreaLinearGradientOptions {
 		 * - setting 'null' for stop-color, will set its original data color
 		 * - setting 'function' for stop-color, will pass data id as argument. It should return color string or null value
 		 */
-		[number, string | null | ((this: void, id: string) => string), number]
+		[number, string | null | ((id: string) => string), number][]
 	];
 }
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -740,15 +740,12 @@ export interface AreaLinearGradientOptions {
 
 	/**
 	 * The ramp of colors to use on a gradient
+	 * 
+	 * offset, stop-color, stop-opacity
+	 * - setting 'null' for stop-color, will set its original data color
+	 * - setting 'function' for stop-color, will pass data id as argument. It should return color string or null value
 	 */
-	stops?: [
-		/**
-		 * offset, stop-color, stop-opacity
-		 * - setting 'null' for stop-color, will set its original data color
-		 * - setting 'function' for stop-color, will pass data id as argument. It should return color string or null value
-		 */
-		[number, string | null | ((id: string) => string), number][]
-	];
+	stops?: [number, string | null | ((this: void, id: string) => string), number][];
 }
 
 export interface RegionOptions {


### PR DESCRIPTION
## Issue

## Details
Current type definition od 'stops' filed does not math to its purpose and API description: "tops {Array}: Each item should be having [offset, stop-color, stop-opacity] values." https://naver.github.io/billboard.js/release/latest/doc/Options
