### PR TITLE
Fix some bugs and side effects in XAxisTickAutorotate + optimizations

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1239,17 +1239,20 @@ var demos = {
 								autorotate: true,
 								rotate: 15,
 								culling: false
-							}
+							},
+							clipPath: false
 						}
 					}
 				},
 				func: function(chart) {
 					chart.timer = [
-setTimeout(function() {
-	chart.resize({width: window.innerWidth * 0.4});
-}, 1000),
+						setTimeout(function() {
+							chart.resize({width: window.innerWidth * 0.4});
+						}, 1000),
 
-setTimeout(function() {chart.resize();}, 3000)
+						setTimeout(function() {
+							chart.resize();
+						}, 3000)
 					];
 				}
 			},
@@ -1294,6 +1297,7 @@ setTimeout(function() {chart.resize();}, 3000)
 					},
 					axis: {
 						x: {
+							type: "timeseries",
 							tick: {
 								fit: true,
 								multiline: false,
@@ -1303,16 +1307,19 @@ setTimeout(function() {chart.resize();}, 3000)
 								count: 8,
 								format: "%m-%d-%Y %H:%M:%S"
 							},
-							type: "timeseries"
+							clipPath: false
 						}
 					}
 				},
 				func: function(chart) {
 					chart.timer = [
-setTimeout(function() {
-	chart.resize({width: window.innerWidth * 0.4});
-}, 1000),
-setTimeout(function() {chart.resize();}, 3000)
+						setTimeout(function() {
+							chart.resize({width: window.innerWidth * 0.4});
+						}, 1000),
+						
+						setTimeout(function() {
+							chart.resize();
+						}, 3000)
 					];
 				}
 			}

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -698,9 +698,13 @@ class Axis {
 			maxOverflow = Math.max(maxOverflow, overflow);
 		}
 
+		const filteredTargets = $$.filterTargetsToShow($$.data.targets);
 		let tickOffset = 0;
 
