### PR TITLE
fix(grid): Make grid elements pass through pointer events

### DIFF
--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -62,6 +62,8 @@
 
 /*-- Grid --*/
 .bb-grid {
+	pointer-events: none;
+
 	line {
 		stroke: #aaa;
 	}

--- a/src/scss/theme/datalab.scss
+++ b/src/scss/theme/datalab.scss
@@ -62,6 +62,8 @@ $text-font-size: 11px;
 
 /*-- Grid --*/
 .bb-grid {
+    pointer-events: none;
+
     line {
         stroke: #f1f1f1;
     }

--- a/src/scss/theme/graph.scss
+++ b/src/scss/theme/graph.scss
@@ -72,6 +72,8 @@ $axis-color: #8c8c8c;
 
 /*-- Grid --*/
 .bb-grid {
+    pointer-events: none;
+
     line {
         stroke: #f1f1f1;
     }

--- a/src/scss/theme/insight.scss
+++ b/src/scss/theme/insight.scss
@@ -67,6 +67,8 @@ $font-family: sans-serif, Arial, "nanumgothic", "Dotum";
 
 /*-- Grid --*/
 .bb-grid {
+    pointer-events: none;
+
     line {
         stroke: #f1f1f1;
     }

--- a/test/internals/grid-spec.ts
+++ b/test/internals/grid-spec.ts
@@ -364,6 +364,13 @@ describe("GRID", function() {
 				};
 			});
 
+			it("grid elements shouldn't receive any pointer events", () => {
+				const {$el: {grid, gridLines}} = chart.internal;
+
+				expect(grid.main.style("pointer-events")).to.be.equal("none");
+				expect(gridLines.main.style("pointer-events")).to.be.equal("none");
+			})
+
 			it("should show 3 grid lines", () => {
 				expect(chart.$.main.selectAll(`.${CLASS.xgrid}-lines .${CLASS.xgrid}-line`).size()).to.be.equal(3);
 			});


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2355

## Details
<!-- Detailed description of the change/feature -->
Add 'pointer-events:none' to grid elements