### PR TITLE
fix(types): Allow string dates for zoom() domain

### DIFF
--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -223,7 +223,7 @@ export interface Chart {
 		 * Zoom by giving x domain.
 		 * @param domain If domain is given, the chart will be zoomed to the given domain. If no argument is given, the current zoomed domain will be returned.
 		 */
-		(domain?: Array<Date|number>): Array<Date|number>;
+		(domain?: Array<Date|number|string>): Array<Date|number|string>;
 
 		/**
 		 * Enable and disable zooming.


### PR DESCRIPTION
The changes in 5f7779bdb191 ("fix(types): Fix wrong type definition")
provided support for Date type as argument in zoom(), but string dates
are also accepted and parsed properly, e.g. "2021-01-01T01:02:03.567".

Fix #2316
