### PR TITLE
fix(browser): fix referencing global order

### DIFF
--- a/src/module/browser.ts
+++ b/src/module/browser.ts
@@ -12,7 +12,9 @@ export {win as window, doc as document};
 const win = (() => {
 	const def = o => typeof o !== "undefined" && o;
 
-	return def(self) || def(window) || def(global) || def(globalThis) || Function("return this")();
+	// Prioritize referencing Node.js global first to prevent refence error
+	// https://github.com/naver/billboard.js/issues/1778
+	return def(global) || def(globalThis) || def(self) || def(window) || Function("return this")();
 })();
 /* eslint-enable no-new-func, no-undef */
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1778

## Details
<!-- Detailed description of the change/feature -->
Prioritize referencing Node.js' global to prevent reference error for some environment.
```
// the reference order when the prior is undefined.
global -> globalThis -> self -> window -> this
```