### PR TITLE
feat(tooltip): Enhance tooltip.position passing curr pos

### DIFF
--- a/src/ChartInternal/internals/tooltip.ts
+++ b/src/ChartInternal/internals/tooltip.ts
@@ -5,6 +5,7 @@
 import {select as d3Select} from "d3-selection";
 import {document} from "../../module/browser";
 import CLASS from "../../config/classes";
+import {IDataRow} from "../data/IData";
 import {getPointer, isFunction, isObject, isString, isValue, callFn, sanitise, tplProcess, isUndefined, parseDate} from "../../module/util";
 
 export default {
@@ -12,7 +13,7 @@ export default {
 	 * Initializes the tooltip
 	 * @private
 	 */
-	initTooltip() {
+	initTooltip(): void {
 		const $$ = this;
 		const {config, $el} = $$;
 
@@ -31,7 +32,7 @@ export default {
 		$$.bindTooltipResizePos();
 	},
 
-	initShowTooltip() {
+	initShowTooltip(): void {
 		const $$ = this;
 		const {config, $el, state: {hasAxis, hasRadar}} = $$;
 
@@ -240,7 +241,7 @@ export default {
 	 * @returns {Array} Template string
 	 * @private
 	 */
-	getTooltipContentTemplate(tplStr): string[] {
+	getTooltipContentTemplate(tplStr?: string): string[] {
 		return (tplStr || `<table class="{=CLASS_TOOLTIP}"><tbody>
 				{=TITLE}
 				{{<tr class="{=CLASS_TOOLTIP_NAME}">
@@ -318,12 +319,12 @@ export default {
 	/**
 	 * Show the tooltip
 	 * @param {object} selectedData Data object
-	 * @param {HTMLElement} element Tooltip element
+	 * @param {SVGElement} eventRect Event <rect> element
 	 * @private
 	 */
-	showTooltip(selectedData, element): void {
+	showTooltip(selectedData: IDataRow[], eventRect: SVGElement): void {
 		const $$ = this;
-		const {config, state, $el: {tooltip}} = $$;
+		const {config, scale, state, $el: {tooltip}} = $$;
 		const {bindto} = config.tooltip_contents;
 		const dataToShow = selectedData.filter(d => d && isValue($$.getBaseValue(d)));
 
@@ -363,9 +364,16 @@ export default {
 
 		if (!bindto) {
 			const fnPos = config.tooltip_position?.bind($$.api) || $$.tooltipPosition.bind($$);
+			const [x, y] = getPointer(state.event, eventRect); // get mouse event position
+			const currPos: any = {x, y};
+			const data = selectedData.filter(Boolean)?.shift();
+
+			if (scale.x && data && "x" in data) {
+				currPos.xAxis = scale.x(data.x);
+			}
 
 			// Get tooltip dimensions
-			const pos = fnPos(dataToShow, width, height, element);
+			const pos = fnPos(dataToShow, width, height, eventRect, currPos);
 
 			["top", "left"].forEach(v => {
 				const value = pos[v];

--- a/src/config/Options/common/tooltip.ts
+++ b/src/config/Options/common/tooltip.ts
@@ -27,6 +27,12 @@ export default {
 	 *  If undefined returned, the row of that value will be skipped.
 	 * @property {Function} [tooltip.position] Set custom position function for the tooltip.<br>
 	 *  This option can be used to modify the tooltip position by returning object that has top and left.
+	 *  - Will pass following arguments to the given function:
+	 *   - `data {Array}`: Current selected data array object.
+	 *   - `width {number}`: Width of tooltip.
+	 *   - `height {number}`: Height of tooltip.
+	 *   - `element {SVGElement}`: Tooltip event bound element
+	 *   - `pos {object}`: Current position of the tooltip.
 	 * @property {Function|object} [tooltip.contents] Set custom HTML for the tooltip.<br>
 	 *  Specified function receives data, defaultTitleFormat, defaultValueFormat and color of the data point to show. If tooltip.grouped is true, data includes multiple data points.
 	 * @property {string|HTMLElement} [tooltip.contents.bindto=undefined] Set CSS selector or element reference to bind tooltip.
@@ -73,7 +79,16 @@ export default {
 	 *          name: function(name, ratio, id, index) { return name; },
 	 *          value: function(value, ratio, id, index) { return ratio; }
 	 *      },
-	 *      position: function(data, width, height, element) {
+	 *      position: function(data, width, height, element, pos) {
+	 *          // data: [{x, index, id, name, value}, ...]
+	 *          // width: Tooltip width
+	 *          // height: Tooltip height
+	 *          // element: Tooltip event bound element
+	 *          // pos: {
+	 *          //   x: Current mouse event x position,
+	 *          //   y: Current mouse event y position,
+	 *          //   xAxis: Current x Axis position (the value is given for axis based chart type only)
+	 *          // }
 	 *          return {top: 0, left: 0}
 	 *      },
 	 *

--- a/test/api/load-spec.ts
+++ b/test/api/load-spec.ts
@@ -803,36 +803,36 @@ describe("API load", function() {
 		});
 
 		it("should be rendered properly", done => {
-			setTimeout(function () {
-			  chart.load({
-				columns: [["data1", 230, 190, 300, 500, 300, 400]],
-				unload: true
-			  });
-			}, 1000);
-			
-			setTimeout(function () {
-			  chart.load({
-				columns: [["data3", 130, 150, 200, 300, 200, 100]],
-				unload: true
-			  });
-			}, 1100);			
-			
-			setTimeout(function () {
-			  chart.load({
-				columns: [["data4", 100, 110, 120, 130, 140, 150]],
-				unload: true,
-				done: function() {
-					const {axis} = this.internal.$el;
-					const {lines} = this.$.line;
+			new Promise((resolve, reject) => {
+				chart.load({
+					columns: [["data1", 230, 190, 300, 500, 300, 400]],
+					unload: true,
+					done: resolve
+				});
+			}).then(() => {
+				return new Promise((resolve, reject) => {
+					chart.load({
+						columns: [["data3", 130, 150, 200, 300, 200, 100]],
+						unload: true,
+						done: resolve
+					});
+				});
+			}).then(() => {
+				chart.load({
+					columns: [["data4", 100, 110, 120, 130, 140, 150]],
+					unload: true,
+					done: function() {
+						const {axis} = this.internal.$el;
+						const {lines} = this.$.line;
+	
+						expect(lines.size()).to.be.equal(1);
+						expect(+axis.y.selectAll(".tick:last-of-type text").text()).to.be.equal(155);
+						expect(lines.attr("d")).to.be.equal("M6,390.5833333333333L124,319.75L241,248.91666666666663L358,178.08333333333331L475,107.25L593,36.41666666666668");
 
-					expect(lines.size()).to.be.equal(1);
-					expect(+axis.y.selectAll(".tick:last-of-type text").text()).to.be.equal(155);
-					expect(lines.attr("d")).to.be.equal("M6,390.5833333333333L124,319.75L241,248.91666666666663L358,178.08333333333331L475,107.25L593,36.41666666666668");
-					done();
-				}
-			  });
-			}, 1200);
-
+						done();
+					}
+				});
+			});
 		});
 	});
 });

--- a/test/internals/tooltip-spec.ts
+++ b/test/internals/tooltip-spec.ts
@@ -384,6 +384,10 @@ describe("TOOLTIP", function() {
 			};
 		});
 
+		after(() => {
+			delete args.tooltip.position;
+		});
+
 		it("should be set to the coordinate where the function returned", () => {
 			util.hoverChart(chart, "mousemove", {
 				clientX: 270,
@@ -423,9 +427,15 @@ describe("TOOLTIP", function() {
 		});
 
 		it("set option tooltip.position", () => {
-			args.tooltip.position = () => ({
-				top: 50, left: 300
-			});
+			args.tooltip.position = function(data, width, height, element, pos) {
+				expect(pos.x).to.be.equal(99.5);
+				expect(pos.y).to.be.equal(100.5);
+				expect(pos.xAxis).to.be.equal(this.internal.scale.x(data[0].x));
+
+				return {
+					top: 50, left: 300
+				};
+			};
 		});
 
 		it("tooltip repositioning: when the chart width is increasing", done => {
@@ -441,6 +451,7 @@ describe("TOOLTIP", function() {
 
 			setTimeout(() => {
 				expect(parseInt(tooltip.style("left"))).to.be.above(left);
+
 				done();
 			}, 200);
 		});


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2267

## Details
<!-- Detailed description of the change/feature -->
Pass position object argument to tooltip.position callback
to facilitate position value control.

```js
tooltip: {
     position: function(data, width, height, element, pos) {
         // data: [{x, index, id, name, value}, ...]
         // width: Tooltip width
         // height: Tooltip height
         // element: Tooltip event bound element
         // pos: {
         //   x: Current mouse event x position,
         //   y: Current mouse event y position,
         //   xAxis: Current x Axis position
         // }
         return {top: 0, left: 0}
     },
}
```