### PR TITLE
fix(arc): wrong right padding calculation

### DIFF
--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -322,7 +322,7 @@ export default {
 
 		// for arc
 		const hasGauge = $$.hasType("gauge");
-		const isLegendRight = state.legend_show && state.isLegendRight;
+		const isLegendRight = config.legend_show && state.isLegendRight;
 
 		state.arcWidth = state.width - (isLegendRight ? currLegend.width + 10 : 0);
 		state.arcHeight = state.height - (isLegendRight && !hasGauge ? 0 : 10);


### PR DESCRIPTION
## Issue
#1471 

## Details
`legend_show` is not defined in `state`

For this reason `isLegendRight = state.legend_show && state.isLegendRight;` was always undefined, and the chart wasn't transformed correctly:

![Screenshot_2020-07-21 billboard js - examples](https://user-images.githubusercontent.com/42860868/88030565-ae89d900-cb3b-11ea-8cac-fa60856e9381.png)

How it was before and after this pull request:
![Screenshot_2020-07-21 billboard js - examples(1)](https://user-images.githubusercontent.com/42860868/88030613-c1041280-cb3b-11ea-8d31-1547a9fdfbfa.png)
