### PR TITLE
Added PageCDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ If you want to use 'billboard.js' without installation, load files directly from
 
 - cdnjs: https://cdnjs.com/libraries/billboard.js
 - jsDelivr: https://cdn.jsdelivr.net/npm/billboard.js/dist/
+- PageCDN: https://pagecdn.com/lib/billboardjs
 - unpkg: https://unpkg.com/billboard.js/dist/
 
 ## Supported Browsers


### PR DESCRIPTION
Ref: #1524 

Hi @netil

I read your [exciting blog post on medium](https://medium.com/@alberto.park/billboard-js-2-0-is-out-15e84b52ab11) about how you worked hard to get the performance improvements for version 2 of billboard.js.

Knowing that you are concerned about build size and performance, I have created [Billboard.js CDN](https://pagecdn.com/lib/billboardjs) (on PageCDN) that compresses JS and CSS files very hard to reduce their transfer sizes. PageCDN hosts only a collection of high quality libraries, and now Billboard.js is part of it. 

Here are some numbers:

                                 PageCDN         Current         Saving
                             --------------------------------------------
    billboard.pkgd.min.js      115.77 KB       138.10 KB       22.33 KB
    d3.min.js                   67.37 KB        75.40 KB        8.03 KB
    billboard.min.js            54.28 KB        64.33 KB       10.05 KB
    billboard.min.css            1.53 KB         1.84 KB        0.31 KB

So, billboard.js on PageCDN is around 18-22 KB smaller than normal due to better compression. The files are available on CDN here: [Billboard.js](https://pagecdn.com/lib/billboardjs) and [D3](https://pagecdn.com/lib/d3).

Adding these CDN links on download & installation section is helpful for users looking to reduce JS size. If you allow, I can proceed with a PR to add it.

Thanks.