### PR TITLE
refactor(clip): Avoid generate xaxisticktexts defs

### DIFF
--- a/src/internals/ChartInternal.js
+++ b/src/internals/ChartInternal.js
@@ -268,7 +268,6 @@ export default class ChartInternal {
 
 		$$.clipChart = $$.appendClip($$.defs, $$.clipId);
 		$$.clipXAxis = $$.appendClip($$.defs, $$.clipIdForXAxis);
-		$$.clipXAxisTickTexts = $$.appendClip($$.defs, $$.clipIdForXAxisTickTexts);
 		$$.clipYAxis = $$.appendClip($$.defs, $$.clipIdForYAxis);
 		$$.clipGrid = $$.appendClip($$.defs, $$.clipIdForGrid);
 
@@ -547,7 +546,9 @@ export default class ChartInternal {
 			$$.margin3.left = $$.arcWidth / 2 + $$.radiusExpanded * 1.1;
 		}
 
-		!hasArc && config.axis_x_show && $$.updateXAxisTickClip();
+		if (!hasArc && config.axis_x_show && config.axis_x_tick_autorotate) {
+			$$.updateXAxisTickClip();
+		}
 	}
 
 	/**

--- a/src/internals/clip.js
+++ b/src/internals/clip.js
@@ -126,8 +126,13 @@ extend(ChartInternal.prototype, {
 		const $$ = this;
 		const newXAxisHeight = $$.getHorizontalAxisHeight("x");
 
-		$$.clipIdForXAxisTickTexts = `${$$.clipId}-xaxisticktexts`;
-		$$.clipPathForXAxisTickTexts = $$.getClipPath($$.clipIdForXAxisTickTexts);
+		if ($$.defs && !$$.clipXAxisTickTexts) {
+			const clipId = `${$$.clipId}-xaxisticktexts`;
+
+			$$.clipXAxisTickTexts = $$.appendClip($$.defs, clipId);
+			$$.clipPathForXAxisTickTexts = $$.getClipPath(clipId);
+			$$.clipIdForXAxisTickTexts = clipId;
+		}
 
 		if (!$$.config.axis_x_tick_multiline &&
 			$$.getAxisTickRotate("x") &&


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
Make to generate 'clip-xaxisticktexts' only when axis.x.tick.autorotate option is set to true.
