### PR TITLE
feat(event): add option for step-before/step-after charts for tooltip to match step behavior

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -760,11 +760,15 @@ var demos = {
 		StepChart: [
 			{
 				options: {
+					title: {
+						text: "default",
+					},
 					data: {
 						columns: [
 							["data1", 300, 350, 300, 20, 240, 100],
 							["data2", 130, 100, 140, 200, 150, 50]
 						],
+						type: "step",
 						types: {
 							data1: "step",
 							data2: 'area-step'
@@ -774,11 +778,15 @@ var demos = {
 			},
 			{
 				options: {
+					title: {
+						text: "step-before",
+					},
 					data: {
 						columns: [
 							["data1", 300, 350, 300, 20, 240, 100],
 							["data2", 130, 100, 140, 200, 150, 50]
 						],
+						type: "step",
 						types: {
 							data1: "step",
 							data2: 'area-step'
@@ -786,18 +794,23 @@ var demos = {
 					},
 					line: {
 						step: {
-							type: "step-before"
+							type: "step-before",
+							tooltipMatch: true,
 						}
 					}
 				}
 			},
 			{
 				options: {
+					title: {
+						text: "step-after",
+					},
 					data: {
 						columns: [
 							["data1", 300, 350, 300, 20, 240, 100],
 							["data2", 130, 100, 140, 200, 150, 50]
 						],
+						type: "step",
 						types: {
 							data1: "step",
 							data2: 'area-step'
@@ -805,7 +818,8 @@ var demos = {
 					},
 					line: {
 						step: {
-							type: "step-after"
+							type: "step-after",
+							tooltipMatch: true
 						}
 					}
 				}

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -406,14 +406,34 @@ export default {
 
 					state.event = event;
 
-					// do nothing while dragging/flowing
-					if (state.dragging || state.flowing || $$.hasArcType() ||
-						!d || (config.tooltip_grouped && d && d.index === eventReceiver.currentIdx)
-					) {
+					if (!d) {
 						return;
 					}
 
-					const {index} = d;
+					let {index} = d;
+
+					if ($$.isStepType(d)) {
+						const scale = $$.scale.zoom || $$.scale.x;
+
+						if (config.line_step_type === "step-after" &&
+							config.line_step_tooltipMatch &&
+							scale.invert(getPointer(event, this)[0]) < $$.axis.xs[index]
+						) {
+							index -= 1;
+						} else if (config.line_step_type === "step-before" &&
+							config.line_step_tooltipMatch &&
+							scale.invert(getPointer(event, this)[0]) > $$.axis.xs[index]
+						) {
+							index += 1;
+						}
+					}
+
+					// do nothing while dragging/flowing
+					if (state.dragging || state.flowing || $$.hasArcType() ||
+						(config.tooltip_grouped && d && index === eventReceiver.currentIdx)
+					) {
+						return;
+					}
 
 					if (index !== eventReceiver.currentIdx) {
 						$$.setOverOut(false, eventReceiver.currentIdx);

--- a/src/config/Options/shape/line.ts
+++ b/src/config/Options/shape/line.ts
@@ -20,6 +20,8 @@ export default {
 	 * - step
 	 * - step-before
 	 * - step-after
+	 * @property {boolean} [line.step.tooltipMatch=false] Set to true for step-before and step-after types to have cursor/tooltip match to hovered step's point instead of nearest point.<br>
+	 * Note that [data.type](#.data․type) must be set to `step`.
 	 * @property {boolean|Array} [line.point=true] Set to false to not draw points on linecharts. Or pass an array of line ids to draw points for.
 	 * @property {boolean} [line.zerobased=false] Set if min or max value will be 0 on line chart.
 	 * @example
@@ -30,7 +32,8 @@ export default {
 	 *          "line-class2"
 	 *      ],
 	 *      step: {
-	 *          type: "step-after"
+	 *          type: "step-after",
+	 *          tooltipMatch: true
 	 *      },
 	 *
 	 *      // hide all data points ('point.show=false' also has similar effect)
@@ -46,6 +49,7 @@ export default {
 	 */
 	line_connectNull: false,
 	line_step_type: <"step"|"step-before"|"step-after"> "step",
+	line_step_tooltipMatch: false,
 	line_zerobased: false,
 	line_classes: <string[]|undefined> undefined,
 	line_point: <string[]|boolean> true

--- a/test/internals/tooltip-spec.ts
+++ b/test/internals/tooltip-spec.ts
@@ -411,6 +411,105 @@ describe("TOOLTIP", function() {
 			})
 		});
 
+		describe('tooltip index with step types and tooltipMatch', function () {
+			// x axis ticks getBoundingClientRect x are at [43.4375, 336.4375, 630.4375]
+			before(() => {
+				args = {
+					data: {
+						columns: [
+							['data1', 30, 40, 20],
+						],
+						type: 'step',
+					},
+					line: {
+						step: {
+							type: 'step',
+							tooltipMatch: true,
+						}
+					}
+				}
+			});
+
+			it("should have tooltip to nearest", () => {
+				util.hoverChart(chart, "mousemove", {clientX: 150, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(0);
+
+				util.hoverChart(chart, "mousemove", {clientX: 200, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(1);
+
+				util.hoverChart(chart, "mousemove", {clientX: 425, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(1);
+
+				util.hoverChart(chart, "mousemove", {clientX: 500, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(2);
+			})
+
+			it("set step type to step before", () => {
+				args.line.step.type = 'step-before';
+			});
+
+			it("should have tooltip to right", () => {
+				util.hoverChart(chart, "mousemove", {clientX: 150, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(1);
+
+				util.hoverChart(chart, "mousemove", {clientX: 200, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(1);
+
+				util.hoverChart(chart, "mousemove", {clientX: 450, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(2);
+
+				util.hoverChart(chart, "mousemove", {clientX: 500, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(2);
+			});
+
+			it("set step type to default", () => {
+				args.line.step.type = 'step-after';
+			});
+
+			const checkStepAfter = () => {
+				util.hoverChart(chart, "mousemove", {clientX: 150, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(0);
+
+				util.hoverChart(chart, "mousemove", {clientX: 200, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(0);
+
+				util.hoverChart(chart, "mousemove", {clientX: 450, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(1);
+
+				util.hoverChart(chart, "mousemove", {clientX: 500, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(1);
+			}
+
+			it("should have tooltip to left", () => {
+				checkStepAfter();
+			});
+
+			it("set timeseries", () => {
+				args.axis = {
+					x: {
+						type: "timeseries",
+					}
+				}
+				args.data.x = "x";
+				args.data.columns = args.data.columns.concat([
+					["x", "2021-01-01", "2021-01-02", "2021-01-03"],
+				]);
+			});
+
+			it("should work with timeseries", () => {
+				checkStepAfter();
+			});
+
+			it("should change when enter from right", () => {
+				util.hoverChart(chart, "mousemove", {clientX: 350, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(1);
+
+				util.hoverChart(chart, "mousemove", {clientX: 250, clientY: 300});
+				expect(chart.internal.state.eventReceiver.currentIdx).to.be.equal(0);
+			});
+
+		});
+
 		describe("Narrow width container's tooltip position", () => {
 			const orgArgs = args;
 


### PR DESCRIPTION
## Issue
#2287

## Details
Optionally makes tooltip show for point of moused over step for `step-after` and `step-before` charts.
Fixes the previous inconsistencies when mousing between step transitions and fixes it for timeseries charts.
Added note to the documentation that `data․type` must be `step`, and updated the demo to reflect this.

It's worth noting that prior to 5d3a5ed, this behavior was default for charts with `step-after` that weren't timeseries, but not `step-before`. I'm not sure what was intended, so I added it as an option with default `false` to be safe, though I think it makes the step chart feel far more intuitive.

`step-before` example: https://i.imgur.com/mXywDti.png
`step-after` example: https://i.imgur.com/IBoR69K.png

`step-after` with `tooltipMatch=false` (also current behavior): https://i.imgur.com/4B9rx2d.png