### PR TITLE
feat(data.labels.colors): Add callback support

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2138,6 +2138,21 @@ var demos = {
 						}
 					}
 				}
+			},
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 100, 150, 300],
+							["data2", 130, 210, 140],
+							["data3", 220, 150, 50]
+						],
+						type: "bar",
+						labels: {
+							colors: function(color, d) { return d.value > 200 ? "cyan" : color; }
+						}
+					}
+				}
 			}
 		],
 		DataLabelFormat: {

--- a/src/ChartInternal/internals/text.ts
+++ b/src/ChartInternal/internals/text.ts
@@ -8,7 +8,7 @@ import {
 } from "d3-selection";
 import {KEY} from "../../module/Cache";
 import CLASS from "../../config/classes";
-import {capitalize, getBoundingRect, getRandom, isNumber, isObject, isString, getTranslation, setTextValue} from "../../module/util";
+import {capitalize, getBoundingRect, getRandom, isFunction, isNumber, isObject, isString, getTranslation, setTextValue} from "../../module/util";
 import {AxisType} from "../../../types/types";
 
 
@@ -100,6 +100,7 @@ export default {
 	updateTextColor(d): null | object | string {
 		const $$ = this;
 		const labelColors = $$.config.data_labels_colors;
+		const defaultColor = $$.isArcType(d) && !$$.isRadarType(d) ? null : $$.color(d);
 		let color;
 
 		if (isString(labelColors)) {
@@ -108,11 +109,11 @@ export default {
 			const {id} = d.data || d;
 
 			color = labelColors[id];
+		} else if (isFunction(labelColors)) {
+			color = labelColors.bind($$.api)(defaultColor, d);
 		}
 
-		return color || (
-			$$.isArcType(d) && !$$.isRadarType(d) ? null : $$.color(d)
-		);
+		return color || defaultColor;
 	},
 
 	/**

--- a/src/config/Options/data/data.ts
+++ b/src/config/Options/data/data.ts
@@ -300,7 +300,7 @@ export default {
 	 *  - `i` is the index of the data point where the label is shown.
 	 *  - `j` is the sub index of the data point where the label is shown.<br><br>
 	 * Formatter function can be defined for each data by specifying as an object and D3 formatter function can be set (ex. d3.format('$'))
-	 * @property {string|object} [data.labels.colors] Set label text colors.
+	 * @property {string|object|Function} [data.labels.colors] Set label text colors.
 	 * @property {object} [data.labels.position] Set each dataset position, relative the original.
 	 * @property {number} [data.labels.position.x=0] x coordinate position, relative the original.
 	 * @property {number} [data.labels.position.y=0] y coordinate position, relative the original.
@@ -337,11 +337,19 @@ export default {
 	 *     // apply for all label texts
 	 *     colors: "red",
 	 *
-	 *     // or set different colors per dataset
+	 *     // set different colors per dataset
 	 *     // for not specified dataset, will have the default color value
 	 *     colors: {
 	 *        data1: "yellow",
 	 *        data3: "green"
+	 *     },
+	 *
+	 *     // call back for label text color
+	 *     colors: function(color, d) {
+	 *         // color: the default data label color string
+	 *         // data: ex) {x: 0, value: 200, id: "data3", index: 0}
+	 *         ....
+	 *         return d.value > 200 ? "cyan" : color;
 	 *     },
 	 *
 	 *     // set x, y coordinate position
@@ -365,7 +373,7 @@ export default {
 			colors?: string|{[key: string]: string};
 			position?: {[key: string]: number}|{[key: string]: {x?: number; y?: number;}}
 		}> {},
-	data_labels_colors: <string|object|undefined> undefined,
+	data_labels_colors: <string|object|Function|undefined> undefined,
 	data_labels_position: {},
 
 	/**

--- a/test/internals/data-spec.ts
+++ b/test/internals/data-spec.ts
@@ -612,7 +612,7 @@ describe("DATA", () => {
 		});
 	});
 
-	describe("data.label", () => {
+	describe("data.labels", () => {
 		describe("on line chart", () => {
 			before(() => {
 				args = {
@@ -1804,6 +1804,39 @@ describe("DATA", () => {
 						expectedPos[1] + confPos[d.id].y
 					]);
 				});
+			});
+		});
+
+		describe("labels.colors callback", () => {
+			let ctx = [];
+
+			before(() => {
+				args = {
+					data: {
+						columns: [
+							["data1", 100, 150, 300],
+							["data2", 130, 210, 140],
+							["data3", 220, 150, 50]
+						],
+						labels: {
+							colors: function(color, d) {
+								ctx.push(this);
+								return d.value > 200 ? "cyan" : color;
+							}
+						}
+					}
+				}
+			});
+
+			it("callback called correctly?", () => {
+				chart.$.text.texts.each(function(d) {
+					if (d.value > 200) {
+						expect(this.style.fill).to.be.equal("cyan");
+					}
+				});
+
+				// check the data.labels.colors callback context
+				expect(ctx.every(v => v === chart)).to.be.true;
 			});
 		});
 	});

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1423,7 +1423,9 @@ export interface Data {
 		/**
 		 * Set label text colors.
 		 */
-		colors?: string | { [key: string]: string };
+		colors?: string |
+			{ [key: string]: string } |
+			((this: Chart, color: string, d: DataItem) => string);
 
 		/**
 		 * The formatter function receives 4 arguments such as v, id, i, j and it **must return a string**(`\n` character will be used as line break) that will be shown as the label.<br><br>


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1845

## Details
<!-- Detailed description of the change/feature -->
Enhance data.labels.colors option to support callback function.

```js
data: {
    labels: {
        // call back for label text color
        colors: function(color, d) {
            // color: the default data label color string
            // data: ex) {x: 0, value: 200, id: "data3", index: 0}
            ....
            return d.value > 200 ? "cyan" : color;
        }
    }
}
```