### PR TITLE
fix(build): suport for legacy browser

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,8 @@ const config = {
 	resolve: {
 		extensions: [".ts", ".js"]
 	},
+	// https://webpack.js.org/migrate/5/#need-to-support-an-older-browser-like-ie-11
+	target: ["web", "es5"],
 	module: {
 		rules: [
 			{


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1913

## Details
<!-- Detailed description of the change/feature -->
As of Webpack v5 transpile using ES6 syntax, needs to
add extra target configuration to support old browser.

Ref. https://webpack.js.org/migrate/5/#need-to-support-an-older-browser-like-ie-11