### PR TITLE
fix(shape): shape not showing on ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
 		"optimize-css-assets-webpack-plugin": "^5.0.4",
 		"regenerator-runtime": "^0.13.7",
 		"rollup": "^2.32.1",
-		"sass-loader": "^10.0.4",
+		"sass-loader": "^10.0.5",
 		"semantic-release": "^17.2.1",
 		"simulant": "^0.2.2",
 		"sinon": "^9.2.0",

--- a/src/Chart/api/show.ts
+++ b/src/Chart/api/show.ts
@@ -22,10 +22,14 @@ function showHide(show: boolean, targetIdsValue: string[], options: any): void {
 	const targets = $$.$el.svg.selectAll($$.selectorTargets(targetIds));
 	const opacity = show ? "1" : "0";
 
+	show && targets.style("display", null);
+
 	targets.transition()
 		.style("opacity", opacity, "important")
 		.call(endall, () => {
-			targets.style("opacity", null).style("opacity", opacity);
+			// https://github.com/naver/billboard.js/issues/1758
+			!show && targets.style("display", "none");
+			targets.style("opacity", opacity);
 		});
 
 	options.withLegend && $$[`${show ? "show" : "hide"}Legend`](targetIds);

--- a/test/api/show-spec.ts
+++ b/test/api/show-spec.ts
@@ -79,6 +79,27 @@ describe("API show", () => {
 				done();
 			}, 500);
 		});
+
+		// https://github.com/naver/billboard.js/issues/1758
+		it("hidden target display should be 'none' when is hidden", done => {
+			before(() => {
+				args.data.type = "bar";
+			});
+
+			after(() => {
+				args.data.type = "line";
+			});
+
+			// when
+			chart.hide("data1");
+
+			setTimeout(() => {
+				expect(
+					chart.$.main.select(`.${CLASS.target}-data1`).style("display")
+				).to.be.equal("none");
+				done();
+			}, 500);
+		})
 	});
 
 	describe("show()", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1758

## Details
<!-- Detailed description of the change/feature -->
When dataseries is hidden, set 'display:none' to fix
certain data values of bar shape is not correctly shown
on ie11.