### PR TITLE
feat(api): Intent to ship append load

### DIFF
--- a/src/Chart/api/load.ts
+++ b/src/Chart/api/load.ts
@@ -22,6 +22,7 @@ export default {
 	 *    | --- | --- |
 	 *    | - url<br>- json<br>- rows<br>- columns | The data will be loaded. If data that has the same target id is given, the chart will be updated. Otherwise, new target will be added |
 	 *    | data | Data objects to be loaded. Checkout the example. |
+	 *    | append | Load data appending it to the current dataseries.<br>If the existing chart has`x` value, should provide with corresponding `x` value for newly loaded data.  |
 	 *    | names | Same as data.names() |
 	 *    | xs | Same as data.xs option  |
 	 *    | classes | The classes specified by data.classes will be updated. classes must be Object that has target id as keys. |
@@ -45,6 +46,48 @@ export default {
 	 *    unload: ["data2", "data3"],
 	 *    url: "...",
 	 *    done: function() { ... }
+	 * });
+	 * @example
+	 * const chart = bb.generate({
+	 *   data: {
+	 *     columns: [
+	 *       ["data1", 20, 30, 40]
+	 *     ]
+	 *   }
+	 * });
+	 *
+	 * chart.load({
+	 *    columns: [
+	 *        // with 'append' option, the 'data1' will have `[20,30,40,50,60]`.
+	 *        ["data1", 50, 60]
+	 *    ]
+	 *    append: true
+	 * });
+	 * @example
+	 * const chart = bb.generate({
+	 *   data: {
+	 *     x: "x",
+	 *     xFormat: "%Y-%m-%dT%H:%M:%S",
+	 *     columns: [
+	 *       ["x", "2021-01-03T03:00:00", "2021-01-04T12:00:00", "2021-01-05T21:00:00"],
+	 *       ["data1", 36, 30, 24]
+	 *     ]
+	 *   },
+	 *   axis: {
+	 *     x: {
+	 *       type: "timeseries"
+	 *     }
+	 *   }
+	 * };
+	 *
+	 * chart.load({
+	 *   columns: [
+	 *     // when existing chart has `x` value, should provide correponding 'x' value.
+	 *     // with 'append' option, the 'data1' will have `[36,30,24,37]`.
+	 *     ["x", "2021-02-01T08:00:00"],
+	 *     ["data1", 37]
+	 *   ],
+	 *   append: true
 	 * });
 	 * @example
 	 * // myAPI.json

--- a/src/ChartInternal/data/convert.ts
+++ b/src/ChartInternal/data/convert.ts
@@ -307,6 +307,11 @@ export default {
 			const hasCategory = isCategory && data.map(v => v.x)
 				.every(v => config.axis_x_categories.indexOf(v) > -1);
 
+			// when .load() with 'append' option is used for indexed axis
+			const isDataAppend = data.__append__;
+			const xIndex = xKey === null && isDataAppend ?
+				$$.api.data.values(id).length : 0;
+
 			return {
 				id: convertedId,
 				id_org: id,
@@ -320,7 +325,7 @@ export default {
 
 					// use x as categories if custom x and categorized
 					if ((isCategory || state.hasRadar) && index === 0 && !isUndefined(rawX)) {
-						if (!hasCategory && index === 0 && i === 0) {
+						if (!hasCategory && index === 0 && i === 0 && !isDataAppend) {
 							config.axis_x_categories = [];
 						}
 
@@ -331,7 +336,7 @@ export default {
 							config.axis_x_categories.push(rawX);
 						}
 					} else {
-						x = $$.generateTargetX(rawX, id, i);
+						x = $$.generateTargetX(rawX, id, xIndex + i);
 					}
 
 					// mark as x = undefined if value is undefined and filter to remove after mapped

--- a/src/ChartInternal/data/load.ts
+++ b/src/ChartInternal/data/load.ts
@@ -8,6 +8,7 @@ import {endall} from "../../module/util";
 export default {
 	load(rawTargets, args): void {
 		const $$ = this;
+		const {append} = args;
 		let targets = rawTargets;
 
 		if (targets) {
@@ -29,7 +30,9 @@ export default {
 			$$.data.targets.forEach(d => {
 				for (let i = 0; i < targets.length; i++) {
 					if (d.id === targets[i].id) {
-						d.values = targets[i].values;
+						d.values = append ?
+							d.values.concat(targets[i].values) : targets[i].values;
+
 						targets.splice(i, 1);
 						break;
 					}
@@ -67,6 +70,8 @@ export default {
 		$$.cache.reset();
 
 		const data = args.data || $$.convertData(args, d => $$.load($$.convertDataToTargets(d), args));
+
+		args.append && (data.__append__ = true);
 
 		data && $$.load($$.convertDataToTargets(data), args);
 	},

--- a/test/api/export-spec.ts
+++ b/test/api/export-spec.ts
@@ -52,8 +52,12 @@ describe("API export", () => {
 
 	it("should export in different size", done => {
   	    const expectedDataURL = [
-			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA+gAAAJYCAYAAADxHswlAAAgAElEQVR4XuzdCZhlVX3v/e9/",
-			"AAAABJRU5ErkJggg=="
+			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA+gAAAJYCAYAAADxHswlAAAgAElEQVR4XuzdCZhlVX3v",
+			"AAAABJRU5ErkJggg==",
+
+			// for window test
+			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA+gAAAJYCAYAAADxHswlAAAgAElEQVR4Xuzde5xkZX3v",
+			"AAAAAElFTkSuQmCC"
 		];
 
 		setTimeout(() => {
@@ -61,8 +65,8 @@ describe("API export", () => {
 				width: 1000, height: 600
 			}, data => {
 				expect(
-					expectedDataURL.every(v => data.indexOf(v) >= 0)
-				).to.be.true;
+				 	expectedDataURL.map(v => data.indexOf(v) >= 0).filter(Boolean).length
+				).to.be.equal(2);
 
 				done();
 			});
@@ -70,13 +74,18 @@ describe("API export", () => {
 	});
 
 	it("should export in different aspectRatio", done => {
-		const expectedDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAEsCAYAAACG+vy+AAAgAElEQVR4Xu19CZRcVbX2t8+t";
+		const expectedDataURL = [
+			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAEsCAYAAACG+vy+AAAgAElEQVR4Xu19CZRcVbX2t8+t",
+			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAEsCAYAAACG+vy+AAAgAElEQVR4Xu19CZhcVZX/79xXn"
+		];
 
 	  	setTimeout(() => {
 			chart.export({
 				width: 200, height: 300, preserveAspectRatio: false
 			}, data => {
-				expect(data.indexOf(expectedDataURL) >= 0).to.be.true;
+				expect(
+					expectedDataURL.map(v => data.indexOf(v) >= 0).filter(Boolean).length
+			    ).to.be.equal(1);
 
 				done();
 			});

--- a/test/api/load-spec.ts
+++ b/test/api/load-spec.ts
@@ -648,4 +648,141 @@ describe("API load", function() {
 			});
 		});
 	});
+
+	describe("Append data loading", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["x", '2021-01-03T03:00:00', '2021-01-04T12:00:00', '2021-01-05T21:00:00'],
+						["data1", 36, 30, 24]
+					],
+					x: "x",
+					xFormat: "%Y-%m-%dT%H:%M:%S",
+					type: "line"
+				},
+				axis: {
+					x: {
+						type: "timeseries"
+					}
+				}
+			};
+		});
+
+
+		it("timeseries: check if data has been appended", done => {
+			const value = 37;
+
+			chart.load({
+				columns: [
+					["x", "2021-02-01T08:00:00"],
+					["data1", value]
+				],
+				append: true,
+				done: function() {
+					const oldData = args.data.columns[1].slice(1);
+					const newData = this.data.values("data1");
+
+					expect(newData.length).to.be.equal(oldData.length + 1);
+					expect(newData).to.deep.equal(oldData.concat(value));
+					done();
+				}
+			});
+		});
+
+		it("set options", () => {
+			args.data.columns[0] = ["x", "a", "b", "c"];
+			args.axis.x.type = "category";
+		});
+
+		it("category: check if data has been appended", done => {
+			const category = "dd";
+			const value = 37;
+
+			chart.load({
+				columns: [
+					["x", category],
+					["data1", value]
+				],
+				append: true,
+				done: function() {
+					const oldData = args.data.columns[1].slice(1);
+					const newData = this.data.values("data1");
+
+					expect(this.categories()).to.deep.equal(args.data.columns[0].slice(1).concat(category));
+					expect(newData.length).to.be.equal(oldData.length + 1);
+					expect(newData).to.deep.equal(oldData.concat(value));
+					done();
+				}
+			});
+		});
+
+		it("set options", () => {
+			args = {
+				data: {
+					columns: [
+						["data1", 36, 30, 24]
+					],
+					type: "line"
+				}
+			};
+		});
+
+		it("indexed: check if data has been appended", done => {
+			const value = 37;
+
+			chart.load({
+				columns: [
+					["data1", value]
+				],
+				append: true,
+				done: function() {
+					const oldData = args.data.columns[0].slice(1);
+					const newData = this.data.values("data1");
+
+					expect(newData.length).to.be.equal(oldData.length + 1);
+					expect(newData).to.deep.equal(oldData.concat(value));
+					expect(
+						this.internal.$el.axis.x.selectAll(".tick text").nodes().map(v => +v.textContent)
+					).to.deep.equal([0,1,2,3]);
+
+					done();
+				}
+			});
+		});
+
+		it("set options", () => {
+			args = {
+				data: {
+					rows: [
+						["data1"],
+						[90],
+						[40],
+					],
+					type: "line"
+				}
+			}
+		});
+
+		it("row data: check if data has been appended", done => {
+			const value = 37;
+			const oldData = chart.data.values("data1");
+
+			chart.load({
+				rows: [
+					["data1"],
+					[value]
+				],
+				append: true,
+				done: function() {
+					const newData = this.data.values("data1");
+
+				 	expect(newData.length).to.be.equal(oldData.length + 1);
+					expect(newData).to.deep.equal(oldData.concat(value));
+
+					done();
+				}
+			});
+		});
+	});
 });

--- a/test/shape/radar-spec.ts
+++ b/test/shape/radar-spec.ts
@@ -37,7 +37,7 @@ describe("SHAPE RADAR", () => {
 			const rect = chart.$.main.select(`.${CLASS.chartRadars}`).node().getBoundingClientRect();
 			const left = (chart.$.chart.node().getBoundingClientRect().width - rect.width) / 2;
 
-			expect(left).to.be.closeTo(rect.x, 3);
+			expect(left).to.be.closeTo(rect.x, 5);
 		});
 
 		it("data points should positioned next to radar polygon element", () => {
@@ -52,7 +52,7 @@ describe("SHAPE RADAR", () => {
 				expect(radar.select(".bb-shapes polygon").attr("points")).to.be.equal(expectedPoints);
 
 				done();
-			}, 200)
+			}, 300)
 		});
 
 		it("Should render level, axes and data edges", () => {

--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -345,6 +345,7 @@ export interface Chart {
 	 *     It's because rendering will finish after some transition and there is some time lag between loading and rendering
 	 */
 	load(this: Chart, args: {
+		append?: boolean;
 		url?: string;
 		json?: [{ [key: string]: string }];
 		rows?: PrimitiveArray[];


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2140

## Details
<!-- Detailed description of the change/feature -->
Implement data append option for .load() API.

```js
// Given chart
const chart = bb.generate({
    data: {
      x: "x",
      xFormat: "%Y-%m-%dT%H:%M:%S",
      columns: [
        ["x", "2021-01-03T03:00:00", "2021-01-04T12:00:00", "2021-01-05T21:00:00"],
        ["data1", 36, 30, 24]
      ]
    },
    axis: {
      x: {
        type: "timeseries"
      }
    }
};

// load new data by appending it.
chart.load({
    columns: [
      // when existing chart has `x` value, should provide correponding 'x' value.
      // with 'append' option, the 'data1' will have `[36,30,24,37]`.
      ["x", "2021-02-01T08:00:00"],
      ["data1", 37]
    ],
    append: true
});
```