### PR TITLE
fix(interaction): fix retrieving event rect position

### DIFF
--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -623,7 +623,7 @@ export default {
 		const e = inputType === "touch" && event.changedTouches ? event.changedTouches[0] : event;
 		const index = findIndex(
 			coords,
-			isRotated ? e.clientY - rect.y : e.clientX - rect.x,
+			isRotated ? e.clientY - rect.top : e.clientX - rect.left,
 			0,
 			coords.length - 1,
 			isRotated


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1670

## Details
<!-- Detailed description of the change/feature -->
Legacy IE, x & y prop values aren't available from .getBoundingClientRect().
Use left & top prop instead.
