### PR TITLE
fix: prevent TypeError when chart already destroyed

### DIFF
--- a/src/Chart/api/chart.ts
+++ b/src/Chart/api/chart.ts
@@ -88,9 +88,10 @@ export default {
 	 */
 	destroy(): null {
 		const $$ = this.internal;
-		const {$el: {chart, svg}} = $$;
 
 		if (notEmpty($$)) {
+			const {$el: {chart, svg}} = $$;
+
 			$$.callPluginHook("$willDestroy");
 			$$.charts.splice($$.charts.indexOf(this), 1);
 

--- a/test/api/chart-spec.ts
+++ b/test/api/chart-spec.ts
@@ -103,6 +103,11 @@ describe("API chart", () => {
 				setTimeout(done, 500);
 			}, 500);
 		});
+
+		it("should not throw error when already destroyed", () => {
+			chart.destroy();
+			chart.destroy();
+		});
 	});
 
 	describe("config()", () => {


### PR DESCRIPTION
## Details
When calling `chart.destroy()` twice on the same reference, a `TypeError` is raised.

```
TypeError: Cannot read property '$el' of undefined
    at Chart.destroy
```
