### PR TITLE
fix(legend): legend.inset.anchor is working again

### DIFF
--- a/src/ChartInternal/internals/size.axis.ts
+++ b/src/ChartInternal/internals/size.axis.ts
@@ -140,7 +140,7 @@ export default {
 		const $$ = this;
 		const {state: {axis, current}} = $$;
 		const xAxisLength = current.width -
-			$$.getCurrentPaddingLeft(false) - $$.getCurrentPaddingRight(true);
+			$$.getCurrentPaddingLeft(false) - $$.getCurrentPaddingRight();
 		const tickCountWithPadding = axis.x.tickCount +
 			axis.x.padding.left + axis.x.padding.right;
 

--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -88,15 +88,15 @@ export default {
 		return padding + (axisWidth * axesLen);
 	},
 
-	getCurrentPaddingRight(withoutTickTextOverflow = false): number {
+	getCurrentPaddingRight(withXAxisTickTextOverflow = false): number {
 		const $$ = this;
 		const {config, state: {hasAxis}} = $$;
 		const defaultPadding = 10;
 		const legendWidthOnRight = $$.state.isLegendRight ? $$.getLegendWidth() + 20 : 0;
 		const axesLen = hasAxis ? config.axis_y2_axes.length : 0;
 		const axisWidth = hasAxis ? $$.getAxisWidthByAxisId("y2") : 0;
-		const xAxisTickTextOverflow = withoutTickTextOverflow ?
-			0 : $$.axis.getXAxisTickTextY2Overflow(defaultPadding);
+		const xAxisTickTextOverflow = withXAxisTickTextOverflow ?
+			$$.axis.getXAxisTickTextY2Overflow(defaultPadding) : 0;
 		let padding;
 
 		if (isValue(config.padding_right)) {
@@ -266,12 +266,12 @@ export default {
 		// for main
 		state.margin = !hasArc && isRotated ? {
 			top: $$.getHorizontalAxisHeight("y2") + $$.getCurrentPaddingTop(),
-			right: hasArc ? 0 : $$.getCurrentPaddingRight(),
+			right: hasArc ? 0 : $$.getCurrentPaddingRight(true),
 			bottom: $$.getHorizontalAxisHeight("y") + legendHeightForBottom + $$.getCurrentPaddingBottom(),
 			left: subchartHeight + (hasArc ? 0 : $$.getCurrentPaddingLeft())
 		} : {
 			top: 4 + $$.getCurrentPaddingTop(), // for top tick text
-			right: hasArc ? 0 : $$.getCurrentPaddingRight(),
+			right: hasArc ? 0 : $$.getCurrentPaddingRight(true),
 			bottom: xAxisHeight + subchartHeight + legendHeightForBottom + $$.getCurrentPaddingBottom(),
 			left: hasArc ? 0 : $$.getCurrentPaddingLeft()
 		};

--- a/src/ChartInternal/internals/tooltip.ts
+++ b/src/ChartInternal/internals/tooltip.ts
@@ -266,7 +266,7 @@ export default {
 		const hasGauge = $$.hasType("gauge") && !config.gauge_fullCircle;
 		const svgLeft = $$.getSvgLeft(true);
 		let [x, y] = d3Mouse(element);
-		let chartRight = svgLeft + current.width - $$.getCurrentPaddingRight(true);
+		let chartRight = svgLeft + current.width - $$.getCurrentPaddingRight();
 		const chartLeft = $$.getCurrentPaddingLeft(true);
 		const size = 20;
 


### PR DESCRIPTION
## Issue
#1935

## Details
Refactored `getCurrentPaddingRight(withoutTickTextOverflow = false)` to `getCurrentPaddingRight(withXAxisTickTextOverflow = false)`.
From now on, if `getCurrentPaddingRight()` is called without passing parameters `xAxisTickOverflow` will be 0 and `getXAxisTickTextY2Overflow()` will only be called when x axis ticks autorotate is enabled.
