### PR TITLE
fix(axis): Fix evaluating tick text size

### DIFF
--- a/spec/internals/axis-spec.js
+++ b/spec/internals/axis-spec.js
@@ -2480,5 +2480,39 @@ describe("AXIS", function() {
 				done();
 			}, 200);
 		});
-	})
+	});
+
+	describe("x Axis tick width size", () => {
+		before(() => {
+			args = {
+				data: {
+					x: "x",
+					columns: [
+						["x", "City of New York"],
+						["data1", 380],
+						["data2", 302]
+					],
+					order: null,
+					type: "bar",
+					groups: [['data1', 'data2']],
+				},
+				axis: {
+					x: {
+						type: 'category',
+						tick: {
+							multiline: false
+						}
+					},
+					rotated: true,
+				}
+			};
+		});
+
+		it("x Axis tick width should be evaluated correctly", () => {
+			const maxTickWidth = chart.internal.currentMaxTickWidths.x.size;
+			const tickWdith = chart.$.main.select(".bb-axis-x tspan").node().getBoundingClientRect().width;
+
+			expect(maxTickWidth).to.be.equal(tickWdith);
+		});
+	});
 });

--- a/src/axis/Axis.js
+++ b/src/axis/Axis.js
@@ -478,7 +478,7 @@ export default class Axis {
 			const domain = scale.domain();
 
 			// do not compute if domain is same
-			if (domain[0] === domain[1] ||
+			if ((domain[0] === domain[1] && domain.every(v => v > 0)) ||
 				(isArray(currentTickMax.domain) && currentTickMax.domain[0] === currentTickMax.domain[1])
 			) {
 				return currentTickMax.size;


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1429

## Details
<!-- Detailed description of the change/feature -->
Force adding a condition for not evaluating x Axis tick size when
domain values are same and also greater than 0.