### PR TITLE
fix(api): fix tooltip showing when lesser data loaded

### DIFF
--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -275,6 +275,9 @@ export default {
 		const {eventReceiver} = state;
 		const call: any = (fn, v) => (isFunction(fn) ? fn(v) : fn);
 
+		// reset for possible remains coords data before the data loading
+		eventReceiver.coords.splice(eventReceiver.data.length);
+
 		eventReceiver.data.forEach((d, i) => {
 			eventReceiver.coords[i] = {
 				x: call(x, d),

--- a/test/api/load-spec.ts
+++ b/test/api/load-spec.ts
@@ -523,4 +523,27 @@ describe("API load", function() {
 			}, 500);
 		});
 	});
+
+	describe("should handle correct event rect lengths", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 130, 100, 140, 200, 150]
+					]
+				}
+			};
+		});
+
+		it("should updating correct event rect length when loaded new data are lesser", done => {
+			chart.load({
+				columns: [["data1", 100, 200]],
+				unload: true,
+				done: function() {
+					expect(this.internal.state.eventReceiver.coords.length).to.be.equal(2);
+					done();
+				}
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1761

## Details
<!-- Detailed description of the change/feature -->
When .updateEventRectData() is called, reset eventReceiver
coords data length to prevent incorrect coords length setting.