### PR TITLE
updated bar options types

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -285,7 +285,7 @@ export interface ChartOptions {
 			/**
 			 * Set the width option for specific dataset
 			 */
-			[key: string]: {
+			[key: string]: number | {
 				ratio: number;
 				max: number;
 			}


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
_none_

## Details
<!-- Detailed description of the change/feature -->
The following example [from the documentation](https://naver.github.io/billboard.js/release/latest/doc/Options.html#.bar) would throw a TS error currently:
```
// or specify width per dataset
     width: {
         data1: 20, // <---- this is currently not allowed
         data2: {
             ratio: 0.2,
             max: 20
         }
     },
```
