### PR TITLE
docs(api): fix missing comma for append load

### DIFF
--- a/src/Chart/api/load.ts
+++ b/src/Chart/api/load.ts
@@ -61,7 +61,7 @@ export default {
 	 *    columns: [
 	 *        // with 'append' option, the 'data1' will have `[20,30,40,50,60]`.
 	 *        ["data1", 50, 60]
-	 *    ]
+	 *    ],
 	 *    append: true
 	 * });
 	 * @example


### PR DESCRIPTION
Fix the api documentation to enable working copy-paste.

Fixes: 80767955cedd ("feat(api): Intent to ship append load")
