### PR TITLE
fix(tooltip): Fix tooltip position in narrow size container

### DIFF
--- a/spec/internals/tooltip-spec.js
+++ b/spec/internals/tooltip-spec.js
@@ -285,6 +285,72 @@ describe("TOOLTIP", function() {
 				expect(left).to.be.above(tooltipPos.left);
 			});
 		});
+
+		describe("Narrow width container's tooltip position", () => {
+			const orgArgs = args;
+
+			before(() => {
+				args = {
+					"transition":{
+						"duration":0
+					  },
+					  "axis":{
+						"x":{
+						  "type":"category"
+						},
+						"rotated":true
+					  },
+					  "data":{
+						"json":[
+						  {
+							"region":"South and Central America",
+							"A":10.34,
+							"B":22.62,
+							"Total":32.96
+						  },
+						  {
+							"region":"North America",
+							"A":7.73,
+							"B":22.64,
+							"Total":30.37
+						  },
+						  {
+							"region":"East and South East Asia",
+							"A":12.28,
+							"B":15.02,
+							"Total":27.299999999999997
+						  },
+						  {
+							"region":"Europe",
+							"A":9.72,
+							"B":14.42,
+							"Total":24.14
+						  }
+						],
+						"type":"bar",
+						"keys":{
+						  "x":"region",
+						  "value":["region", "A"]
+						}
+					}
+				};
+
+				chart.$.chart.style("width", "200px");
+			});
+
+			after(() => {
+				// revert
+				chart.$.chart.style("width", "640px");
+				args = orgArgs;
+			});
+
+			it("tooltip shoundn't be positioned out of viewport", () => {
+				// when
+				chart.tooltip.show({x: 2});
+
+				expect(chart.$.tooltip.style("left")).to.equal("0px");
+			});
+		});
 	});
 
 	describe("tooltip positionFunction", () => {

--- a/src/internals/tooltip.js
+++ b/src/internals/tooltip.js
@@ -270,11 +270,16 @@ extend(ChartInternal.prototype, {
 			top -= hasGauge ? tHeight * 3 : tHeight + 30;
 		}
 
-		if (top < 0) {
-			top = 0;
-		}
+		const pos = {top, left};
 
-		return {top, left};
+		// make sure to not be positioned out of viewport
+		Object.keys(pos).forEach(v => {
+			if (pos[v] < 0) {
+				pos[v] = 0;
+			}
+		});
+
+		return pos;
 	},
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1400

## Details
<!-- Detailed description of the change/feature -->
Force x/y coordinate to be 0 when it becomes below to 0.
Is to prevent tooltip not be positioned out of viewport.

![tooltip-pos](https://user-images.githubusercontent.com/2178435/82541872-0f248600-9b8c-11ea-824f-149b53f70f9d.gif)
