### PR TITLE
fix(axis): fix handling x axis localtime

### DIFF
--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -82,7 +82,7 @@ class Axis {
 		let type = "linear";
 
 		if (this.isTimeSeries(id)) {
-			type = "time";
+			type = this.owner.config.axis_x_localtime ? "time" : "utc";
 		} else if (this.isLog(id)) {
 			type = "log";
 		}

--- a/src/ChartInternal/internals/scale.ts
+++ b/src/ChartInternal/internals/scale.ts
@@ -4,6 +4,7 @@
  */
 import {
 	scaleTime as d3ScaleTime,
+	scaleUtc as d3ScaleUtc,
 	scaleLinear as d3ScaleLinear,
 	scaleLog as d3ScaleLog,
 	scaleSymlog as d3ScaleSymlog
@@ -25,7 +26,8 @@ export function getScale(type = "linear", min = 0, max = 1): any {
 		linear: d3ScaleLinear,
 		log: d3ScaleSymlog,
 		_log: d3ScaleLog,
-		time: d3ScaleTime
+		time: d3ScaleTime,
+		utc: d3ScaleUtc
 	})[type]();
 
 	scale.type = type;

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -2894,4 +2894,49 @@ describe("AXIS", function() {
 			});
 		});
 	});
+
+	describe("Axis x type localtime", () => {
+		before(() => {
+			args = {
+				data: {
+					x: 'x',
+					columns: [
+						['x', 1356998400000, 1357084800000, 1357171200000, 1357257600000, 1357344000000, 1357430400000],
+						['data1', 30, 200, 100, 400, 150],
+						['data2', 130, 340, 200, 500, 250, 350]
+					],
+					type: "line"
+				  },
+				  axis: {
+					  y: {
+						  show: false
+					  },
+					x: {
+						localtime: false,
+						type: "timeseries",
+						tick: {
+							fit: false
+						}
+					}
+				}
+			};
+		});
+
+		it("check if datetime treated as UTC", () => {
+			const res = [];
+			const expected = [
+				['12 AM', '12 PM', '12 AM', '12 PM', '12 AM', '12 PM', '12 AM', '12 PM', '12 AM', '12 PM', '12 AM'],
+				['2013', '12 PM', 'Jan 02', '12 PM', 'Jan 03', '12 PM', 'Jan 04', '12 PM', 'Jan 05', '12 PM', 'Jan 06']
+			];
+			
+			expect(chart.internal.scale.x.type).to.be.equal("utc");
+
+			chart.internal.$el.axis.x.selectAll(".tick text tspan")
+				.each(function() {
+					res.push(this.innerHTML);
+				});
+
+ 			expect(res.every((v, i) => v === expected[0][i]) || res.every((v, i) => v === expected[1][i])).to.be.true;
+		});
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2186

## Details
<!-- Detailed description of the change/feature -->
Make to use UTC scale when axis.x.localtime=false