### PR TITLE
fix(gauge): fixed wrong bottom padding calculation

### DIFF
--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -321,11 +321,15 @@ export default {
 		}
 
 		// for arc
-		state.arcWidth = state.width - (state.isLegendRight ? currLegend.width + 10 : 0);
-		state.arcHeight = state.height - (state.isLegendRight ? 0 : 10);
+		const hasGauge = $$.hasType("gauge");
+		const isLegendRight = state.legend_show && state.isLegendRight;
 
-		if ($$.hasType("gauge") && !config.gauge_fullCircle) {
-			state.arcHeight += state.height - $$.getGaugeLabelHeight();
+		state.arcWidth = state.width - (isLegendRight ? currLegend.width + 10 : 0);
+		state.arcHeight = state.height - (isLegendRight && !hasGauge ? 0 : 10);
+
+		if (hasGauge && !config.gauge_fullCircle) {
+			state.defaultGaugeLabelHeight = 20;
+			state.arcHeight += state.height - $$.getPaddingBottomForGauge();
 		}
 
 		$$.updateRadius && $$.updateRadius();

--- a/src/ChartInternal/internals/transform.ts
+++ b/src/ChartInternal/internals/transform.ts
@@ -12,7 +12,6 @@ export default {
 		const $$ = this;
 		const {config, state} = $$;
 		const isRotated = config.axis_rotated;
-		const hasGauge = $$.hasType("gauge");
 		let padding = 0;
 		let x;
 		let y;
@@ -29,7 +28,7 @@ export default {
 			y = asHalfPixel(state.margin2.top);
 		} else if (target === "legend") {
 			x = state.margin3.left;
-			y = state.margin3.top + (hasGauge ? 10 : 0);
+			y = state.margin3.top;
 		} else if (target === "x") {
 			x = isRotated ? -padding : 0;
 			y = isRotated ? 0 : state.height + padding;

--- a/src/ChartInternal/shape/gauge.ts
+++ b/src/ChartInternal/shape/gauge.ts
@@ -88,6 +88,12 @@ export default {
 	},
 
 	getGaugeLabelHeight(): 20 | 0 {
-		return this.config.gauge_label_show ? 20 : 0;
+		return this.config.gauge_label_show ? this.state.defaultGaugeLabelHeight : 0;
+	},
+
+	getPaddingBottomForGauge() {
+		const $$ = this;
+
+		return $$.getGaugeLabelHeight() * ($$.config.gauge_label_show ? 2 : 2.5);
 	}
 };


### PR DESCRIPTION
## Issue
#1441 

## Details
- from now on, 'isLegendRight' can be truthy only if legend is enabled
- padding bottom is added if legend/gauge_labels are shown or not