### PR TITLE
refactor(api): reset zooming state when .flush() called

### DIFF
--- a/src/Chart/api/chart.ts
+++ b/src/Chart/api/chart.ts
@@ -36,6 +36,7 @@ export default {
 
 	/**
 	 * Force to redraw.
+	 * - **NOTE:** When zoom/subchart is used, the zoomed state will be resetted.
 	 * @function flush
 	 * @instance
 	 * @memberof Chart
@@ -72,6 +73,12 @@ export default {
 				withTransition: false,
 				withTransitionForTransform: false,
 			});
+
+			// reset subchart selection & selection state
+			if (!state.resizing && $$.brush) {
+				$$.brush.getSelection().call($$.brush.move);
+				$$.unselectRect();
+			}
 		} else {
 			$$.initToRender(true);
 		}

--- a/src/ChartInternal/internals/grid.ts
+++ b/src/ChartInternal/internals/grid.ts
@@ -423,9 +423,9 @@ export default {
 
 	hideGridFocus(): void {
 		const $$ = this;
-		const {state: {inputType}, $el: {main}} = $$;
+		const {state: {inputType, resizing}, $el: {main}} = $$;
 
-		if (inputType === "mouse") {
+		if (inputType === "mouse" || !resizing) {
 			main.selectAll(`line.${CLASS.xgridFocus}, line.${CLASS.ygridFocus}`)
 				.style("visibility", "hidden");
 

--- a/test/interactions/subchart-spec.ts
+++ b/test/interactions/subchart-spec.ts
@@ -404,4 +404,47 @@ describe("SUBCHART", () => {
 			]);
 		});
 	});
+
+	describe("subchart with touch inputType", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["sample", 30, 200, 100, 400, 150, 250]
+					]
+				},
+				interaction: {
+					inputType: {
+						touch: true
+					}
+				},
+				subchart: {
+					show: true
+				}
+			};
+		});
+
+		it("calling .flush(), should be resetted zoomming state", () => {
+			const {main, tooltip, subchart} = chart.internal.$el;
+
+			// set subchart visible state
+			const selection = subchart.main.select(".selection")
+				.attr("width", "100")
+				.attr("height", "60")
+				.style("display", null);
+			
+			chart.tooltip.show({x:2});
+
+			// when
+			chart.flush();
+
+			// tooltip, subchart selection & focus grid should be resetted
+			expect(selection.style("display")).to.to.equal("none");
+			expect(selection.attr("width")).to.be.null;
+			expect(selection.attr("height")).to.be.null;
+
+			expect(tooltip.style("display")).to.be.equal("none");
+			expect(main.selectAll(`line.${CLASS.xgridFocus}`).style("visibility")).to.be.equal("hidden");
+		});
+	});
 });

--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -458,6 +458,7 @@ export interface Chart {
 
 	/**
 	 * Force to redraw.
+	 * - **NOTE:** When zoom/subchart is used, the zoomed state will be resetted.
 	 * @param soft For soft redraw.
 	 */
 	flush(soft?: boolean): void;


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1681

## Details
<!-- Detailed description of the change/feature -->
Improve .flush() to reset zomming state when is called programmatically.