### PR TITLE
feat(api): make return values for axis.labels()

### DIFF
--- a/src/Chart/api/axis.ts
+++ b/src/Chart/api/axis.ts
@@ -65,6 +65,7 @@ const axis = {
 	 * @param {string} [labels.x] x Axis string
 	 * @param {string} [labels.y] y Axis string
 	 * @param {string} [labels.y2] y2 Axis string
+	 * @returns {object|undefined} axis labels text object
 	 * @example
 	 * // Update axis' label
 	 * chart.axis.labels({
@@ -72,17 +73,36 @@ const axis = {
 	 *   y: "New Y Axis Label",
 	 *   y2: "New Y2 Axis Label"
 	 * });
+	 *
+	 * chart.axis.labels();
+	 * // --> {
+	 * //  x: "New X Axis Label",
+	 * //  y: "New Y Axis Label",
+	 * //  y2: "New Y2 Axis Label"
+	 * // }
 	 */
-	labels: function(labels: {x?: string, y?: string, y2?: string}): void {
+	labels: function<T>(labels?: {x?: string, y?: string, y2?: string}): T | undefined {
 		const $$ = this.internal;
+		let labelText;
 
-		if (arguments.length) {
+		if (labels) {
 			Object.keys(labels).forEach(axisId => {
 				$$.axis.setLabelText(axisId, labels[axisId]);
 			});
 
 			$$.axis.updateLabels();
 		}
+
+		["x", "y", "y2"].forEach(v => {
+			const text = $$.axis.getLabelText(v);
+
+			if (text) {
+				!labelText && (labelText = {});
+				labelText[v] = text;
+			}
+		});
+
+		return <T>labelText;
 	},
 
 	/**

--- a/test/api/axis-spec.ts
+++ b/test/api/axis-spec.ts
@@ -7,6 +7,7 @@ import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
 import CLASS from "../../src/config/classes";
+import axis from "../../src/Chart/api/axis";
 
 describe("API axis", function() {
 	const chart = util.generate({
@@ -22,7 +23,6 @@ describe("API axis", function() {
 		},
 		axis: {
 			y: {
-				label: "Y Axis Label",
 				padding: {
 					bottom: 0
 				}
@@ -38,9 +38,12 @@ describe("API axis", function() {
 
 	describe("axis.labels()", () => {
 		it("should update y axis label", done => {
-			chart.axis.labels({
+			const axisLabel = {
 				y: "New Y Axis Label"
-			});
+			};
+
+			// when
+			const labels = chart.axis.labels(axisLabel);
 
 			setTimeout(() => {
 				const label = main.select(`.${CLASS.axisYLabel}`);
@@ -49,11 +52,17 @@ describe("API axis", function() {
 				expect(label.attr("dx")).to.be.equal("-0.5em");
 				expect(label.attr("dy")).to.be.equal("1.2em");
 
+				expect(labels).to.be.deep.equal({
+					y: axisLabel.y,
+					y2: "Y2 Axis Label"
+				});
+
 				done();
 			}, 500);
 		});
 
 		it("should update y axis label", done => {
+			// when
 			chart.axis.labels({
 				y2: "New Y2 Axis Label"
 			});
@@ -67,6 +76,13 @@ describe("API axis", function() {
 
 				done();
 			}, 500);
+		});
+
+		it("should return axis labels", () => {
+			expect(chart.axis.labels()).to.be.deep.equal({
+				y: 'New Y Axis Label',
+				y2: 'New Y2 Axis Label'
+			});
 		});
 	});
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1865

## Details
<!-- Detailed description of the change/feature -->
The API description states return values, but it wasn't.
Make return axis' label text object when .axis.labels() is called.

```js
const chart = bb.generate({
  axis: {
    x: {
       label: "X Label"
    },
});

// before
chart.axis.labels({y: "Y Axis Label"));
//--> does not return any value

// after
chart.axis.labels();
//--> {x: "X Label"}

chart.axis.labels({y: "Y Axis Label"));
//--> {x: "X Label", y: "Y Axis Label"}
```