### PR TITLE
fix(axis): fix y axis clip-path coordinates

### DIFF
--- a/src/ChartInternal/internals/clip.ts
+++ b/src/ChartInternal/internals/clip.ts
@@ -83,7 +83,7 @@ export default {
 		const isInner = config.axis_y_inner;
 
 		const x = isInner ? -1 : (isRotated ? -(1 + left) : -(left - 1));
-		const y = -(isRotated ? -20 : margin.top);
+		const y = -(isRotated ? 20 : margin.top);
 		const w = (isRotated ? width + 15 + left : margin.left + 20) + (isInner ? 20 : 0);
 		const h = (isRotated ? margin.bottom : (margin.top + height)) + 10;
 

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -1735,7 +1735,7 @@ describe("AXIS", function() {
 		});
 	});
 
-	describe("axis.x.rotated", () => {
+	describe("axis.rotated", () => {
 		before(() => {
 			args = {
 				data: {
@@ -1770,6 +1770,14 @@ describe("AXIS", function() {
 
 				expect(tick.attr("transform")).to.be.equal("translate(0,"+y+")");
 			});
+		});
+
+		it("y Axis clipPath element's x/y value should be < 0", () => {
+			const {state, $el} = chart.internal;
+			const yAxisClipPathRect = $el.svg.select(`#${state.clip.idYAxis} rect`);
+
+			expect(+yAxisClipPathRect.attr("x")).to.be.below(0);
+			expect(+yAxisClipPathRect.attr("y")).to.be.below(0);
 		});
 	});
 

--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -175,7 +175,7 @@ export interface yAxisConfigurationBase extends AxisConfigurationBase {
 	default?: number[];
 }
 
-export interface yAxisConfiguration extends AxisConfigurationBase {
+export interface yAxisConfiguration extends yAxisConfigurationBase {
 	/**
 	 * Set type of y axis (timeseries, category, indexed, log)
 	 *
@@ -193,7 +193,7 @@ export interface yAxisConfiguration extends AxisConfigurationBase {
 	clipPath?: boolean;
 }
 
-export interface y2AxisConfiguration extends AxisConfigurationBase {}
+export interface y2AxisConfiguration extends yAxisConfigurationBase {}
 
 export interface XTickConfiguration {
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1572

## Details
<!-- Detailed description of the change/feature -->
- Fix wrong y attribute value when axis is rotated
- Fix wrong interface name for y/y2 definition file
