### PR TITLE
fix(interaction): correct draggable selection functionaliy

### DIFF
--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -24,7 +24,6 @@ import data from "./data/data";
 import dataLoad from "./data/load";
 
 // interactions
-import drag from "./interactions/drag";
 import interaction from "./interactions/interaction";
 
 // internals
@@ -667,7 +666,6 @@ extend(ChartInternal.prototype, [
 	classModule,
 	color,
 	domain,
-	drag,
 	interaction,
 	format,
 	legend,

--- a/src/ChartInternal/interactions/drag.ts
+++ b/src/ChartInternal/interactions/drag.ts
@@ -31,7 +31,7 @@ export default {
 			return;
 		}
 
-		const [sx, sy] = state.dragStart;
+		const [sx, sy] = state.dragStart || [0, 0];
 		const [mx, my] = mouse;
 
 		const minX = Math.min(sx, mx);
@@ -129,9 +129,5 @@ export default {
 			.classed(CLASS.INCLUDED, false);
 
 		$$.setDragStatus(false);
-	},
-
-	setDragStatus(isDragging: boolean): void {
-		this.state.dragging = isDragging;
 	}
 };

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -56,6 +56,9 @@ export default {
 				$$.generateEventRectsForMultipleXs(eventRectUpdate) :
 				$$.generateEventRectsForSingleX(eventRectUpdate);
 
+			// bind draggable selection
+			eventRectUpdate.call($$.getDraggableSelection());
+
 			$el.eventRect = eventRectUpdate;
 
 			if ($$.state.inputType === "touch" && !$el.svg.on("touchstart.eventRect") && !$$.hasArcType()) {

--- a/src/ChartInternal/interactions/interaction.ts
+++ b/src/ChartInternal/interactions/interaction.ts
@@ -209,5 +209,9 @@ export default {
 		};
 
 		emulateEvent[/^(mouse|click)/.test(type) ? "mouse" : "touch"](element, type, params);
+	},
+
+	setDragStatus(isDragging: boolean): void {
+		this.state.dragging = isDragging;
 	}
 };

--- a/src/ChartInternal/internals/selection.ts
+++ b/src/ChartInternal/internals/selection.ts
@@ -4,10 +4,13 @@
  */
 import {select as d3Select} from "d3-selection";
 import {rgb as d3Rgb} from "d3-color";
+import drag from "../interactions/drag";
 import CLASS from "../../config/classes";
 import {callFn} from "../../module/util";
 
 export default {
+	...drag,
+
 	/**
 	 * Select a point
 	 * @param {object} target Target point

--- a/src/ChartInternal/shape/point.ts
+++ b/src/ChartInternal/shape/point.ts
@@ -149,7 +149,6 @@ export default {
 
 		const t: any = getRandom();
 		const opacityStyleFn = $$.opacityForCircle.bind($$);
-
 		const mainCircles: any[] = [];
 
 		circle.each(function(d) {
@@ -163,7 +162,7 @@ export default {
 
 		return [
 			mainCircles,
-			selectedCircles
+			(withTransition ? selectedCircles.transition() : selectedCircles)
 				.attr(`${posAttr}x`, cx)
 				.attr(`${posAttr}y`, cy)
 		];

--- a/test/assets/helper.ts
+++ b/test/assets/helper.ts
@@ -8,6 +8,7 @@
 import simulant from "simulant";
 
 export {
+	doDrag,
 	fireEvent,
 	getBBox,
 	hexToRgb,
@@ -62,6 +63,13 @@ const hoverChart = (hoverChart, eventName = "mousemove", pos = {clientX: 100, cl
 	const {eventRect} = hoverChart.internal.$el;
 
 	fireEvent(eventRect.node(), eventName, pos, hoverChart);
+};
+
+// do mouse drag selection
+const doDrag = (el, from = {clientX: 100, clientY: 100}, to = {clientX: 200, clientY: 200}, chart?) => {
+	fireEvent(el, "mousedown", from, chart);
+	fireEvent(el, "mousemove", to, chart);
+	fireEvent(el, "mouseup", from, chart);
 };
 
 /**

--- a/test/assets/util.ts
+++ b/test/assets/util.ts
@@ -7,6 +7,7 @@
 /* global sandbox, window */
 import bb from "../../src/";
 import {
+	doDrag,
 	fireEvent,
 	getBBox,
 	hexToRgb,
@@ -62,6 +63,7 @@ const generate = args => {
 };
 
 export default {
+	doDrag,
 	fireEvent,
 	generate,
 	getBBox,

--- a/test/interactions/drag-spec.ts
+++ b/test/interactions/drag-spec.ts
@@ -10,33 +10,34 @@ import util from "../assets/util";
 
 describe("DRAG", function() {
 	let chart;
+	let args: any = {
+		data: {
+			selection: {
+				enabled: true,
+				draggable: true
+			},
+			columns: [
+				["data1", 30, 200, 100, 170, 150, 250],
+				["data2", 130, 100, 140, 35, 110, 50]
+			],
+			types: {
+				data1: "line",
+				data2: "area-spline"
+			},
+			colors: {
+				data1: "red",
+				data2: "green"
+			}
+		}
+	};
+
+	beforeEach(() => {
+		chart = util.generate(args);
+	});
 
 	describe("default extent", () => {
-		before(() => {
-			chart = util.generate({
-				data: {
-					selection: {
-						enabled: true,
-						draggable: true
-					},
-					columns: [
-						["data1", 30, 200, 100, 170, 150, 250],
-						["data2", 130, 100, 140, 35, 110, 50]
-					],
-					types: {
-						data1: "line",
-						data2: "area-spline"
-					},
-					colors: {
-						data1: "red",
-						data2: "green"
-					}
-				}
-			});
-		});
-
 		it("should set dragStart xy coordinates", () => {
-			const internal = chart.internal;
+			const {internal} = chart;
 			const xy = [95.5, 83.5];
 
 			// when
@@ -49,26 +50,20 @@ describe("DRAG", function() {
 		});
 
 		it("should set drag area and points to be selected", () => {
-			const internal = chart.internal;
-			const main = chart.$.main;
+			const {internal} = chart;
+			const {main} = chart.$;
 
 			// when
 			internal.drag([186.5, 320.5]);
 
 			// circles are selected?
 			expect(main.selectAll(`.${CLASS.selectedCircles}`).size()).to.be.equal(2);
-			expect(main.selectAll(`.${CLASS.INCLUDED}`).size()).to.be.equal(2);
-
-			// check for selection rect
-			const dragAreaRect = util.getBBox(main.select(`.${CLASS.dragarea}`));
-
-			expect(dragAreaRect.width).to.be.above(0);
-			expect(dragAreaRect.height).to.be.above(0);
+			expect(main.selectAll(`.${CLASS.INCLUDED}`).size()).to.be.equal(3);
 		});
 
 		it("selected points should be unselected and drag area should be removed", done => {
-			const internal = chart.internal;
-			const main = chart.$.main;
+			const {internal} = chart;
+			const {main} = chart.$;
 
 			// when
 			internal.dragend();
@@ -82,6 +77,44 @@ describe("DRAG", function() {
 				// dragging flag to be set false
 				expect(internal.state.dragging).to.be.false;
 
+				done();
+			}, 500);
+		});
+	});
+
+	describe("selection.draggable", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 170, 150, 250],
+						["data2", 130, 100, 140, 35, 110, 50]
+					],
+					selection: {
+					  enabled: true,
+					  draggable: true
+					}
+				  }
+			};
+		});
+
+		it("should select data points by dragging event", done => {
+			const {internal: {$el}} = chart;
+
+			chart.$.svg.select(".overlay").node()
+
+			util.doDrag($el.eventRect.node(), {
+				clientX: 34.5,
+				clientY: 20
+			}, {
+				clientX: 380,
+				clientY: 340,
+			});
+
+			setTimeout(() => {
+				const selectedCircle = $el.chart.selectAll(`.${CLASS.selectedCircles}`);
+
+				expect(selectedCircle.size()).to.be.equal(2);
 				done();
 			}, 500);
 		});

--- a/test/interactions/subchart-spec.ts
+++ b/test/interactions/subchart-spec.ts
@@ -16,15 +16,6 @@ describe("SUBCHART", () => {
 		chart = util.generate(args);
 	});
 
-	// do mouse drag selection
-	const doDrag = (from = {clientX: 100, clientY: 100}, to = {clientX: 200, clientY: 200}) => {
-		const overlay = chart.$.svg.select(".overlay").node();
-
-		util.fireEvent(overlay, "mousedown", from, chart);
-		util.fireEvent(overlay, "mousemove", to, chart);
-		util.fireEvent(overlay, "mouseup", from, chart);
-	};
-
 	describe("generate subchart", () => {
 		before(() => {
 			args = {
@@ -162,7 +153,7 @@ describe("SUBCHART", () => {
 			const baseWidth = 100;
 
 			// mouse drag selection on subchart
-			doDrag();
+			util.doDrag(chart.$.svg.select(".overlay").node(), undefined, undefined, chart);
 
 			expect(+selection.attr("width")).to.be.equal(baseWidth);
 
@@ -220,7 +211,7 @@ describe("SUBCHART", () => {
 			const selection = chart.$.svg.select(".selection");
 
 			// mouse drag selection on subchart
-			doDrag( {clientX: 0, clientY: 0}, {clientX: 300, clientY: 300});
+			util.doDrag(chart.$.svg.select(".overlay").node(), {clientX: 0, clientY: 0}, {clientX: 300, clientY: 300}, chart);
 
 			// selection shouldn't over pass
 			expect(Math.floor(selection.attr("width"))).to.be.equal(args.axis.x.extent[1]);
@@ -237,7 +228,7 @@ describe("SUBCHART", () => {
 				.reduce((a, c) => Math.abs(a - c));
 
 			// mouse drag selection on subchart
-			doDrag( {clientX: 0, clientY: 0}, {clientX: 300, clientY: 300});
+			util.doDrag(chart.$.svg.select(".overlay").node(), {clientX: 0, clientY: 0}, {clientX: 300, clientY: 300}, chart);
 
 			// selection shouldn't over pass
 			expect(+selection.attr("width")).to.be.closeTo(range, 10);
@@ -251,7 +242,7 @@ describe("SUBCHART", () => {
 			const selection = chart.$.svg.select(".selection");
 
 			// mouse drag selection on subchart
-			doDrag( {clientX: 0, clientY: 0}, {clientX: 300, clientY: 300});
+			util.doDrag(chart.$.svg.select(".overlay").node(), {clientX: 0, clientY: 0}, {clientX: 300, clientY: 300}, chart);
 
 			// selection shouldn't over pass
 			expect(Math.floor(selection.attr("width"))).to.be.equal(args.axis.x.extent()[1]);


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1642

## Details
<!-- Detailed description of the change/feature -->
- remove default ‘drag’ module import. It will be imported along with selection module.
- move .setDragStatus() from drag.ts to interaction.ts
- fix draggable selection to work
- fix selected point to be transitioning