### PR TITLE
fix(api): fix resizing event element

### DIFF
--- a/src/Chart/api/chart.ts
+++ b/src/Chart/api/chart.ts
@@ -29,6 +29,8 @@ export default {
 			config.size_width = size ? size.width : null;
 			config.size_height = size ? size.height : null;
 
+			state.resizing = true;
+
 			this.flush(false, true);
 			$$.resizeFunction();
 		}

--- a/test/api/chart-spec.ts
+++ b/test/api/chart-spec.ts
@@ -75,6 +75,22 @@ describe("API chart", () => {
 			expect(chart.internal.getCurrentWidth()).to.be.equal(newSize.width);
 			expect(chart.internal.getCurrentHeight()).to.be.equal(newSize.height);
 		});
+
+		it("set options resize.auto=false", () => {
+			args.resize = {
+				auto: false
+			}
+		});
+
+		it("event <rect> element should resize", () => {
+			const {eventRect} = chart.internal.$el;
+			const height = +eventRect.attr("height");
+
+			// when
+			chart.resize({height:600});
+
+			expect(+eventRect.attr("height")).to.be.above(height);
+		});
 	});
 
 	describe("destroy()", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1695

## Details
<!-- Detailed description of the change/feature -->
Update resizing state value when .resize() is called to
prevent when resize.auto=false is set.
