### PR TITLE
fix(gauge): units position if fullCircle

### DIFF
--- a/src/ChartInternal/shape/arc.ts
+++ b/src/ChartInternal/shape/arc.ts
@@ -847,7 +847,7 @@ export default {
 			isFullCircle && text && text.attr("dy", `${hasMultiArcGauge ? 0 : Math.round(state.radius / 14)}`);
 
 			arcs.select(`.${CLASS.chartArcsGaugeUnit}`)
-				.attr("dy", ".75em")
+				.attr("dy", config.gauge_fullCircle ? "1.5em" : ".75em")
 				.text(config.gauge_label_show ? config.gauge_units : "");
 
 			if (config.gauge_label_show) {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

Position of units if fullCircle is true.

## Details
<!-- Detailed description of the change/feature -->

Example:
```js
import "billboard.js/dist/theme/insight.css";
import bb from "billboard.js";

bb.generate({
  data: {
    columns: [
	    ["data", 91.4]
    ],
    type: "gauge"
  },
  gauge: {
    fullCircle: true,
    units: "units"
  },
  bindto: "#gaugeChart"
});
```