### PR TITLE
fix(axis): fix axis.x.max error throw

### DIFF
--- a/src/ChartInternal/internals/domain.ts
+++ b/src/ChartInternal/internals/domain.ts
@@ -208,7 +208,7 @@ export default {
 		const dataValue = getMinMax(type, targets.map(t => getMinMax(type, t.values.map(v => v.x))));
 		let value = isObject(configValue) ? configValue.value : configValue;
 
-		value = isDefined(value) && $$.axis.isTimeSeries() ? parseDate(value) : value;
+		value = isDefined(value) && $$.axis.isTimeSeries() ? parseDate.bind(this)(value) : value;
 
 		if (isObject(configValue) && configValue.fit && (
 			(type === "min" && value < dataValue) || (type === "max" && value > dataValue)

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -2453,6 +2453,31 @@ describe("AXIS", function() {
 				}
 			});
 		});
+
+		it("the use of axis.x.max option, shouldn't throw error", () => {
+			const args = {
+				data: {
+					x: "x",
+					columns: [
+					["x", "2013-01-01", "2013-01-02", "2013-01-03", "2013-01-04", "2013-01-05", "2013-01-06"],
+					["data1", 30, 200, 100, 400, 150, 250],
+					["data2", 130, 340, 200, 500, 250, 350]
+					],
+					type: "line", 
+				},
+				axis: {
+					x: {
+						max: "2013-01-04",
+						type: "timeseries",
+						tick: {
+							format: "%Y-%m-%d"
+						}
+					}
+				}
+			};
+
+			expect(bb.generate(args)).to.not.throw;
+		});
 	});
 
 	describe("x Axis tick width size", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1981

## Details
<!-- Detailed description of the change/feature -->
Bind the context correctly when 'parseDate' is called
within .getXDomainMinMax()