### PR TITLE
fix(types): Fix type definition for load().json

### DIFF
--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -347,7 +347,7 @@ export interface Chart {
 	load(this: Chart, args: {
 		append?: boolean;
 		url?: string;
-		json?: [{ [key: string]: string }];
+		json?: [{ [key: string]: string | number }] | {[key: string]: string[] | number[]};
 		rows?: PrimitiveArray[];
 		columns?: PrimitiveArray[];
 		data?: Array<{ [key: string]: number }>;


### PR DESCRIPTION
The "json" field in the load() argument object accepts (at least) two
different types of information:

  Pattern: [{ [key: string]: string | number }]

    json: [
        {name: "www.site1.com", upload: 800, download: 500, total: 400},
    ]

  Pattern: {[key: string]: (string[]|number[])}

    json: {
        "data1": [220, 240, 270, 250, 280],
        "data2": [180, 150, 300, 70, 120]
    }

In the first case, we need to add "number" to the existing value type for
obvious reasons. In the second case, string might be needed in the
array to provide formatted dates, e.g. "2021-01-01T01:02:03.456"
