### PR TITLE
fix(zoom): fix throwing TypeError during zoom

### DIFF
--- a/src/Chart/api/tooltip.ts
+++ b/src/Chart/api/tooltip.ts
@@ -111,8 +111,9 @@ const tooltip = {
 
 		$$.hideTooltip(true);
 		$$.hideGridFocus();
-		$$.unexpandCircles();
-		$$.unexpandBars();
+
+		$$.unexpandCircles && $$.unexpandCircles();
+		$$.unexpandBars && $$.unexpandBars();
 	}
 };
 

--- a/test/esm/bar-spec.ts
+++ b/test/esm/bar-spec.ts
@@ -6,7 +6,7 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import sinon from "sinon";
-import bb, {bar} from "../../src/index.esm";
+import bb, {bar, zoom} from "../../src/index.esm";
 
 // for ESM test, import helper rather than util
 import {getBBox, fireEvent} from "../assets/helper";
@@ -62,5 +62,15 @@ describe("ESM bar", function() {
         }
 
         expect(true).to.be.true;
+    });
+
+    it("set options zoom.enabled=true", () => {
+        args.zoom = {
+            enabled: zoom()
+        };
+    });
+
+    it("shouldn't throw error during zoom", () => {
+        expect(chart.zoom([0,1])).to.not.throw;
     });
 });

--- a/test/esm/line-spec.ts
+++ b/test/esm/line-spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+/* global describe, beforeEach, it, expect */
+import {expect} from "chai";
+import bb, {line, zoom} from "../../src/index.esm";
+
+describe("ESM line", function() {
+    let chart;
+
+    const args: any = {
+        data: {
+            columns: [
+                ["data1", 30, 350, 300, 0, 100],
+                ["data2", 200, 100, 140, 200, 150]
+            ],
+            type: line()
+        },
+        zoom: {
+            enabled: zoom()
+        }
+    };
+    
+	beforeEach(() => {
+		chart = bb.generate(args);
+	});
+
+    it("shouldn't throw error during zoom", () => {
+        expect(chart.zoom([0,1])).to.not.throw;
+    });
+});


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1760

## Details
<!-- Detailed description of the change/feature -->
The call of tooltip.hide(), unexpad of circles & bars internal methods are called.
They're extended when line() or bar() modules are imported and called for esm env.