### PR TITLE
docs(plugin): fix documentation for textoverlap plugin

### DIFF
--- a/src/Plugin/textoverlap/index.ts
+++ b/src/Plugin/textoverlap/index.ts
@@ -35,13 +35,14 @@ import Options from "./Options";
  *  var chart = bb.generate({
  *     data: {
  *     	  columns: [ ... ]
- *     }
+ *     },
  *     ...
  *     plugins: [
  *        new bb.plugin.textoverlap({
  *          selector: ".bb-texts text",
  *          extent: 8,
  *          area: 3
+ *        })
  *     ]
  *  });
  * @example


### PR DESCRIPTION
Closing brackets were missing.
