### PR TITLE
feat(bar): Intent to ship bar.indices.removeNull

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3741,6 +3741,42 @@ d3.select(".chart_area")
 		]
 	},
 	BarChartOptions: {
+		BarIndices: [
+			{
+				options: {
+					data: {
+						columns: [
+							['data1', 4, null, 4],
+							['data2', null, 3, null],
+							['data3', 1, 4, 4]
+						],
+						type: "bar"
+					},
+					bar: {
+						indices: {
+							removeNull: true
+						}
+					}
+				}
+			},
+			{
+				options: {
+					data: {
+						columns: [
+							['data1', 4, null, 4],
+							['data2', null, 3, null],
+							['data3', 1, 4, 4]
+						],
+						type: "bar"
+					},
+					bar: {
+						indices: {
+							removeNull: false
+						}
+					}
+				}
+			},
+		],
 		BarPadding: {
 			options: {
 				data: {

--- a/src/Chart/api/data.ts
+++ b/src/Chart/api/data.ts
@@ -4,8 +4,7 @@
  */
 import {DataItem} from "../../../types/types";
 import {extend, isUndefined, isArray} from "../../module/util";
-
-type DataParam = {x: number, value: number, id: string, index: number}[];
+import {IDataRow} from "../../ChartInternal/data/IData";
 
 /**
  * Get data loaded in the chart.
@@ -173,7 +172,7 @@ extend(data, {
 	 * chart.data.min();
 	 * // --> [{x: 0, value: 30, id: "data1", index: 0}, ...]
 	 */
-	min: function(): DataParam {
+	min: function(): IDataRow[] {
 		return this.internal.getMinMaxData().min;
 	},
 
@@ -188,7 +187,7 @@ extend(data, {
 	 * chart.data.max();
 	 * // --> [{x: 3, value: 400, id: "data1", index: 3}, ...]
 	 */
-	max: function(): DataParam {
+	max: function(): IDataRow[] {
 		return this.internal.getMinMaxData().max;
 	}
 });

--- a/src/ChartInternal/data/IData.ts
+++ b/src/ChartInternal/data/IData.ts
@@ -30,3 +30,12 @@ export interface IGridData {
 	text: string;
 	value: number;
 }
+
+export interface IDataIndice {
+    [key: string]: number;
+    __max__: number;
+}
+
+export type TIndices = {} | {
+    [key:string]: IDataIndice
+};

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -154,7 +154,7 @@ export default {
 			.map(t => $$.addName($$.getValueOnIndex(t.values, index)));
 
 		if (filterNull) {
-			value = value.filter(v => isValue(v.value));
+			value = value.filter(v => v && "value" in v && isValue(v.value));
 		}
 
 		return value;

--- a/src/Plugin/sparkline/index.ts
+++ b/src/Plugin/sparkline/index.ts
@@ -105,8 +105,8 @@ export default class Sparkline extends Plugin {
 		const {getBarW, getIndices} = $$;
 
 		// override internal methods to positioning bars
-		$$.getIndices = function(indices, id, caller) {
-			return caller === "getShapeX" ? {} : getIndices.call(this, indices, id);
+		$$.getIndices = function(indices, d, caller) {
+			return caller === "getShapeX" ? {} : getIndices.call(this, indices, d);
 		};
 
 		$$.getBarW = function(type, axis) {

--- a/src/config/Options/shape/bar.ts
+++ b/src/config/Options/shape/bar.ts
@@ -12,6 +12,7 @@ export default {
 	 * @memberof Options
 	 * @type {object}
 	 * @property {object} bar Bar object
+	 * @property {number} [bar.indices.removeNull=false] Remove nullish data on bar indices positions.
 	 * @property {number} [bar.label.threshold=0] Set threshold ratio to show/hide labels.
 	 * @property {number} [bar.padding=0] The padding pixel value between each bar.
 	 * @property {number} [bar.radius] Set the radius of bar edge in pixel.
@@ -27,12 +28,18 @@ export default {
 	 * @property {number} [bar.width.dataname.ratio=0.6] Change the width of bar chart by ratio.
 	 * @property {number} [bar.width.dataname.max] The maximum width value for ratio.
 	 * @property {boolean} [bar.zerobased=true] Set if min or max value will be 0 on bar chart.
+	 * @see [Demo: bar indices](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarIndices)
 	 * @see [Demo: bar padding](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarPadding)
 	 * @see [Demo: bar radius](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarRadius)
 	 * @see [Demo: bar width](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarWidth)
 	 * @see [Demo: bar width variant](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarWidthVariant)
 	 * @example
 	 *  bar: {
+	 *      // remove nullish data on bar indices postions
+	 *      indices: {
+	 *          removeNull: true
+	 *      },
+	 *
 	 *      padding: 1,
 	 *
 	 *      // bar radius
@@ -72,6 +79,7 @@ export default {
 	 *  }
 	 */
 	bar_label_threshold: 0,
+	bar_indices_removeNull: false,
 	bar_padding: 0,
 	bar_radius: <number|{ratio: number}|undefined> undefined,
 	bar_radius_ratio: <number|undefined> undefined,

--- a/test/shape/bar-spec.ts
+++ b/test/shape/bar-spec.ts
@@ -723,6 +723,38 @@ describe("SHAPE BAR", () => {
 		});
 	});
 
+	describe("bar indices", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 4, null, 4],
+						["data2", null, 3, null],
+						["data3", 1, 4, 4]
+					],
+					type: "bar"
+				},
+				bar: {
+					indices: {
+						removeNull: true
+					}
+				}
+			}
+		});
+
+		it("should redefined bar indices removing nullish values.", () => {
+			const {$: {bar}, internal} = chart;
+
+			bar.bars.each(d => {
+				const indices = internal.getIndices(null, d);
+
+				expect(indices.__max__).to.be.equal(1);
+				expect(indices.data3).to.be.equal(1);
+				expect(indices["data1" in indices ? "data1" : "data2"]).to.be.equal(0);
+			});
+		});
+	});
+
 	describe("bar radius", () => {
 		before(() => {
 			args = {

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -276,6 +276,41 @@ export interface ChartOptions {
 
 	bar?: {
 		/**
+		 * Set threshold ratio to show/hide labels.
+		 */
+		label?: {
+			threshold?: number;
+		}
+
+		/**
+		 * Remove nullish data on bar indices positions.
+		 */
+		indices?: {
+			removeNull?: boolean;
+		}
+
+		/**
+		 * The padding pixel value between each bar.
+		 */
+		padding?: number;
+
+		/**
+		 * Set the radius of bar edge in pixel.
+		 * - NOTE: Only for non-stacking bars.
+		 */
+		radius?: number | {
+			/**
+			 * Set the radius ratio of bar edge in relative the bar's width.
+			 */
+			ratio?: number;
+		};
+
+		/**
+		 * The senstivity offset value for interaction boundary.
+		 */
+		sensitivity?: number;
+
+		/**
 		 * Change the width of bar chart. If ratio is specified, change the width of bar chart by ratio.
 		 */
 		width?: number | {
@@ -298,45 +333,10 @@ export interface ChartOptions {
 			}
 		};
 
-		headers?: Array<{ [key: string]: string; }>;
-
-		/**
-		 * Set threshold ratio to show/hide labels.
-		 */
-		label?: {
-			threshold?: number;
-		}
-
 		/**
 		 * Set if min or max value will be 0 on bar chart.
 		 */
 		zerobased?: boolean;
-
-		/**
-		 * Set space between bars in bar charts
-		 */
-		space?: number;
-
-		/**
-		 * The padding pixel value between each bar.
-		 */
-		padding?: number;
-
-		/**
-		 * Set the radius of bar edge in pixel.
-		 * - NOTE: Only for non-stacking bars.
-		 */
-		radius?: number | {
-			/**
-			 * Set the radius ratio of bar edge in relative the bar's width.
-			 */
-			ratio?: number;
-		};
-
-		/**
-		 * The senstivity offset value for interaction boundary.
-		 */
-		sensitivity?: number;
 	};
 
 	bubble?: {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1687

## Details
<!-- Detailed description of the change/feature -->
Implement bar.indices.removeNull option, where make positioning
each bar shape's position on each tick removing nullish values.

ex) When data is given as:
  ```js
data: {
    columns: [
        ['data1', 4, null, 4],
        ['data2', null, 3, null],
        ['data3', 1, 4, 4]
    ]
}
  ```

- left: default
- right: with`bar.indices.removeNull=true` option
<img src=https://user-images.githubusercontent.com/2178435/146896091-db8b1cd4-b83b-45ee-93e3-2ce61fceef80.png width=500>
