### PR TITLE
fix(api): fix incorrect legend text positioning

### DIFF
--- a/src/Chart/api/data.ts
+++ b/src/Chart/api/data.ts
@@ -3,7 +3,6 @@
  * billboard.js project is licensed under the MIT license
  */
 import {DataItem} from "../../../types/types";
-import {KEY} from "../../module/Cache";
 import {extend, isUndefined, isArray} from "../../module/util";
 
 type dataParam = {x: number, value: number, id: string, index: number}[];
@@ -114,9 +113,6 @@ extend(data, {
 	 */
 	names: function(names?: Array<{ [key: string]: string; }>): {[key: string]: string} {
 		const $$ = this.internal;
-
-		// reset existing legend item dimension cache data
-		$$.cache.remove(KEY.legendItemTextBox);
 
 		return $$.updateDataAttributes("names", names);
 	},

--- a/src/ChartInternal/internals/legend.ts
+++ b/src/ChartInternal/internals/legend.ts
@@ -354,14 +354,14 @@ export default {
 	 */
 	getLegendItemTextBox(id?: string, textElement?) {
 		const $$ = this;
-		const {cache} = $$;
+		const {cache, state} = $$;
 		let data;
 
 		// do not prefix w/'$', to not be resetted cache in .load() call
 		const cacheKey = KEY.legendItemTextBox;
 
 		if (id) {
-			data = cache.get(cacheKey) || {};
+			data = (!state.redrawing && cache.get(cacheKey)) || {};
 
 			if (!data[id]) {
 				data[id] = $$.getTextRect(textElement, CLASS.legendItem);
@@ -479,6 +479,7 @@ export default {
 			const reset = index === 0;
 			const isLast = index === targetIdz.length - 1;
 			const box = $$.getLegendItemTextBox(id, textElement);
+
 			const itemWidth = box.width + tileWidth +
 				(isLast && !isLegendRightOrInset ? 0 : paddingRight) + config.legend_padding;
 			const itemHeight = box.height + paddingTop;

--- a/src/ChartInternal/internals/redraw.ts
+++ b/src/ChartInternal/internals/redraw.ts
@@ -12,8 +12,10 @@ export default {
 		const $$ = this;
 		const {config, state, $el} = $$;
 		const {main} = $el;
-		const targetsToShow = $$.filterTargetsToShow($$.data.targets);
 
+		state.redrawing = true;
+
+		const targetsToShow = $$.filterTargetsToShow($$.data.targets);
 		const initializing = options.initializing;
 		const flow = options.flow;
 		const wth = $$.getWithOption(options);
@@ -139,6 +141,8 @@ export default {
 		// callback function after redraw ends
 		const afterRedraw = flow || config.onrendered ? () => {
 			flowFn && flowFn();
+
+			state.redrawing = false;
 			callFn(config.onrendered, $$.api);
 		} : null;
 

--- a/src/config/Store/State.ts
+++ b/src/config/Store/State.ts
@@ -113,6 +113,7 @@ export default class State {
 			mouseover: false,
 			rendered: false,
 			transiting: false,
+			redrawing: false, // if redraw() is on process
 			resizing: false, // resize event called
 			toggling: false, // legend toggle
 			zooming: false,

--- a/test/api/data-spec.ts
+++ b/test/api/data-spec.ts
@@ -140,23 +140,39 @@ describe("API data", function() {
 		});
 
 		it("should return data.names specified as API", () => {
-			const results = chart.data.names({
-				data: "New Data Name 1",
-				data2: "New Data Name 2"
+			const legendText = {
+				data: "New New Data Name Value 1",
+				data2: "New New Data Name Value 2",
+			};
+			const pos = {};
+			const updatedPos = {};
+
+			chart.$.legend.selectAll("g").each(function(id) {
+				pos[id] = [
+					+this.querySelector("text").getAttribute("x"),
+					+this.querySelector("rect").getAttribute("x")
+				];
 			});
 
-			expect(results.data).to.be.equal("New Data Name 1");
-			expect(results.data2).to.be.equal("New Data Name 2");
-		});
+			// when
+			const results = chart.data.names(legendText);
 
-		it("should set data.names specified as API", () => {
-			const svg = chart.$.svg;
+			chart.$.legend.selectAll("g").each(function(id) {
+				const text = this.querySelector("text");
 
-			expect(svg.select(`.${CLASS.legendItem}-data text`).text())
-				.to.be.equal("New Data Name 1");
+				expect(results[id]).to.be.equal(text.textContent);
 
-			expect(svg.select(`.${CLASS.legendItem}-data2 text`).text())
-				.to.be.equal("New Data Name 2");
+				updatedPos[id] = [
+					+text.getAttribute("x"),
+					+this.querySelector("rect").getAttribute("x")
+				];
+			});
+
+			expect(results).to.be.deep.equal(legendText);
+
+			Object.keys(updatedPos).forEach(id => {
+				expect(updatedPos[id].every((v, i) => v >= pos[id][i])).to.be.true;
+			});
 		});
 	});
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1888

## Details
<!-- Detailed description of the change/feature -->
Issue caused by the use of cached legend dimension value.
To avoid the use of cache, added redraw state value,
to not take cached value during the redraw process.