### PR TITLE
docs(gauge): improve description of gauge.label.format

### DIFF
--- a/src/config/Options/shape/gauge.ts
+++ b/src/config/Options/shape/gauge.ts
@@ -15,7 +15,11 @@ export default {
 	 * @property {boolean} [gauge.background=""] Set background color. (The `.bb-chart-arcs-background` element)
 	 * @property {boolean} [gauge.fullCircle=false] Show full circle as donut. When set to 'true', the max label will not be showed due to start and end points are same location.
 	 * @property {boolean} [gauge.label.show=true] Show or hide label on gauge.
-	 * @property {Function} [gauge.label.format] Set formatter for the label on gauge. Label text can be multilined with `\n` character.
+	 * @property {Function} [gauge.label.format] Set formatter for the label on gauge. Label text can be multilined with `\n` character.<br>
+	 * Will pass following arguments to the given function:
+	 * - value {number}: absolute value
+	 * - ratio {number}: value's ratio
+	 * - id {string}: data's id value
 	 * @property {Function} [gauge.label.extents] Set customized min/max label text.
 	 * @property {number} [gauge.label.threshold=0] Set threshold ratio to show/hide labels.
 	 * @property {boolean} [gauge.expand=true] Enable or disable expanding gauge.
@@ -57,7 +61,7 @@ export default {
 	 *      fullCircle: false,
 	 *      label: {
 	 *          show: false,
-	 *          format: function(value, ratio) {
+	 *          format: function(value, ratio, id) {
 	 *              return value;
 	 *
 	 *              // to multiline, return with '\n' character


### PR DESCRIPTION
Add a description of the function arguments and document the id
parameter in code example.