### PR TITLE
fix(legend): Make legend blurry after click

### DIFF
--- a/src/ChartInternal/internals/legend.ts
+++ b/src/ChartInternal/internals/legend.ts
@@ -393,14 +393,17 @@ export default {
 		if (config.interaction_enabled) {
 			item
 				.style("cursor", "pointer")
-				.on("click", id => {
+				.on("click", function(id) {
 					if (!callFn(config.legend_item_onclick, api, id)) {
 						if (d3Event.altKey) {
 							api.hide();
 							api.show(id);
 						} else {
 							api.toggle(id);
-							!isTouch && $$.isTargetToShow(id) ? api.focus(id) : api.revert();
+
+							d3Select(this)
+								.classed(CLASS.legendItemFocused, false)
+								.style("opacity", null);
 						}
 					}
 

--- a/test/assets/util.ts
+++ b/test/assets/util.ts
@@ -63,7 +63,7 @@ const generate = args => {
  */
 const fireEvent = (element, name, options: any = {}, chart?: Chart) => {
 	const paddingLeft =
-		(chart && chart.internal.$el.main.node().transform.baseVal.getItem(0).matrix.e) || 0;
+		(chart && chart.$.main.node().transform.baseVal.getItem(0).matrix.e) || 0;
 
 	// adjust clientX/Y value
 	"clientX" in options && (options.clientX += paddingLeft);

--- a/test/internals/legend-spec.ts
+++ b/test/internals/legend-spec.ts
@@ -555,4 +555,34 @@ describe("LEGEND", () => {
 			expect(tileColor[3]).to.be.equal("rgb(139, 0, 139)");
 		});
 	});
+
+	describe("legend opacity onclcik", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, -200, 100, 200, 190, 280],
+						["data2", 30, 200, 120, 400, 150, 150]
+					]
+				}
+			};
+		});
+
+		it("check legend item after click", () => {
+			const legend = chart.$.legend.select(`.${CLASS.legendItem}-data2`);
+			const {x, y} = legend.node().getBoundingClientRect();
+			
+			util.fireEvent(legend.node(), "mouseover", {
+				clientX: x,
+				clientY: y
+			}, chart);
+
+			util.fireEvent(legend.node(), "click", {
+				clientX: x,
+				clientY: y
+			}, chart);
+
+			expect(legend.classed(CLASS.legendItemFocused)).to.false;
+		});
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1599

## Details
<!-- Detailed description of the change/feature -->
Remove 'bb-legend-item-focused' class and opacity when legend element is clicked.