### PR TITLE
fix(Chart): Handle nullish properties from API extendings safely

### DIFF
--- a/src/Chart/Chart.ts
+++ b/src/Chart/Chart.ts
@@ -89,12 +89,15 @@ export default class Chart {
 			Object.keys(fn).forEach(key => {
 				const isFunc = isFunction(fn[key]);
 				const isChild = target !== argThis;
-				const hasChild = Object.keys(fn[key]).length > 0;
+				const isNotNil = fn[key] != null;
+				const hasChild = isNotNil && Object.keys(fn[key]).length > 0;
 
 				if (isFunc && ((!isChild && hasChild) || isChild)) {
 					target[key] = fn[key].bind(argThis);
-				} else if (!isFunc) {
+				} else if (isNotNil && !isFunc) {
 					target[key] = {};
+				} else {
+					target[key] = fn[key];
 				}
 
 				hasChild && bindThis(fn[key], target[key], argThis);

--- a/test/chart-spec.ts
+++ b/test/chart-spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+import {expect} from "chai";
+import {extend} from "../src/module/util";
+
+import Chart from "../src/Chart/Chart";
+
+describe("Chart", () => {
+	it("should bind correctly with nullish properties", () => {
+		const options = {
+			data: {
+				columns: [["data1", 0]]
+			}
+		};
+
+		class Extended extends Chart {
+			nullProperty;
+			voidProperty;
+		}
+
+		extend(Chart.prototype, {
+			nullProperty: null,
+			voidProperty: undefined
+		});
+
+		const extendedInstance = new Chart(options);
+
+		expect((extendedInstance as Extended).nullProperty).to.be.a("null");
+
+		expect((extendedInstance as Extended).voidProperty).to.be.an("undefined");
+	});
+});


### PR DESCRIPTION
Chart APIs having null/undefined properties should not break the chart construction now

Ref #2132

## Issue
#2132

## Details
APIs that we use to extend our base `Chart` class with might have `null` or `undefined` properties, which will fail to extend the base class. This PR ensures we care such properties safely.
