### PR TITLE
fix(eventrect): fix resizing event rect element after .load()

### DIFF
--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -34,7 +34,7 @@ export default {
 		const isMultipleX = $$.isMultipleX();
 
 		if ($el.eventRect) {
-			$$.updateEventRect($el.eventRect);
+			$$.updateEventRect($el.eventRect, true);
 		} else {
 			const eventRects = $$.$el.main.select(`.${CLASS.eventRects}`)
 				.style("cursor", config.zoom_enabled && config.zoom_type !== "drag" ? (
@@ -169,7 +169,13 @@ export default {
 		});
 	},
 
-	updateEventRect(eventRect?): void {
+	/**
+	 * Update event rect size
+	 * @param {d3Selection} eventRect Event <rect> element
+	 * @param {boolean} force Force to update
+	 * @private
+	 */
+	updateEventRect(eventRect?, force = false): void {
 		const $$ = this;
 		const {state, $el} = $$;
 		const {eventReceiver, width, height, rendered, resizing} = state;
@@ -181,7 +187,7 @@ export default {
 			);
 		};
 
-		if (!rendered || resizing) {
+		if (!rendered || resizing || force) {
 			rectElement
 				.attr("x", 0)
 				.attr("y", 0)

--- a/test/api/load-spec.ts
+++ b/test/api/load-spec.ts
@@ -461,6 +461,59 @@ describe("API load", function() {
 				}
 			});
 		});
+
+		it("set options", () => {
+			args = {
+				axis: {
+					x: {
+					  categories: [
+						"xxxx PREFIX: column1",
+						"xxxxxx PREFIX: column2",
+						"x PREFIX: column3",
+						"xx PREFIX: column4",
+						"PREFIX: column5"
+					  ],
+					  tick: {
+						rotate: 15,
+						autorotate: true,
+						multiline: false,
+						culling: false,
+						fit: true
+					  },
+					  clipPath: false,
+					  type: "category"
+					},
+					y2: {
+					  show: true
+					}
+				},
+				data: {
+					columns: [
+						["series", 33200000, 24000000, 4280000, 16000, -155000]
+					],
+					type: "line"
+				}
+			}	
+		});
+
+		it("event rect size should update after .load() is called", done => {
+			// when
+			chart.load({
+				columns: [
+					["data1", 130, 120, 150, 140, 160, 150],
+					["data4", 30, 20, 50, 40, 60, 50]
+				],
+				unload: true,
+				done: function() {
+					const {internal: {$el, state}} = this;
+
+					expect(+$el.eventRect.attr("width")).to.be.equal(state.width);
+					expect(+$el.eventRect.attr("height")).to.be.equal(state.height);
+
+					done();
+				}
+			});
+		});
 	});
 
 	describe("different type loading", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1864

## Details
<!-- Detailed description of the change/feature -->
Force to update event rect size when .redrawEventRect() is called.