### PR TITLE
refactor(eventrect): remove duplicated class value setting

### DIFF
--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -370,7 +370,6 @@ export default {
 		const {eventReceiver} = state;
 
 		const rect = eventRectEnter
-			.attr("class", $$.classEvent.bind($$))
 			.style("cursor", config.data_selection_enabled && config.data_selection_grouped ? "pointer" : null)
 			.on("click", function() {
 				const {currentIdx, data} = eventReceiver;

--- a/src/ChartInternal/internals/class.ts
+++ b/src/ChartInternal/internals/class.ts
@@ -85,10 +85,6 @@ export default {
 		return `${this.generateClass(CLASS.region, i)} ${"class" in d ? d.class : ""}`;
 	},
 
-	classEvent(d) {
-		return this.generateClass(CLASS.eventRect, d.index);
-	},
-
 	classTarget(id: string): string {
 		const additionalClassSuffix = this.config.data_classes[id];
 		let additionalClass = "";


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
fix the duplicated 'bb-event-rect' class setting to event <rect> element.

<img src=https://user-images.githubusercontent.com/2178435/103199820-19331200-492f-11eb-95fe-37b7d9986036.png width=700>
