### PR TITLE
feat(axis): Enhance padding to accept px value

### DIFF
--- a/src/ChartInternal/internals/domain.ts
+++ b/src/ChartInternal/internals/domain.ts
@@ -3,6 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {TYPE, TYPE_BY_CATEGORY} from "../../config/const";
+import {IData} from "../data/IData";
 import {brushEmpty, getBrushSelection, getMinMax, isDefined, notEmpty, isValue, isObject, isNumber, diffDomain, parseDate, sortValue} from "../../module/util";
 
 export default {
@@ -58,14 +59,6 @@ export default {
 		return getMinMax(type, Object.keys(ys).map(key => getMinMax(type, ys[key])));
 	},
 
-	getYDomainMin(targets): number {
-		return this.getYDomainMinMax(targets, "min");
-	},
-
-	getYDomainMax(targets): number {
-		return this.getYDomainMinMax(targets, "max");
-	},
-
 	/**
 	 * Check if hidden targets bound to the given axis id
 	 * @param {string} id ID to be checked
@@ -106,19 +99,20 @@ export default {
 
 		const yMin = config[`${pfx}_min`];
 		const yMax = config[`${pfx}_max`];
-		let yDomainMin = $$.getYDomainMin(yTargets);
-		let yDomainMax = $$.getYDomainMax(yTargets);
 		const center = config[`${pfx}_center`];
+		const isInverted = config[`${pfx}_inverted`];
+		const showHorizontalDataLabel = $$.hasDataLabel() && config.axis_rotated;
+		const showVerticalDataLabel = $$.hasDataLabel() && !config.axis_rotated;
+
+		let yDomainMin = $$.getYDomainMinMax(yTargets, "min");
+		let yDomainMax = $$.getYDomainMinMax(yTargets, "max");
+
 		let isZeroBased = [TYPE.BAR, TYPE.BUBBLE, TYPE.SCATTER, ...TYPE_BY_CATEGORY.Line]
 			.some(v => {
 				const type = v.indexOf("area") > -1 ? "area" : v;
 
 				return $$.hasType(v, yTargets) && config[`${type}_zerobased`];
 			});
-
-		const isInverted = config[`${pfx}_inverted`];
-		const showHorizontalDataLabel = $$.hasDataLabel() && config.axis_rotated;
-		const showVerticalDataLabel = $$.hasDataLabel() && !config.axis_rotated;
 
 		// MEMO: avoid inverting domain unexpectedly
 		yDomainMin = isValue(yMin) ? yMin :
@@ -137,7 +131,6 @@ export default {
 		if (yDomainMin === yDomainMax) {
 			yDomainMin < 0 ? yDomainMax = 0 : yDomainMin = 0;
 		}
-
 
 		const isAllPositive = yDomainMin >= 0 && yDomainMax >= 0;
 		const isAllNegative = yDomainMin <= 0 && yDomainMax <= 0;
@@ -176,7 +169,7 @@ export default {
 			const lengths = $$.getDataLabelLength(yDomainMin, yDomainMax, "height");
 
 			["bottom", "top"].forEach((v, i) => {
-				padding[v] += axis.convertPixelsToAxisPadding(lengths[i], domainLength);
+				padding[v] += $$.convertPixelToScale("y", lengths[i], domainLength);
 			});
 		}
 
@@ -219,60 +212,75 @@ export default {
 		return isDefined(value) ? value : dataValue;
 	},
 
-	getXDomainMin(targets) {
-		return this.getXDomainMinMax(targets, "min");
-	},
-
-	getXDomainMax(targets) {
-		return this.getXDomainMinMax(targets, "max");
-	},
-
-	getXDomainPadding(domain) {
+	/**
+	 * Get x Axis padding
+	 * @param {Array} domain x Axis domain
+	 * @param {number} tickCount Tick count
+	 * @returns {object} Padding object values with 'left' & 'right' key
+	 * @private
+	 */
+	getXDomainPadding(domain, tickCount: number): {left: number, right: number} {
 		const $$ = this;
 		const {axis, config} = $$;
-		const diff = domain[1] - domain[0];
-		const xPadding = config.axis_x_padding;
-		let maxDataCount;
-		let padding;
+		const padding = config.axis_x_padding;
+		const isTimeSeriesTickCount = axis.isTimeSeries() && tickCount;
+		const diff = diffDomain(domain);
+		let defaultValue;
 
-		if (axis.isCategorized()) {
-			padding = 0;
+		// determine default padding value
+		if (axis.isCategorized() || isTimeSeriesTickCount) {
+			defaultValue = 0;
 		} else if ($$.hasType("bar")) {
-			maxDataCount = $$.getMaxDataCount();
-			padding = maxDataCount > 1 ? (diff / (maxDataCount - 1)) / 2 : 0.5;
+			const maxDataCount = $$.getMaxDataCount();
+
+			defaultValue = maxDataCount > 1 ? (diff / (maxDataCount - 1)) / 2 : 0.5;
 		} else {
-			padding = diff * 0.01;
+			defaultValue = diff * 0.01;
 		}
 
-		let left = padding;
-		let right = padding;
+		let {left = defaultValue, right = defaultValue} = isNumber(padding) ?
+			{left: padding, right: padding} : padding;
 
-		if (isObject(xPadding) && notEmpty(xPadding)) {
-			left = isValue(xPadding.left) ? xPadding.left : padding;
-			right = isValue(xPadding.right) ? xPadding.right : padding;
-		} else if (isNumber(config.axis_x_padding)) {
-			left = xPadding;
-			right = xPadding;
+		// when the unit is pixel, convert pixels to axis scale value
+		if (padding.unit === "px") {
+			const domainLength = Math.abs(diff + (diff * 0.2));
+
+			left = axis.getPadding(padding, "left", defaultValue, domainLength);
+			right = axis.getPadding(padding, "right", defaultValue, domainLength);
+		} else {
+			const range = diff + left + right;
+
+			if (isTimeSeriesTickCount && range) {
+				const relativeTickWidth = (diff / tickCount) / range;
+
+				left = left / range / relativeTickWidth;
+				right = right / range / relativeTickWidth;
+			}
 		}
 
 		return {left, right};
 	},
 
-	getXDomain(targets) {
+	/**
+	 * Get x Axis domain
+	 * @param {Array} targets targets
+	 * @returns {Array} x Axis domain
+	 * @private
+	 */
+	getXDomain(targets?: IData[]): (Date|number)[] {
 		const $$ = this;
-		const isLog = $$.scale.x.type === "log";
-		const xDomain = [$$.getXDomainMin(targets), $$.getXDomainMax(targets)];
-		let min: Date | number = 0;
-		let max: Date | number = 0;
+		const {axis, scale: {x}} = $$;
+		const domain = [
+			$$.getXDomainMinMax(targets, "min"),
+			$$.getXDomainMinMax(targets, "max")
+		];
+		let [min = 0, max = 0] = domain;
 
-		if (isLog) {
-			min = xDomain[0];
-			max = xDomain[1];
-		} else {
-			const isCategorized = $$.axis.isCategorized();
-			const isTimeSeries = $$.axis.isTimeSeries();
-			const padding = $$.getXDomainPadding(xDomain);
-			let [firstX, lastX] = xDomain;
+		if (x.type !== "log") {
+			const isCategorized = axis.isCategorized();
+			const isTimeSeries = axis.isTimeSeries();
+			const padding = $$.getXDomainPadding(domain);
+			let [firstX, lastX] = domain;
 
 			// show center of x domain if min and max are the same
 			if ((firstX - lastX) === 0 && !isCategorized) {
@@ -362,5 +370,28 @@ export default {
 		}
 
 		return [min, max];
+	},
+
+	/**
+	 * Converts pixels to axis' scale values
+	 * @param {string} type Axis type
+	 * @param {number} pixels Pixels
+	 * @param {number} domainLength Domain length
+	 * @returns {number}
+	 * @private
+	 */
+	convertPixelToScale(type: "x"|"y", pixels: number, domainLength: number): number {
+		const $$ = this;
+		const {config, state} = $$;
+		const isRotated = config.axis_rotated;
+		let length;
+
+		if (type === "x") {
+			length = isRotated ? "height" : "width";
+		} else {
+			length = isRotated ? "width" : "height";
+		}
+
+		return domainLength * (pixels / state[length]);
 	}
 };

--- a/src/ChartInternal/internals/size.axis.ts
+++ b/src/ChartInternal/internals/size.axis.ts
@@ -110,7 +110,12 @@ export default {
 				}
 
 				if (tickCount !== state.axis.x.tickCount) {
-					state.axis.x.padding = $$.axis.getXAxisPadding(tickCount);
+					const {targets} = $$.data;
+
+					state.axis.x.padding = $$.getXDomainPadding([
+						$$.getXDomainMinMax(targets, "min"),
+						$$.getXDomainMinMax(targets, "max")
+					], tickCount);
 				}
 
 				state.axis.x.tickCount = tickCount;

--- a/src/config/Options/axis/x.ts
+++ b/src/config/Options/axis/x.ts
@@ -494,12 +494,15 @@ export default {
 	 * Set padding for x axis.<br><br>
 	 * If this option is set, the range of x axis will increase/decrease according to the values.
 	 * If no padding is needed in the rage of x axis, 0 should be set.
+	 * By default, left/right padding are set depending on x axis type or chart types.
 	 * - **NOTE:**
-	 *   The padding values aren't based on pixels. It differs according axis types<br>
-	 *   - **category:** The unit of tick value
-	 *     ex. the given value `1`, is same as the width of 1 tick width
-	 *   - **timeseries:** Numeric time value
-	 *     ex. the given value `1000*60*60*24`, which is numeric time equivalent of a day, is same as the width of 1 tick width
+	 *   - The meaning of padding values, differs according axis types:<br>
+	 *     - **category/indexed:** The unit of tick value
+	 *       ex. the given value `1`, is same as the width of 1 tick width
+	 *     - **timeseries:** Numeric time value
+	 *       ex. the given value `1000*60*60*24`, which is numeric time equivalent of a day, is same as the width of 1 tick width
+	 *   - If want values to be treated as pixels, specify `unit:"px"`.
+	 *     - The pixel value will be convered based on the scale values. Hence can not reflect accurate padding result.
 	 * @name axis․x․padding
 	 * @memberof Options
 	 * @type {object|number}
@@ -518,7 +521,14 @@ export default {
 	 *     },
 	 *
 	 *     // or set both values at once.
-	 *     padding: 10
+	 *     padding: 10,
+	 *
+	 *     // or set padding values as pixel unit.
+	 *     padding: {
+	 *       left: 100,
+	 *       right: 50,
+	 *       unit: "px"
+	 *     },
 	 *   }
 	 * }
 	 */

--- a/src/config/Store/State.ts
+++ b/src/config/Store/State.ts
@@ -11,6 +11,7 @@
 export default class State {
 	constructor() {
 		return {
+			// chart drawn area dimension, excluding axes
 			width: 0,
 			width2: 0,
 			height: 0,
@@ -41,6 +42,7 @@ export default class State {
 			hasRadar: false,
 
 			current: {
+				// chart whole dimension
 				width: 0,
 				height: 0,
 				dataMax: 0,

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -12,6 +12,7 @@ import {getBoundingRect} from "../../src/module/util";
 import bb from "../../src";
 import CLASS from "../../src/config/classes";
 import AxisRendererHelper from "../../src/ChartInternal/Axis/AxisRendererHelper";
+import { stratify } from "d3";
 //import getSizeFor1Char from "exports-loader?getSizeFor1Char!../../src/axis/bb.axis";
 
 describe("AXIS", function() {
@@ -2703,6 +2704,80 @@ describe("AXIS", function() {
 
 			expect(internal.scale.y.domain()[1]).to.be.closeTo(max, 10);
 			expect(+internal.$el.axis.y.select(".tick:nth-child(10) tspan").text()).to.be.closeTo(max, 10);
+		});
+	});
+
+	describe("x Axis padding: unit='px'", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						['data1', 80, 250, 200, 200, 250, 150],
+						['data2', 170, 350, 240, 200, 250, 150]
+					],
+					type: "line"
+				},
+				axis: {
+					x: {
+						padding: {
+							left: 100,
+							right: 80,
+							unit: "px"
+						}
+					}
+				}
+			}
+		});
+
+		const chkPadding = () => {
+			const lines = chart.$.line.lines.node();
+			let rect = lines.getBoundingClientRect();
+			let expected = {left: 129.5, right: 568.5};
+
+			expect(rect.left).to.be.closeTo(expected.left, 1);
+			expect(rect.right).to.be.closeTo(expected.right, 1);
+
+			// when
+			chart.resize({width: 300});
+
+			
+			rect = lines.getBoundingClientRect();
+			expected = {left: 106.5, right: 246.5};
+
+			expect(rect.left).to.be.closeTo(expected.left, 1);
+			expect(rect.right).to.be.closeTo(expected.right, 1);
+		};
+
+		it("should apply pixel value paddings", () => {
+			chkPadding();
+		});
+
+		it("set options axis.x.type='timeseries'", () => {
+			args = {
+				data: {
+					x: "x",
+					columns: [
+						["x", "2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"],
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 130, 340, 200, 500, 250, 350]
+					],
+					type: "line"
+				},
+				axis: {
+					x: {
+						type: "timeseries",
+						padding: {
+							left: 100,
+							right: 80,
+							unit: "px"
+						}
+					}
+				}
+			}
+		});
+
+		it("should apply pixel value paddings for axis.x.type='timeseies'", () => {
+			chkPadding();
 		});
 	});
 

--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -80,6 +80,7 @@ export interface xAxisConfiguration extends AxisConfigurationBase {
 	padding?: {
 		left?: number;
 		right?: number;
+		unit?: string;
 	} | number;
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2246

## Details
<!-- Detailed description of the change/feature -->
- Implement axis.x.padding.unit='px'
- Removed axis.getXAxisPadding() substituting by .getXDomainPadding()
- Refactor convert pixel to scale

```js
  axis: {
    x: {
	 padding: {
	    left: 100,
	    right: 80,
	    unit: "px"
	}
     }
  }
```