### PR TITLE
fix(types): fix data.onshown/hidden types

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -983,7 +983,12 @@ export interface TooltipOptions {
 		data: any,
 		width: number,
 		height: number,
-		element: any
+		element: any,
+		pos: {
+			x: number;
+			y: number;
+			xAxis?: number;
+		}
 	) => { top: number; left: number });
 
 	/**
@@ -1670,13 +1675,13 @@ export interface Data {
 	 * Set a callback for when data is shown.
 	 * The callback will receive shown data ids in array.
 	 */
-	onshown?(): void;
+	onshown?(this: Chart, ids: string[]): void;
 
 	/**
 	 * Set a callback for when data is hidden.
 	 * The callback will receive hidden data ids in array.
 	 */
-	onhidden?(): void;
+	onhidden?(this: Chart, ids: string[]): void;
 }
 
 export type FormatFunction = (


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2275

## Details
<!-- Detailed description of the change/feature -->
- Fix wrong types for data.onshown/onhidden function params
- Add missing newly added(#2270) tooltip.position params types