### PR TITLE
refactor(axis): prevent transition not found error

### DIFF
--- a/src/Chart/api/flow.ts
+++ b/src/Chart/api/flow.ts
@@ -67,7 +67,7 @@ export default {
 			data = $$.convertData(args);
 		}
 
-		if (!data || !isTabVisible()) {
+		if ($$.state.redrawing || !data || !isTabVisible()) {
 			return;
 		}
 

--- a/src/ChartInternal/Axis/AxisRenderer.ts
+++ b/src/ChartInternal/Axis/AxisRenderer.ts
@@ -100,7 +100,7 @@ export default class AxisRenderer {
 			path.enter().append("path")
 				.attr("class", "domain")
 				// https://observablehq.com/@d3/d3-selection-2-0
-				.merge(helper.transitionise(path).selection())
+				.merge(path as d3Selection)
 				.attr("d", () => {
 					const outerTickSized = config.outerTickSize * sign;
 

--- a/src/ChartInternal/Axis/AxisRendererHelper.ts
+++ b/src/ChartInternal/Axis/AxisRendererHelper.ts
@@ -170,8 +170,17 @@ export default class AxisRendererHelper {
 
 	transitionise(selection): d3Selection {
 		const {config} = this;
+		let transitionSelection = config.withoutTransition ?
+			selection.interrupt() : selection.transition();
 
-		return config.withoutTransition ?
-			selection.interrupt() : selection.transition(config.transition);
+		if (config.transition) {
+			// prevent for 'transition not found' case
+			// https://github.com/naver/billboard.js/issues/2140
+			try {
+				transitionSelection = selection.transition(config.transition);
+			} catch (e) {}
+		}
+
+		return transitionSelection;
 	}
 }

--- a/src/ChartInternal/internals/redraw.ts
+++ b/src/ChartInternal/internals/redraw.ts
@@ -136,12 +136,12 @@ export default {
 		const redrawList = $$.getRedrawList(shape, flow, flowFn, isTransition);
 
 		// callback function after redraw ends
-		const afterRedraw = flow || config.onrendered ? () => {
+		const afterRedraw = () => {
 			flowFn && flowFn();
 
 			state.redrawing = false;
 			callFn(config.onrendered, $$.api);
-		} : null;
+		};
 
 		if (afterRedraw) {
 			// Only use transition when current tab is visible.

--- a/test/interactions/zoom-spec.ts
+++ b/test/interactions/zoom-spec.ts
@@ -508,6 +508,21 @@ describe("ZOOM", function() {
 
 			expect(clickedData).to.not.be.undefined;
 		});
+
+		it("shouldn't throw error on '.flow() -> .zoom()' flow calls", done => {
+			// when flow
+			chart.flow({
+				columns: [
+					["data1", 37]
+				],
+				length: 0,
+				duration: 0,
+				done: function() {
+					expect(this.zoom([1,2])).to.not.throw;
+					done();
+				}
+			});
+		})
 	});
 
 	describe("zoom on regions", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2140

## Details
<!-- Detailed description of the change/feature -->
- Prevent transition selection to throw error
- Make state.redrawing to be set false after redraw calls