### PR TITLE
fix(zoom): Fix zoomend call on .zoom()

### DIFF
--- a/src/ChartInternal/interactions/zoom.ts
+++ b/src/ChartInternal/interactions/zoom.ts
@@ -226,7 +226,7 @@ export default {
 		state.zooming = false;
 
 		// do not call event cb when is .unzoom() is called
-		!isUnZoom && callFn(config.zoom_onzoomend, $$.api, $$.zoom.getDomain());
+		!isUnZoom && (e || state.dragging) && callFn(config.zoom_onzoomend, $$.api, $$.zoom.getDomain());
 	},
 
 	/**

--- a/test/api/zoom-spec.ts
+++ b/test/api/zoom-spec.ts
@@ -495,4 +495,70 @@ describe("API zoom", function() {
 			}, 500);
 		});
 	});
+
+	describe("zoom events", () => {
+		const onzoomstartSpy = sinon.spy();
+		const onzoomSpy = sinon.spy();
+		const onzoomendSpy = sinon.spy();
+		let args = {
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400, 150, 250],
+					["data2", 50, 20, 10, 40, 15, 25],
+					["data3", 150, 120, 110, 140, 115, 125]
+				]
+			},
+			transition: {
+				duration: 0
+			},
+			zoom: {
+				enabled: true,
+				type: "whee",
+				onstart: onzoomstartSpy,
+				onzoom: onzoomSpy,
+				onzoomend: onzoomendSpy
+			}
+		}
+
+		beforeEach(() => {
+			chart = util.generate(args);
+
+			onzoomstartSpy.resetHistory();
+			onzoomSpy.resetHistory();
+			onzoomendSpy.resetHistory();
+		});
+
+		// check zoom event triggers
+		function chkZoomEvents() {
+			// when
+			chart.zoom([1, 2]);
+
+			// only 'onzoom' event should be called.
+			expect(onzoomstartSpy.called).to.be.false;
+			expect(onzoomSpy.calledOnce).to.be.true;
+			expect(onzoomendSpy.called).to.be.false;
+			
+			onzoomstartSpy.resetHistory();
+			onzoomSpy.resetHistory();
+			onzoomendSpy.resetHistory();
+
+			// when
+			chart.unzoom();
+
+			// on unzoom, no event should be called.
+			expect([onzoomstartSpy.called, onzoomSpy.called, onzoomendSpy.called].every(v => v === false)).to.be.true;
+		}
+
+		it("wheel type: check for zoom events trigger", ()=> {
+			chkZoomEvents();
+		});
+
+		it("set options: zoom.type='drag'", () => {
+			args.zoom.type = "drag";
+		});
+
+		it("drag type: check for zoom events trigger", ()=> {
+			chkZoomEvents();
+		});
+	});
 });

--- a/test/interactions/zoom-spec.ts
+++ b/test/interactions/zoom-spec.ts
@@ -131,7 +131,7 @@ describe("ZOOM", function() {
 							expect(spyOnZoomStart.args[0][0].type).to.be.equal("start");
 
 							util.fireEvent(rect, "mousemove", {
-								clientX: 100,
+								clientX: 120,
 								clientY: 150
 							}, chart);
 
@@ -148,7 +148,7 @@ describe("ZOOM", function() {
 							expect(spyOnZoom.args[0][0].map(Math.round)).to.be.deep.equal([0, 3]);
 
 							util.fireEvent(rect, "mouseup", {
-								clientX: 100,
+								clientX: 120,
 								clientY: 150
 							}, chart);
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2254

## Details
<!-- Detailed description of the change/feature -->
Remove triggering 'onzoomend' when .zoom() is called.
Side-effect caused by #2217