### PR TITLE
fix(interaction): bind touch event only for rect element

### DIFF
--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -99,6 +99,11 @@ export default {
 			}
 		};
 
+		const unselectRect = () => {
+			$$.unselectRect();
+			$$.callOverOutForTouch();
+		};
+
 		// call event.preventDefault()
 		// according 'interaction.inputType.touch.preventDefault' option
 		const preventDefault = config.interaction_inputType_touch.preventDefault;
@@ -130,9 +135,8 @@ export default {
 		};
 
 		// bind touch events
-		svg
+		eventRect
 			.on("touchstart.eventRect touchmove.eventRect", () => {
-				// const eventRect = getEventRect();
 				const event = d3Event;
 
 				if (!eventRect.empty() && eventRect.classed(CLASS.eventRect)) {
@@ -144,19 +148,24 @@ export default {
 					preventEvent(event);
 					selectRect(eventRect.node());
 				} else {
-					$$.unselectRect();
-					$$.callOverOutForTouch();
+					unselectRect();
 				}
 			}, true)
 			.on("touchend.eventRect", () => {
-				// const eventRect = getEventRect();
-
 				if (!eventRect.empty() && eventRect.classed(CLASS.eventRect)) {
 					if ($$.hasArcType() || !$$.toggleShape || state.cancelClick) {
 						state.cancelClick && (state.cancelClick = false);
 					}
 				}
 			}, true);
+
+		svg.on("touchstart", () => {
+			const {target} = d3Event;
+
+			if (target && target !== eventRect.node()) {
+				unselectRect();
+			}
+		});
 	},
 
 	updateEventRect(eventRect): void {

--- a/test/interactions/interaction-spec.ts
+++ b/test/interactions/interaction-spec.ts
@@ -904,7 +904,7 @@ describe("INTERACTION", () => {
 			});
 
 			it("showed each data points tooltip?", done => {
-				util.simulator(chart.internal.$el.svg.node(), {
+				util.simulator(chart.internal.$el.eventRect.node(), {
 					pos: [250,150],
 					deltaX: -200,
 					deltaY: 0,
@@ -926,7 +926,7 @@ describe("INTERACTION", () => {
 					expect(+this.innerHTML).to.be.equal(args.data.columns[i][2]);
 				});
 
-				util.simulator(chart.internal.$el.svg.node(), {
+				util.simulator(chart.internal.$el.eventRect.node(), {
 					pos: [250,150],
 					deltaX: -200,
 					deltaY: 0,
@@ -945,7 +945,7 @@ describe("INTERACTION", () => {
 				let left;
 
 				new Promise(resolve => {
-					util.simulator(chart.$.svg.node(), {
+					util.simulator(chart.internal.$el.eventRect.node(), {
 						pos: [250,150],
 						deltaX: -200,
 						deltaY: 0,
@@ -1008,7 +1008,7 @@ describe("INTERACTION", () => {
 		it("x focus grid position & visibility should be maintained after resize", done => {
 			new Promise(resolve => {
 				// when
-				util.simulator(chart.$.svg.node(), {
+				util.simulator(chart.internal.$el.eventRect.node(), {
 					pos: [250,150],
 					deltaX: -200,
 					deltaY: 0,
@@ -1098,9 +1098,11 @@ describe("INTERACTION", () => {
 		});
 
 		it("should be called callbacks for touch events", done => {
-			chart.internal.callOverOutForTouch.last = null;
+			const {internal: {$el, callOverOutForTouch}} = chart;
 
-			util.simulator(chart.$.svg.node(), {
+			callOverOutForTouch.last = null;
+
+			util.simulator($el.eventRect.node(), {
 				pos: [250,150],
 				deltaX: -100,
 				deltaY: 0,


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1650

## Details
<!-- Detailed description of the change/feature -->
- Bind touch event only for rect element
- Make to unselect if touch happens outside of rect element