### PR TITLE
prevent setting legend color when chart has no legend

### DIFF
--- a/src/ChartInternal/internals/legend.ts
+++ b/src/ChartInternal/internals/legend.ts
@@ -199,8 +199,9 @@ export default {
 	 * @private
 	 */
 	updateLegendItemColor(id: string, color: string): void {
-		this.$el.legend.select(`.${CLASS.legendItem}-${id} line`)
-			.style("stroke", color);
+		const {legend} = this.$el;
+		if (!legend) return;
+		legend.select(`.${CLASS.legendItem}-${id} line`).style("stroke", color);
 	},
 
 	/**


### PR DESCRIPTION
## Issue
#1604

## Details
Prevents `TypeError: Cannot read property 'select' of null` when chart has no legend and `$el.legend` is `null`.
