### PR TITLE
fix(axis): Fix axis.x.padding value setting

### DIFF
--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -737,29 +737,20 @@ class Axis {
 	 */
 	getXAxisPadding(tickCount) {
 		const $$ = this.owner;
-		let padding = $$.config.axis_x_padding;
-
-		if (isEmpty(padding)) {
-			padding = {left: 0, right: 0};
-		} else {
-			padding.left = padding.left || 0;
-			padding.right = padding.right || 0;
-		}
+		let {left = 0, right = 0} = $$.config.axis_x_padding;
+		let padding = {left, right};
 
 		if ($$.axis.isTimeSeries()) {
 			const firstX = +$$.getXDomainMin($$.data.targets);
 			const lastX = +$$.getXDomainMax($$.data.targets);
 			const timeDiff = lastX - firstX;
-
-			const range = timeDiff + padding.left + padding.right;
-			let left = 0;
-			let right = 0;
+			const range = timeDiff + left + right;
 
 			if (tickCount && range) {
 				const relativeTickWidth = (timeDiff / tickCount) / range;
 
-				left = padding.left / range / relativeTickWidth;
-				right = padding.right / range / relativeTickWidth;
+				left = left / range / relativeTickWidth;
+				right = right / range / relativeTickWidth;
 			}
 
 			padding = {left, right};

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -2469,6 +2469,46 @@ describe("AXIS", function() {
 			expect(tickValues.every(v => v % 1 === 0)).to.be.true;
 			expect(translateX).to.be.closeTo(30.5, 1);
 		});
+
+		it("should work with axis.x.padding=10 option", done => {
+			const option = {
+				data: {
+					x: "x",
+					columns: [
+						["x", "2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04", "2020-01-05", "2020-01-06"],
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 130, 340, 200, 500, 250, 350]
+					],
+					type: "line"
+				},
+				axis: {
+					x: {
+						type: "timeseries",
+						tick: {
+						format: "%Y-%m-%d"
+						},
+						padding: 100
+					}
+				},
+				subchart: {
+					show: true,
+					init: {
+						range: [
+							+new Date("2020-01-02 00:00:00"),
+							+new Date("2020-01-03 00:00:00")
+						]
+					}
+				},
+				onafterinit: function() {		
+					// reaching at this point, means no issue happened
+					expect(true).to.be.ok;
+
+					done();
+				}
+			};
+
+			util.generate(option);			
+		});
 	});
 
 	describe("axis min/max", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2038

## Details
<!-- Detailed description of the change/feature -->
Refactor .getXAxisPadding() to handle axis.x.padding option,
when value given is number type.