### PR TITLE
fix(bar): fix bar radius rendering with clipPath=false option

### DIFF
--- a/src/ChartInternal/shape/bar.ts
+++ b/src/ChartInternal/shape/bar.ts
@@ -7,12 +7,20 @@ import {getPointer, getRandom, getRectSegList, isNumber} from "../../module/util
 
 export default {
 	initBar(): void {
-		const {$el} = this;
+		const {$el, config, state: {clip}} = this;
 
 		$el.bar = $el.main.select(`.${CLASS.chart}`)
 			// should positioned at the beginning of the shape node to not overlap others
 			.insert("g", ":first-child")
 			.attr("class", CLASS.chartBars);
+
+		// set clip-path attribute when condition meet
+		// https://github.com/naver/billboard.js/issues/2421
+		if (config.clipPath === false && (
+			config.bar_radius || config.bar_radius_ratio
+		)) {
+			$el.bar.attr("clip-path", clip.pathXAxis.replace(/#[^)]*/, `#${clip.id}`));
+		}
 	},
 
 	updateTargetsForBar(targets): void {
@@ -122,7 +130,7 @@ export default {
 			const pathRadius = ["", ""];
 			let radius = 0;
 
-			if (getRadius && !isGrouped) {
+			if (d.value !== 0 && getRadius && !isGrouped) {
 				const index = isRotated ? indexY : indexX;
 				const barW = points[2][index] - points[0][index];
 

--- a/test/shape/bar-spec.ts
+++ b/test/shape/bar-spec.ts
@@ -723,6 +723,40 @@ describe("SHAPE BAR", () => {
 		});
 	});
 
+	describe("bar radius", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data", 0, 30],
+					],
+					type: "bar"
+				},
+				clipPath: false,
+				bar: {
+					radius: {
+						ratio: 0.2
+					}
+				}
+			}
+		});
+
+		// https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#arcs
+		it("for zero value, Arc 'a' path command shouldn't be added ", () => {
+			expect(chart.$.bar.bars.attr("d").indexOf("a") === -1).to.be.true;
+		});
+
+		it("set options", () => {
+			args.data.columns[0][0] = 2;
+		});
+
+		it("clip-path attribute should be added, to avoid wrong rendering for small values", () => {
+			const chartBars = chart.$.main.select(`.${CLASS.chartBars}`).node();
+
+			expect(chartBars.getAttribute("clip-path")).to.be.ok;
+		})
+	});
+
 	describe("bar position", () => {
 		before(() => {
 			args = {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2421

## Details
<!-- Detailed description of the change/feature -->
- Make 0(zero) value to not apply Arc path command
- When clipPath=false is set, add clip-path attribute to bar element
