### PR TITLE
refactor(load): mitigate unproper rendering

### DIFF
--- a/src/Chart/api/load.ts
+++ b/src/Chart/api/load.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
+import {window} from "../../module/browser";
 import {isString, isArray} from "../../module/util";
 
 export default {
@@ -160,9 +161,11 @@ export default {
 		// unload if needed
 		if ("unload" in args && args.unload !== false) {
 			// TODO: do not unload if target will load (included in url/rows/columns)
-			$$.unload($$.mapToTargetIds(args.unload === true ? null : args.unload), () =>
-				$$.loadFromArgs(args)
-			);
+			$$.unload($$.mapToTargetIds(args.unload === true ? null : args.unload), () => {
+				// to mitigate improper rendering for multiple consecutive calls
+				// https://github.com/naver/billboard.js/issues/2121
+				window.requestIdleCallback(() => $$.loadFromArgs(args));
+			});
 		} else {
 			$$.loadFromArgs(args);
 		}

--- a/test/api/load-spec.ts
+++ b/test/api/load-spec.ts
@@ -785,4 +785,54 @@ describe("API load", function() {
 			});
 		});
 	});
+
+	describe("Multiple consecutive load call", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+					  ["data1", 30, 200, 100, 400, 150, 250],
+					  ["data2", 50, 20, 10, 40, 15, 25]
+					],
+					type: "line"
+				},
+				transition: {
+					duration: 0
+				}
+			};
+		});
+
+		it("should be rendered properly", done => {
+			setTimeout(function () {
+			  chart.load({
+				columns: [["data1", 230, 190, 300, 500, 300, 400]],
+				unload: true
+			  });
+			}, 1000);
+			
+			setTimeout(function () {
+			  chart.load({
+				columns: [["data3", 130, 150, 200, 300, 200, 100]],
+				unload: true
+			  });
+			}, 1100);			
+			
+			setTimeout(function () {
+			  chart.load({
+				columns: [["data4", 100, 110, 120, 130, 140, 150]],
+				unload: true,
+				done: function() {
+					const {axis} = this.internal.$el;
+					const {lines} = this.$.line;
+
+					expect(lines.size()).to.be.equal(1);
+					expect(+axis.y.selectAll(".tick:last-of-type text").text()).to.be.equal(155);
+					expect(lines.attr("d")).to.be.equal("M6,390.5833333333333L124,319.75L241,248.91666666666663L358,178.08333333333331L475,107.25L593,36.41666666666668");
+					done();
+				}
+			  });
+			}, 1200);
+
+		});
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2121 

## Details
<!-- Detailed description of the change/feature -->
When multiple and consecutive loading task w/unload option
are called sequentially in a very short gap, mitigate unproper
rendering by queueing load task using requestIdleCallback().

![multiple-loading](https://user-images.githubusercontent.com/2178435/122540146-4d2bfc00-d063-11eb-8996-e0b62f15ac89.gif)
