### PR TITLE
refactor(api): Remove d3-color package usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
 	"dependencies": {
 		"d3-axis": "^3.0.0",
 		"d3-brush": "^3.0.0",
-		"d3-color": "^3.0.1",
 		"d3-drag": "^3.0.0",
 		"d3-dsv": "^3.0.1",
 		"d3-ease": "^3.0.1",
@@ -143,6 +142,7 @@
 		"cross-env": "^7.0.3",
 		"css-loader": "^6.2.0",
 		"css-minimizer-webpack-plugin": "^3.0.2",
+		"d3-color": "^3.0.1",
 		"d3-format": "^3.0.1",
 		"d3-polygon": "^3.0.1",
 		"d3-voronoi": "^1.1.4",

--- a/src/ChartInternal/internals/selection.ts
+++ b/src/ChartInternal/internals/selection.ts
@@ -3,7 +3,6 @@
  * billboard.js project is licensed under the MIT license
  */
 import {select as d3Select} from "d3-selection";
-import {rgb as d3Rgb} from "d3-color";
 import drag from "../interactions/drag";
 import CLASS from "../../config/classes";
 import {callFn} from "../../module/util";
@@ -85,13 +84,12 @@ export default {
 	 */
 	selectPath(target, d): void {
 		const $$ = this;
-		const {config, $T} = $$;
+		const {config} = $$;
 
 		callFn(config.data_onselected, $$.api, d, target.node());
 
 		if (config.interaction_brighten) {
-			$T(target)
-				.style("fill", () => d3Rgb($$.color(d)).brighter(0.75));
+			target.style("filter", "brightness(1.25)");
 		}
 	},
 
@@ -103,13 +101,12 @@ export default {
 	 */
 	unselectPath(target, d): void {
 		const $$ = this;
-		const {config, $T} = $$;
+		const {config} = $$;
 
 		callFn(config.data_onunselected, $$.api, d, target.node());
 
 		if (config.interaction_brighten) {
-			$T(target)
-				.style("fill", () => $$.color(d));
+			target.style("filter", null);
 		}
 	},
 

--- a/test/api/selection-spec.ts
+++ b/test/api/selection-spec.ts
@@ -4,7 +4,6 @@
  */
 /* eslint-disable */
 import {expect} from "chai";
-import {rgb as d3Rgb} from "d3-color";
 import util from "../assets/util";
 import CLASS from "../../src/config/classes";
 
@@ -140,7 +139,7 @@ describe("API select", () => {
 					expect(v.index).to.be.equal(indice[i]);
 
 					// check for the selected color
-					expect(this.style.fill).to.be.equal(d3Rgb(color).brighter(0.75).toString());
+					expect(this.style.filter).to.be.equal("brightness(1.25)");
 				});
 
 				done();


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2272

## Details
<!-- Detailed description of the change/feature -->
Remove the use of d3-color package and replaces its functionality
by css filter brightness function.