### PR TITLE
fix(tooltip): fix to reset pending events from .show()

### DIFF
--- a/src/Chart/api/tooltip.ts
+++ b/src/Chart/api/tooltip.ts
@@ -105,9 +105,22 @@ const tooltip = {
 	 */
 	hide: function(): void {
 		const $$ = this.internal;
+		const {state: {inputType}, $el: {tooltip}} = $$;
+		const data = tooltip && tooltip.datum();
+
+		if (data) {
+			const {index} = JSON.parse(data.current)[0];
+
+			// make to finalize, possible pending event flow set from '.tooltip.show()' call
+			(inputType === "mouse" ?
+				["mouseout"] : ["touchend"]
+			).forEach(eventName => {
+				$$.dispatchEvent(eventName, index);
+			});
+		}
 
 		// reset last touch point index
-		$$.inputType === "touch" && $$.callOverOutForTouch();
+		inputType === "touch" && $$.callOverOutForTouch();
 
 		$$.hideTooltip(true);
 		$$.hideGridFocus();

--- a/src/ChartInternal/internals/tooltip.ts
+++ b/src/ChartInternal/internals/tooltip.ts
@@ -419,15 +419,16 @@ export default {
 		if (config.tooltip_linked && charts.length > 1) {
 			const linkedName = config.tooltip_linked_name;
 
-			charts.forEach(c => {
-				if (c !== $$.api) {
+			charts
+				.filter(v => v !== $$.api)
+				.forEach(c => {
 					const {config, $el} = c.internal;
 					const isLinked = config.tooltip_linked;
 					const name = config.tooltip_linked_name;
 					const isInDom = document.body.contains($el.chart.node());
 
 					if (isLinked && linkedName === name && isInDom) {
-						const data = c.internal.$el.tooltip.data()[0];
+						const data = $el.tooltip.data()[0];
 						const isNotSameIndex = index !== (data && data.index);
 
 						// prevent throwing error for non-paired linked indexes
@@ -439,8 +440,7 @@ export default {
 							}
 						} catch (e) {}
 					}
-				}
-			});
+				});
 		}
 	}
 };

--- a/test/api/tooltip-spec.ts
+++ b/test/api/tooltip-spec.ts
@@ -82,6 +82,16 @@ describe("API tooltip", () => {
 
 			expect(tooltip.style("display")).to.be.equal("none");
 		});
+
+		it("tooltip should be shown for same index after: show() -> hide() -> show()", () => {
+			const index = 3;
+
+			chart.tooltip.show({index});
+			chart.tooltip.hide();
+			chart.tooltip.show({index});
+
+			expect(chart.$.tooltip.style("display")).to.be.equal("block");
+		});
 	});
 
 	describe("for multiple x", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1753

## Details
<!-- Detailed description of the change/feature -->
- When call tooltip.hide(), dispatch 'mouseend' or 'touchend' event to
  remove possible pending event from tooltip.show()
- update handling linked charts instances by filtering

