### PR TITLE
fix(text): data labels are working in Internet Explorer again

### DIFF
--- a/src/ChartInternal/internals/text.ts
+++ b/src/ChartInternal/internals/text.ts
@@ -144,7 +144,7 @@ export default {
 						const posY = y.bind(this)(d, index);
 
 						// when is multiline
-						if (this.children.length) {
+						if (this.childElementCount) {
 							this.setAttribute("transform", `translate(${posX} ${posY})`);
 						} else {
 							this.setAttribute("x", posX);


### PR DESCRIPTION
## Issue
#1877

## Details
See #1877