-		if (!isTimeSeries && maxOverflow) {
+		if (
+			!isTimeSeries &&
+			config.axis_x_tick_count <= filteredTargets.length && filteredTargets[0].values.length
+		) {
 			const scale = getScale($$.axis.getAxisType("x"), 0, widthWithoutCurrentPaddingLeft - maxOverflow)
 				.domain([
 					left * -1,

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -576,10 +576,13 @@ class Axis {
 			const scale = $$.scale[id].copy().domain($$[`get${isYAxis ? "Y" : "X"}Domain`](targetsToShow, id));
 			const domain = scale.domain();
 
-			// do not compute if domain is same
-			if ((domain[0] === domain[1] && domain.every(v => v > 0)) ||
-				(isArray(currentTickMax.domain) && currentTickMax.domain[0] === currentTickMax.domain[1])
-			) {
+			const isDomainSame = domain[0] === domain[1] && domain.every(v => v > 0);
+			const isCurrentMaxTickDomainSame = isArray(currentTickMax.domain) &&
+				currentTickMax.domain[0] === currentTickMax.domain[1] &&
+				currentTickMax.domain.every(v => v > 0);
+
+			// do not compute if domain or currentMaxTickDomain is same
+			if (isDomainSame || isCurrentMaxTickDomainSame) {
 				return currentTickMax.size;
 			} else {
 				currentTickMax.domain = domain;

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -585,6 +585,10 @@ class Axis {
 				currentTickMax.domain = domain;
 			}
 
+			if (!isYAxis) {
+				currentTickMax.ticks = [];
+			}
+
 			const axis = this.getAxis(id, scale, false, false, true);
 			const tickCount = config[`axis_${id}_tick_count`];
 			const tickValues = config[`axis_${id}_tick_values`];
@@ -618,7 +622,7 @@ class Axis {
 
 					maxWidth = Math.max(maxWidth, currentTextWidth);
 					// cache tick text width for getXAxisTickTextY2Overflow()
-					if (id === "x") {
+					if (!isYAxis) {
 						currentTickMax.ticks[i] = currentTextWidth;
 					}
 				});
@@ -693,7 +697,7 @@ class Axis {
 
 		let tickOffset = 0;
 
-		if (!isTimeSeries) {
+		if (!isTimeSeries && maxOverflow) {
 			const scale = getScale($$.axis.getAxisType("x"), 0, widthWithoutCurrentPaddingLeft - maxOverflow)
 				.domain([
 					left * -1,
@@ -729,10 +733,15 @@ class Axis {
 			const timeDiff = lastX - firstX;
 
 			const range = timeDiff + padding.left + padding.right;
-			const relativeTickWidth = (timeDiff / tickCount) / range;
+			let left = 0;
+			let right = 0;
 
-			const left = padding.left / range / relativeTickWidth || 0;
-			const right = padding.right / range / relativeTickWidth || 0;
+			if (tickCount && range) {
+				const relativeTickWidth = (timeDiff / tickCount) / range;
+
+				left = padding.left / range / relativeTickWidth;
+				right = padding.right / range / relativeTickWidth;
+			}
 
 			padding = {left, right};
 		}

--- a/src/ChartInternal/internals/size.axis.ts
+++ b/src/ChartInternal/internals/size.axis.ts
@@ -99,10 +99,20 @@ export default {
 			const isCategorized = axis.isCategorized();
 			const isTimeSeries = axis.isTimeSeries();
 			const allowedXAxisTypes = isCategorized || isTimeSeries;
-			let tickCount = 0;
 
 			if (config.axis_x_tick_fit && allowedXAxisTypes) {
-				tickCount = state.current.maxTickWidths.x.ticks.length + (isTimeSeries ? -1 : 1);
+				const currentXTicksLength = state.current.maxTickWidths.x.ticks.length;
+				let tickCount = 0;
+
+				if (config.axis_x_tick_count) {
+					if (config.axis_x_tick_count > currentXTicksLength) {
+						tickCount = currentXTicksLength;
+					} else {
+						tickCount = config.axis_x_tick_count;
+					}
+				} else if (currentXTicksLength) {
+					tickCount = currentXTicksLength;
+				}
 
 				if (tickCount !== state.axis.x.tickCount) {
 					state.axis.x.padding = $$.axis.getXAxisPadding(tickCount);
@@ -140,7 +150,7 @@ export default {
 			axis.x.padding.left + axis.x.padding.right;
 
 		const maxTickWidth = $$.axis.getMaxTickWidth("x");
-		const tickLength = (xAxisLength / tickCountWithPadding) || 0;
+		const tickLength = tickCountWithPadding ? xAxisLength / tickCountWithPadding : 0;
 
 		return maxTickWidth > tickLength;
 	}

--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -251,6 +251,10 @@ export default {
 			height: legend ? $$.getLegendHeight() : 0
 		};
 
+		if (!hasArc && config.axis_x_show && config.axis_x_tick_autorotate) {
+			$$.updateXAxisTickClip();
+		}
+
 		const legendHeightForBottom = state.isLegendRight || state.isLegendInset ? 0 : currLegend.height;
 		const xAxisHeight = isRotated || hasArc ? 0 : $$.getHorizontalAxisHeight("x");
 
@@ -335,10 +339,6 @@ export default {
 
 		if (state.isLegendRight && hasArc) {
 			state.margin3.left = state.arcWidth / 2 + state.radiusExpanded * 1.1;
-		}
-
-		if (!hasArc && config.axis_x_show && config.axis_x_tick_autorotate) {
-			$$.updateXAxisTickClip();
 		}
 	}
 };

--- a/src/config/Options/axis/x.ts
+++ b/src/config/Options/axis/x.ts
@@ -312,7 +312,7 @@ export default {
 	 *   - axis.x.tick.multiline=false
 	 *   - axis.x.tick.culling=false
 	 *   - axis.x.tick.fit=true
-	 * - **NOTE:** axis.x.tick.clippath=true is necessary for calculating the overflow padding between the end of x axis and the width of the SVG
+	 * - **NOTE:** axis.x.tick.clippath=false is necessary for calculating the overflow padding between the end of x axis and the width of the SVG
 	 * @name axis․x․tick․autorotate
 	 * @memberof Options
 	 * @type {boolean}
@@ -328,7 +328,7 @@ export default {
 	 *       culling: false,
 	 *       fit: true
 	 *     },
-	 *     clipPath: true
+	 *     clipPath: false
 	 *   }
 	 * }
 	 */

--- a/src/config/Options/axis/x.ts
+++ b/src/config/Options/axis/x.ts
@@ -312,6 +312,7 @@ export default {
 	 *   - axis.x.tick.multiline=false
 	 *   - axis.x.tick.culling=false
 	 *   - axis.x.tick.fit=true
+	 * - **NOTE:** axis.x.tick.clippath=true is necessary for calculating the overflow padding between the end of x axis and the width of the SVG
 	 * @name axis․x․tick․autorotate
 	 * @memberof Options
 	 * @type {boolean}
@@ -326,7 +327,8 @@ export default {
 	 *       multiline: false,
 	 *       culling: false,
 	 *       fit: true
-	 *     }
+	 *     },
+	 *     clipPath: true
 	 *   }
 	 * }
 	 */

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -1128,7 +1128,8 @@ describe("AXIS", function() {
 								centered: false,
 								culling: false,
 								multiline: false
-							}
+							},
+							clipPath: false
 						}
 					}
 				};
@@ -1172,13 +1173,13 @@ describe("AXIS", function() {
 						expect(tspan.attr("dx")).to.be.equal("2.070552360820166");
 					});
 
-				compare(15, 45.525421142578125, 56.82012354874871, 109.4987923936019)
+				compare(15, 45, 56, 71)
 			});
 
-			it("should resize when all data hidden", () => {
+			it("should not resize x axis when all data hidden", () => {
 				chart.hide("data1");
 
-				compare(args.axis.x.tick.rotate, 6, 57, 110);
+				compare(args.axis.x.tick.rotate, 6, 57, 71);
 
 				chart.show("data1");
 			});
@@ -1218,15 +1219,15 @@ describe("AXIS", function() {
 				});
 
 				it("should be above 0 if rotated", () => {
-					compareOverflow(109.4987923936019);
+					compareOverflow(71);
 				});
 
 				it("update config", () => {
 					args.axis.x.padding = {right: 2};
 				});
 
-				it("should be defaultPadding + tickOffset if padding right is set", () => {
-					compareOverflow(defaultPadding + 33);
+				it("should be defaultPadding if padding right is set", () => {
+					compareOverflow(defaultPadding);
 				});
 
 				it("update config", () => {
@@ -1234,15 +1235,15 @@ describe("AXIS", function() {
 				});
 
 				it("should be above defaultPadding if padding left is set", () => {
-					compareOverflow( 109.38116563068422);
+					compareOverflow( 80);
 				});
 
 				it("update config", () => {
 					args.axis.x.padding = {left: 2, right: 2};
 				});
 
-				it("should be above defaultPadding if padding is set", () => {
-					compareOverflow(37);
+				it("should be equal to defaultPadding if padding is set", () => {
+					compareOverflow(defaultPadding);
 				});
 			});
 
@@ -1282,6 +1283,7 @@ describe("AXIS", function() {
 								count: 5,
 								format: "%Y-%m-%d %H:%M:%S",
 							},
+							clipPath: false
 						}
 					}
 				};
@@ -1319,7 +1321,7 @@ describe("AXIS", function() {
 				compare(15, 45.145263671875, 56.439983076254386, 108.67536019184263)
 			});
 
-			it("should resize when all data hidden", () => {
+			it("should not resize x axis when all data hidden", () => {
 				chart.hide("Temperature");
 
 				compare(args.axis.x.tick.rotate, 6, 57, 108);

--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -242,6 +242,7 @@ export interface XTickConfiguration {
 	 *   - axis.x.tick.multiline=false
 	 *   - axis.x.tick.culling=false
 	 *   - axis.x.tick.fit=true
+	 * - **NOTE:** axis.x.tick.clippath=true is necessary for calculating the overflow padding between the end of x axis and the width of the SVG
 	 */
 	autorotate?: boolean;
 

--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -242,7 +242,7 @@ export interface XTickConfiguration {
 	 *   - axis.x.tick.multiline=false
 	 *   - axis.x.tick.culling=false
 	 *   - axis.x.tick.fit=true
-	 * - **NOTE:** axis.x.tick.clippath=true is necessary for calculating the overflow padding between the end of x axis and the width of the SVG
+	 * - **NOTE:** axis.x.tick.clippath=false is necessary for calculating the overflow padding between the end of x axis and the width of the SVG
 	 */
 	autorotate?: boolean;
 


### PR DESCRIPTION
## Issue
#1786

## Details
See description of #1786.

### fix(axis): rotated horizontal xAxisHeight is calculated correctly after loading new data

'maxTickWidths.x.ticks' have to be cached before calculating xAxisHeight
for correct xAxisHeight calculation.
By updating XAxisTickClip BEFORE calculating xAxisHeight we can make use of a side
effect, which will cache 'maxTickWidths.x.ticks'.
The side effect is caused by following call stack:
updateXAxisTickClip() --> getHorizontalAxisHeight() --> $$.axis.getMaxTickWidth()
In this case, 'maxTickWidths.x.ticks' will be calculated and cached, and XAxisTickClip
will be updated.

### fix(axis): getXAxisTickTextY2Overflow is now calculated correctly

Empty 'maxTickWidths.x.ticks' before recalculation to prevent keeping old state
after new data is loaded into the chart.

Added 'axis_x_tick_count' for tick count calculation in 'getAxisTickRotate()' as
setting tick count manually would break the autorotation.

Added extra checks for places in the code where values could have been divided by
zero to avoid runtime errors.

Added extra condition for tick offset calculation.

### fix(axis): removed state mismatch due to wrong conditions in 'getMaxTickWidth'

There was a missing check if every 'currentTicksMax.domain' is greater than zero.
Due to this, if new data was laoded with 'unload: true' it could happen, that
'currentTicksMax.domain' would be [0,0].
In this case, even if the domain is not same, it would always result in returning
'currentTicksMax.size'and not updating 'currentTicksMax.domain' which resulted
in not updating the rotation on x axis.

### fix(axis): optimized tick offset calculation in 'getXAxisTickMaxOverflow'

Calculating tick offset is only necessary when setting 'axis_x_tick_count'
on x axis type 'category'.
It should be calculated only if lower or equal than the actual amount of
filtered targets that should have been shown.

### skip: updated tests
### skip: updated demo
### skip: updated docs
