### PR TITLE
refactor(all): Refactor class module

### DIFF
--- a/config/rollup/esm.js
+++ b/config/rollup/esm.js
@@ -49,6 +49,7 @@ const bbPlugins = readdirSync(resolvePath("../src/Plugin/"), {
             format: "es",
             banner: getBannerStr(true)
         },
+        treeshake: "smallest",
         plugins,
         external
     }));

--- a/config/webpack/plugin.cjs
+++ b/config/webpack/plugin.cjs
@@ -36,7 +36,7 @@ const config = {
 			banner: banner.production + banner.plugin,
 			entryOnly: true
 		})
-	],
+	]
 };
 
 module.exports = (common, env) => {

--- a/src/Chart/api/focus.ts
+++ b/src/Chart/api/focus.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {select as d3Select} from "d3-selection";
-import CLASS from "../../config/classes";
+import {$FOCUS, $GAUGE} from "../../config/classes";
 
 type FocusParam = string | string[];
 
@@ -36,13 +36,13 @@ export default {
 		this.revert();
 		this.defocus();
 
-		candidates.classed(CLASS.focused, true).classed(CLASS.defocused, false);
+		candidates.classed($FOCUS.focused, true).classed($FOCUS.defocused, false);
 
 		if ($$.hasArcType() && !state.hasRadar) {
 			$$.expandArc(targetIds);
 
 			$$.hasType("gauge") &&
-				$$.markOverlapped(targetIdsValue, $$, `.${CLASS.gaugeValue}`);
+				$$.markOverlapped(targetIdsValue, $$, `.${$GAUGE.gaugeValue}`);
 		}
 
 		$$.toggleFocusLegend(targetIds, true);
@@ -76,13 +76,13 @@ export default {
 			$$.selectorTargets(targetIds.filter($$.isTargetToShow, $$))
 		);
 
-		candidates.classed(CLASS.focused, false).classed(CLASS.defocused, true);
+		candidates.classed($FOCUS.focused, false).classed($FOCUS.defocused, true);
 
 		if ($$.hasArcType()) {
 			$$.unexpandArc(targetIds);
 
 			$$.hasType("gauge") &&
-				$$.undoMarkOverlapped($$, `.${CLASS.gaugeValue}`);
+				$$.undoMarkOverlapped($$, `.${$GAUGE.gaugeValue}`);
 		}
 
 		$$.toggleFocusLegend(targetIds, false);
@@ -114,16 +114,16 @@ export default {
 		const targetIds = $$.mapToTargetIds(targetIdsValue);
 		const candidates = $el.svg.selectAll($$.selectorTargets(targetIds)); // should be for all targets
 
-		candidates.classed(CLASS.focused, false).classed(CLASS.defocused, false);
+		candidates.classed($FOCUS.focused, false).classed($FOCUS.defocused, false);
 		$$.hasArcType() && $$.unexpandArc(targetIds);
 
 		if (config.legend_show) {
 			$$.showLegend(targetIds.filter($$.isLegendToShow.bind($$)));
 			$el.legend.selectAll($$.selectorLegends(targetIds))
 				.filter(function() {
-					return d3Select(this).classed(CLASS.legendItemFocused);
+					return d3Select(this).classed($FOCUS.legendItemFocused);
 				})
-				.classed(CLASS.legendItemFocused, false);
+				.classed($FOCUS.legendItemFocused, false);
 		}
 
 		state.focusedTargetIds = [];

--- a/src/Chart/api/regions.ts
+++ b/src/Chart/api/regions.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import CLASS from "../../config/classes";
+import {$REGION} from "../../config/classes";
 import {getOption, extend} from "../../module/util";
 
 type RegionsParam = {axis?: string, class?: string, start?: number, end?: number}[];
@@ -94,8 +94,8 @@ extend(regions, {
 		const {config, $T} = $$;
 
 		const options = optionsValue || {};
-		const classes = getOption(options, "classes", [CLASS.region]);
-		let regions = $$.$el.main.select(`.${CLASS.regions}`)
+		const classes = getOption(options, "classes", [$REGION.region]);
+		let regions = $$.$el.main.select(`.${$REGION.regions}`)
 			.selectAll(classes.map(c => `.${c}`));
 
 		$T(regions)

--- a/src/Chart/api/selection.ts
+++ b/src/Chart/api/selection.ts
@@ -4,7 +4,7 @@
  */
 import {select as d3Select} from "d3-selection";
 import {isDefined} from "../../module/util";
-import CLASS from "../../config/classes";
+import {$AREA, $LINE, $SELECT, $SHAPE} from "../../config/classes";
 import {DataItem} from "../../../types/types";
 
 export default {
@@ -28,10 +28,10 @@ export default {
 		const $$ = this.internal;
 		const dataPoint: DataItem[] = [];
 
-		$$.$el.main.selectAll(`.${CLASS.shapes + $$.getTargetSelectorSuffix(targetId)}`)
-			.selectAll(`.${CLASS.shape}`)
+		$$.$el.main.selectAll(`.${$SHAPE.shapes + $$.getTargetSelectorSuffix(targetId)}`)
+			.selectAll(`.${$SHAPE.shape}`)
 			.filter(function() {
-				return d3Select(this).classed(CLASS.SELECTED);
+				return d3Select(this).classed($SELECT.SELECTED);
 			})
 			.each(d => dataPoint.push(d));
 
@@ -70,27 +70,27 @@ export default {
 			return;
 		}
 
-		$el.main.selectAll(`.${CLASS.shapes}`)
-			.selectAll(`.${CLASS.shape}`)
+		$el.main.selectAll(`.${$SHAPE.shapes}`)
+			.selectAll(`.${$SHAPE.shape}`)
 			.each(function(d, i) {
 				const shape = d3Select(this);
 				const id = d.data ? d.data.id : d.id;
 				const toggle = $$.getToggle(this, d).bind($$);
 				const isTargetId = config.data_selection_grouped || !ids || ids.indexOf(id) >= 0;
 				const isTargetIndex = !indices || indices.indexOf(i) >= 0;
-				const isSelected = shape.classed(CLASS.SELECTED);
+				const isSelected = shape.classed($SELECT.SELECTED);
 
 				// line/area selection not supported yet
-				if (shape.classed(CLASS.line) || shape.classed(CLASS.area)) {
+				if (shape.classed($LINE.line) || shape.classed($AREA.area)) {
 					return;
 				}
 
 				if (isTargetId && isTargetIndex) {
 					if (config.data_selection_isselectable.bind($$.api)(d) && !isSelected) {
-						toggle(true, shape.classed(CLASS.SELECTED, true), d, i);
+						toggle(true, shape.classed($SELECT.SELECTED, true), d, i);
 					}
 				} else if (isDefined(resetOther) && resetOther && isSelected) {
-					toggle(false, shape.classed(CLASS.SELECTED, false), d, i);
+					toggle(false, shape.classed($SELECT.SELECTED, false), d, i);
 				}
 			});
 	},
@@ -120,18 +120,18 @@ export default {
 			return;
 		}
 
-		$el.main.selectAll(`.${CLASS.shapes}`)
-			.selectAll(`.${CLASS.shape}`)
+		$el.main.selectAll(`.${$SHAPE.shapes}`)
+			.selectAll(`.${$SHAPE.shape}`)
 			.each(function(d, i) {
 				const shape = d3Select(this);
 				const id = d.data ? d.data.id : d.id;
 				const toggle = $$.getToggle(this, d).bind($$);
 				const isTargetId = config.data_selection_grouped || !ids || ids.indexOf(id) >= 0;
 				const isTargetIndex = !indices || indices.indexOf(i) >= 0;
-				const isSelected = shape.classed(CLASS.SELECTED);
+				const isSelected = shape.classed($SELECT.SELECTED);
 
 				// line/area selection not supported yet
-				if (shape.classed(CLASS.line) || shape.classed(CLASS.area)) {
+				if (shape.classed($LINE.line) || shape.classed($AREA.area)) {
 					return;
 				}
 
@@ -140,7 +140,7 @@ export default {
 					config.data_selection_isselectable.bind($$.api)(d) &&
 					isSelected
 				) {
-					toggle(false, shape.classed(CLASS.SELECTED, false), d, i);
+					toggle(false, shape.classed($SELECT.SELECTED, false), d, i);
 				}
 			});
 	}

--- a/src/Chart/api/subchart.ts
+++ b/src/Chart/api/subchart.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import CLASS from "../../config/classes";
+import {$COMMON} from "../../config/classes";
 
 export default {
 	subchart: {
@@ -41,14 +41,14 @@ export default {
 				config.subchart_show = !show;
 				!subchart.main && $$.initSubchart();
 
-				let $target = subchart.main.selectAll(`.${CLASS.target}`);
+				let $target = subchart.main.selectAll(`.${$COMMON.target}`);
 
 				// need to cover when new data has been loaded
 				if ($$.data.targets.length !== $target.size()) {
 					$$.updateSizes();
 					$$.updateTargetsForSubchart($$.data.targets);
 
-					$target = subchart.main.selectAll(`.${CLASS.target}`);
+					$target = subchart.main.selectAll(`.${$COMMON.target}`);
 				}
 
 				$target.style("opacity", null);

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -10,7 +10,7 @@ import {
 } from "d3-axis";
 import AxisRenderer from "./AxisRenderer";
 import {getScale} from "../internals/scale";
-import CLASS from "../../config/classes";
+import {$AXIS} from "../../config/classes";
 import {capitalize, isArray, isFunction, isString, isValue, isEmpty, isNumber, isObjectType, mergeObj, notEmpty, parseDate, sortValue} from "../../module/util";
 
 export default {
@@ -45,7 +45,7 @@ class Axis {
 	}
 
 	private getAxisClassName(id) {
-		return `${CLASS.axis} ${CLASS[`axis${capitalize(id)}`]}`;
+		return `${$AXIS.axis} ${$AXIS[`axis${capitalize(id)}`]}`;
 	}
 
 	private isHorizontal($$, forHorizontal) {
@@ -100,7 +100,7 @@ class Axis {
 
 		target.forEach(v => {
 			const classAxis = this.getAxisClassName(v);
-			const classLabel = CLASS[`axis${v.toUpperCase()}Label`];
+			const classLabel = $AXIS[`axis${v.toUpperCase()}Label`];
 
 			axis[v] = main.append("g")
 				.attr("class", classAxis)
@@ -739,9 +739,9 @@ class Axis {
 		const {$el: {main}, $T} = $$;
 
 		const labels = {
-			x: main.select(`.${CLASS.axisX} .${CLASS.axisXLabel}`),
-			y: main.select(`.${CLASS.axisY} .${CLASS.axisYLabel}`),
-			y2: main.select(`.${CLASS.axisY2} .${CLASS.axisY2Label}`)
+			x: main.select(`.${$AXIS.axisX} .${$AXIS.axisXLabel}`),
+			y: main.select(`.${$AXIS.axisY} .${$AXIS.axisYLabel}`),
+			y2: main.select(`.${$AXIS.axisY2} .${$AXIS.axisY2Label}`)
 		};
 
 		Object.keys(labels).filter(id => !labels[id].empty())
@@ -979,7 +979,7 @@ class Axis {
 				if (type === "x") {
 					const clipPath = current.maxTickWidths.x.clipPath ? clip.pathXAxisTickTexts : null;
 
-					$el.svg.selectAll(`.${CLASS.axisX} .tick text`)
+					$el.svg.selectAll(`.${$AXIS.axisX} .tick text`)
 						.attr("clip-path", clipPath);
 				}
 			}

--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -12,8 +12,7 @@ import {
 import {select as d3Select} from "d3-selection";
 import {d3Selection} from "../../types/types";
 import {checkModuleImport} from "../module/error";
-
-import CLASS from "../config/classes";
+import {$COMMON, $TEXT} from "../config/classes";
 import Store from "../config/Store/Store";
 import Options from "../config/Options/Options";
 import {document, window} from "../module/browser";
@@ -413,7 +412,7 @@ export default class ChartInternal {
 
 		// Define regions
 		const main = $el.svg.append("g")
-			.classed(CLASS.main, true)
+			.classed($COMMON.main, true)
 			.attr("transform", $$.getTranslate("main"));
 
 		$el.main = main;
@@ -430,7 +429,7 @@ export default class ChartInternal {
 		// text when empty
 		if (config.data_empty_label_text) {
 			main.append("text")
-				.attr("class", `${CLASS.text} ${CLASS.empty}`)
+				.attr("class", `${$TEXT.text} ${$COMMON.empty}`)
 				.attr("text-anchor", "middle") // horizontal centering of text at x position in all browsers.
 				.attr("dominant-baseline", "middle"); // vertical centering of text at y position in all browsers, except IE.
 		}
@@ -444,7 +443,7 @@ export default class ChartInternal {
 		}
 
 		// Define g for chart area
-		main.append("g").attr("class", CLASS.chart)
+		main.append("g").attr("class", $COMMON.chart)
 			.attr("clip-path", state.clip.path);
 
 		$$.callPluginHook("$init");
@@ -645,7 +644,7 @@ export default class ChartInternal {
 		const $$ = <any> this;
 		const {$el: {svg}, $T} = $$;
 
-		$T(svg.selectAll(`.${CLASS.target}`)
+		$T(svg.selectAll(`.${$COMMON.target}`)
 			.filter(d => $$.isTargetToShow(d.id))
 		).style("opacity", null);
 	}

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import CLASS from "../../config/classes";
+import {$BAR, $CANDLESTICK, $COMMON} from "../../config/classes";
 import {KEY} from "../../module/Cache";
 import {IData, IDataRow} from "./IData";
 import {
@@ -750,8 +750,8 @@ export default {
 			.filter(v => $$.isBarType(v.id) || $$.isCandlestickType(v.id))
 			.forEach(v => {
 				const selector = $$.isBarType(v.id) ?
-					`.${CLASS.chartBar}.${CLASS.target}${$$.getTargetSelectorSuffix(v.id)} .${CLASS.bar}-${v.index}` :
-					`.${CLASS.chartCandlestick}.${CLASS.target}${$$.getTargetSelectorSuffix(v.id)} .${CLASS.candlestick}-${v.index} path`;
+					`.${$BAR.chartBar}.${$COMMON.target}${$$.getTargetSelectorSuffix(v.id)} .${$BAR.bar}-${v.index}` :
+					`.${$CANDLESTICK.chartCandlestick}.${$COMMON.target}${$$.getTargetSelectorSuffix(v.id)} .${$CANDLESTICK.candlestick}-${v.index} path`;
 
 				if (!closest && $$.isWithinBar(main.select(selector).node())) {
 					closest = v;

--- a/src/ChartInternal/data/load.ts
+++ b/src/ChartInternal/data/load.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import CLASS from "../../config/classes";
+import {$LEGEND} from "../../config/classes";
 import {endall} from "../../module/util";
 
 export default {
@@ -111,7 +111,7 @@ export default {
 
 			// Remove target's elements
 			if ($el.legend) {
-				$el.legend.selectAll(`.${CLASS.legendItem}${$$.getTargetSelectorSuffix(id)}`).remove();
+				$el.legend.selectAll(`.${$LEGEND.legendItem}${$$.getTargetSelectorSuffix(id)}`).remove();
 			}
 
 			// Remove target

--- a/src/ChartInternal/interactions/drag.ts
+++ b/src/ChartInternal/interactions/drag.ts
@@ -4,7 +4,7 @@
  */
 import {select as d3Select} from "d3-selection";
 import {d3Selection} from "../../../types/types";
-import CLASS from "../../config/classes";
+import {$BAR, $CIRCLE, $COMMON, $DRAG, $SELECT, $SHAPE} from "../../config/classes";
 import {getPathBox} from "../../module/util";
 
 /**
@@ -39,30 +39,30 @@ export default {
 		const minY = isSelectionGrouped ? state.margin.top : Math.min(sy, my);
 		const maxY = isSelectionGrouped ? state.height : Math.max(sy, my);
 
-		main.select(`.${CLASS.dragarea}`)
+		main.select(`.${$DRAG.dragarea}`)
 			.attr("x", minX)
 			.attr("y", minY)
 			.attr("width", maxX - minX)
 			.attr("height", maxY - minY);
 
 		// TODO: binary search when multiple xs
-		main.selectAll(`.${CLASS.shapes}`)
-			.selectAll(`.${CLASS.shape}`)
+		main.selectAll(`.${$SHAPE.shapes}`)
+			.selectAll(`.${$SHAPE.shape}`)
 			.filter(d => isSelectable?.bind($$.api)(d))
 			.each(function(d, i) {
 				const shape: d3Selection = d3Select(this);
-				const isSelected = shape.classed(CLASS.SELECTED);
-				const isIncluded = shape.classed(CLASS.INCLUDED);
+				const isSelected = shape.classed($SELECT.SELECTED);
+				const isIncluded = shape.classed($DRAG.INCLUDED);
 				let isWithin: any = false;
 				let toggle;
 
-				if (shape.classed(CLASS.circle)) {
+				if (shape.classed($CIRCLE.circle)) {
 					const x: number = +shape.attr("cx") * 1;
 					const y: number = +shape.attr("cy") * 1;
 
 					toggle = $$.togglePoint;
 					isWithin = minX < x && x < maxX && minY < y && y < maxY;
-				} else if (shape.classed(CLASS.bar)) {
+				} else if (shape.classed($BAR.bar)) {
 					const {x, y, width, height} = getPathBox(this);
 
 					toggle = $$.togglePath;
@@ -74,9 +74,9 @@ export default {
 
 				// @ts-ignore
 				if (isWithin ^ isIncluded) {
-					shape.classed(CLASS.INCLUDED, !isIncluded);
+					shape.classed($DRAG.INCLUDED, !isIncluded);
 					// TODO: included/unincluded callback here
-					shape.classed(CLASS.SELECTED, !isSelected);
+					shape.classed($SELECT.SELECTED, !isSelected);
 					toggle.call($$, !isSelected, shape, d, i);
 				}
 			});
@@ -98,9 +98,9 @@ export default {
 
 		state.dragStart = mouse;
 
-		main.select(`.${CLASS.chart}`)
+		main.select(`.${$COMMON.chart}`)
 			.append("rect")
-			.attr("class", CLASS.dragarea)
+			.attr("class", $DRAG.dragarea)
 			.style("opacity", "0.1");
 
 		$$.setDragStatus(true);
@@ -119,12 +119,12 @@ export default {
 			return;
 		}
 
-		$T(main.select(`.${CLASS.dragarea}`))
+		$T(main.select(`.${$DRAG.dragarea}`))
 			.style("opacity", "0")
 			.remove();
 
-		main.selectAll(`.${CLASS.shape}`)
-			.classed(CLASS.INCLUDED, false);
+		main.selectAll(`.${$SHAPE.shape}`)
+			.classed($DRAG.INCLUDED, false);
 
 		$$.setDragStatus(false);
 	}

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import CLASS from "../../config/classes";
+import {$COMMON, $EVENT, $SHAPE} from "../../config/classes";
 import {isboolean, getPointer, isFunction} from "../../module/util";
 
 export default {
@@ -14,9 +14,9 @@ export default {
 	initEventRect(): void {
 		const $$ = this;
 
-		$$.$el.main.select(`.${CLASS.chart}`)
+		$$.$el.main.select(`.${$COMMON.chart}`)
 			.append("g")
-			.attr("class", CLASS.eventRects)
+			.attr("class", $EVENT.eventRects)
 			.style("fill-opacity", "0");
 	},
 
@@ -32,15 +32,15 @@ export default {
 		if ($el.eventRect) {
 			$$.updateEventRect($el.eventRect, true);
 		} else {
-			const eventRects = $$.$el.main.select(`.${CLASS.eventRects}`)
+			const eventRects = $$.$el.main.select(`.${$EVENT.eventRects}`)
 				.style("cursor", config.zoom_enabled && config.zoom_type !== "drag" ? (
 					config.axis_rotated ? "ns-resize" : "ew-resize"
 				) : null)
-				.classed(CLASS.eventRectsMultiple, isMultipleX)
-				.classed(CLASS.eventRectsSingle, !isMultipleX);
+				.classed($EVENT.eventRectsMultiple, isMultipleX)
+				.classed($EVENT.eventRectsSingle, !isMultipleX);
 
 			// append event <rect>
-			const eventRectUpdate = eventRects.selectAll(`.${CLASS.eventRect}`)
+			const eventRectUpdate = eventRects.selectAll(`.${$EVENT.eventRect}`)
 				.data([0])
 				.enter()
 				.append("rect");
@@ -139,7 +139,7 @@ export default {
 			.on("touchstart.eventRect touchmove.eventRect", event => {
 				state.event = event;
 
-				if (!eventRect.empty() && eventRect.classed(CLASS.eventRect)) {
+				if (!eventRect.empty() && eventRect.classed($EVENT.eventRect)) {
 					// if touch points are > 1, means doing zooming interaction. In this case do not execute tooltip codes.
 					if (state.dragging || state.flowing || $$.hasArcType() || event.touches.length > 1) {
 						return;
@@ -154,7 +154,7 @@ export default {
 			.on("touchend.eventRect", event => {
 				state.event = event;
 
-				if (!eventRect.empty() && eventRect.classed(CLASS.eventRect)) {
+				if (!eventRect.empty() && eventRect.classed($EVENT.eventRect)) {
 					if ($$.hasArcType() || !$$.toggleShape || state.cancelClick) {
 						state.cancelClick && (state.cancelClick = false);
 					}
@@ -199,7 +199,7 @@ export default {
 
 			// only for init
 			if (!rendered) {
-				rectElement.attr("class", CLASS.eventRect);
+				rectElement.attr("class", $EVENT.eventRect);
 			}
 		}
 
@@ -334,7 +334,7 @@ export default {
 
 		// Show cursor as pointer if point is close to mouse position
 		if ($$.isBarType(closest.id) || $$.dist(closest, mouse) < config.point_sensitivity) {
-			$$.$el.svg.select(`.${CLASS.eventRect}`).style("cursor", "pointer");
+			$$.$el.svg.select(`.${$EVENT.eventRect}`).style("cursor", "pointer");
 
 			if (!state.mouseover) {
 				config.data_onover.call($$.api, closest);
@@ -351,7 +351,7 @@ export default {
 		const $$ = this;
 		const {config, $el: {circle, tooltip}} = $$;
 
-		$$.$el.svg.select(`.${CLASS.eventRect}`).style("cursor", null);
+		$$.$el.svg.select(`.${$EVENT.eventRect}`).style("cursor", null);
 		$$.hideGridFocus();
 
 		if (tooltip) {
@@ -366,8 +366,8 @@ export default {
 	/**
 	 * Create eventRect for each data on the x-axis.
 	 * Register touch and drag events.
-	 * @param {object} eventRectEnter d3.select(CLASS.eventRects) object.
-	 * @returns {object} d3.select(CLASS.eventRects) object.
+	 * @param {object} eventRectEnter d3.select($EVENT.eventRects) object.
+	 * @returns {object} d3.select($EVENT.eventRects) object.
 	 * @private
 	 */
 	generateEventRectsForSingleX(eventRectEnter) {
@@ -476,7 +476,7 @@ export default {
 
 		const {index} = d;
 
-		main.selectAll(`.${CLASS.shape}-${index}`)
+		main.selectAll(`.${$SHAPE.shape}-${index}`)
 			.each(function(d2) {
 				if (config.data_selection_grouped || $$.isWithinShape(this, d2)) {
 					$$.toggleShape?.(this, d2, index);
@@ -488,7 +488,7 @@ export default {
 	/**
 	 * Create an eventRect,
 	 * Register touch and drag events.
-	 * @param {object} eventRectEnter d3.select(CLASS.eventRects) object.
+	 * @param {object} eventRectEnter d3.select($EVENT.eventRects) object.
 	 * @private
 	 */
 	generateEventRectsForMultipleXs(eventRectEnter): void {
@@ -538,8 +538,8 @@ export default {
 
 		// select if selection enabled
 		if ($$.isBarType(closest.id) || $$.dist(closest, mouse) < config.point_sensitivity) {
-			$$.$el.main.selectAll(`.${CLASS.shapes}${$$.getTargetSelectorSuffix(closest.id)}`)
-				.selectAll(`.${CLASS.shape}-${closest.index}`)
+			$$.$el.main.selectAll(`.${$SHAPE.shapes}${$$.getTargetSelectorSuffix(closest.id)}`)
+				.selectAll(`.${$SHAPE.shape}-${closest.index}`)
 				.each(function() {
 					if (config.data_selection_grouped || $$.isWithinShape(this, closest)) {
 						$$.toggleShape?.(this, closest, closest.index);

--- a/src/ChartInternal/interactions/interaction.ts
+++ b/src/ChartInternal/interactions/interaction.ts
@@ -4,7 +4,7 @@
  */
 import {select as d3Select} from "d3-selection";
 import {drag as d3Drag} from "d3-drag";
-import CLASS from "../../config/classes";
+import {$ARC, $AXIS, $COMMON, $SHAPE} from "../../config/classes";
 import {KEY} from "../../module/Cache";
 import {emulateEvent, getPointer, isNumber, isObject} from "../../module/util";
 
@@ -27,9 +27,9 @@ export default {
 			}
 		}
 
-		main.selectAll(`.${CLASS.shape}-${index}`)
+		main.selectAll(`.${$SHAPE.shape}-${index}`)
 			.each(function() {
-				d3Select(this).classed(CLASS.EXPANDED, true);
+				d3Select(this).classed($COMMON.EXPANDED, true);
 
 				if (isSelectionEnabled) {
 					eventRect.style("cursor", isSelectionGrouped ? "pointer" : null);
@@ -96,8 +96,8 @@ export default {
 		["bar", "candlestick"]
 			.filter(v => $$.$el[v])
 			.forEach(v => {
-				reset && $$.$el[v].classed(CLASS.EXPANDED, false);
-				$$.getShapeByIndex(v, i, id).classed(CLASS.EXPANDED, expand);
+				reset && $$.$el[v].classed($COMMON.EXPANDED, false);
+				$$.getShapeByIndex(v, i, id).classed($COMMON.EXPANDED, expand);
 			});
 	},
 
@@ -119,11 +119,11 @@ export default {
 			config.color_onover && $$.setOverColor(isOver, d, isArc);
 
 			if (isArc) {
-				callback(d, main.select(`.${CLASS.arc}${$$.getTargetSelectorSuffix(d.id)}`).node());
+				callback(d, main.select(`.${$ARC.arc}${$$.getTargetSelectorSuffix(d.id)}`).node());
 			} else if (!config.tooltip_grouped) {
 				let last = $$.cache.get(KEY.setOverOut) || [];
 
-				const shape = main.selectAll(`.${CLASS.shape}-${d}`)
+				const shape = main.selectAll(`.${$SHAPE.shape}-${d}`)
 					.filter(function(d) {
 						return $$.isWithinShape(this, d);
 					});
@@ -151,7 +151,7 @@ export default {
 						$$.setExpand(d, null, true);
 				}
 
-				!$$.isMultipleX() && main.selectAll(`.${CLASS.shape}-${d}`)
+				!$$.isMultipleX() && main.selectAll(`.${$SHAPE.shape}-${d}`)
 					.each(function(d) {
 						callback(d, this);
 					});
@@ -213,8 +213,8 @@ export default {
 		const {config, state: {eventReceiver, hasAxis, hasRadar}, $el: {eventRect, arcs, radar}} = $$;
 		const isMultipleX = $$.isMultipleX();
 		const element = (
-			hasRadar ? radar.axes.select(`.${CLASS.axis}-${index} text`) : (
-				eventRect || arcs.selectAll(`.${CLASS.target} path`).filter((d, i) => i === index)
+			hasRadar ? radar.axes.select(`.${$AXIS.axis}-${index} text`) : (
+				eventRect || arcs.selectAll(`.${$COMMON.target} path`).filter((d, i) => i === index)
 			)
 		).node();
 

--- a/src/ChartInternal/interactions/zoom.ts
+++ b/src/ChartInternal/interactions/zoom.ts
@@ -4,7 +4,7 @@
  */
 import {drag as d3Drag} from "d3-drag";
 import {zoomIdentity as d3ZoomIdentity, zoom as d3Zoom} from "d3-zoom";
-import CLASS from "../../config/classes";
+import {$COMMON, $ZOOM} from "../../config/classes";
 import {callFn, diffDomain, getPointer, isFunction} from "../../module/util";
 
 export default {
@@ -301,7 +301,7 @@ export default {
 				if (!zoomRect) {
 					zoomRect = $$.$el.main.append("rect")
 						.attr("clip-path", state.clip.path)
-						.attr("class", CLASS.zoomBrush)
+						.attr("class", $ZOOM.zoomBrush)
 						.attr("width", isRotated ? state.width : 0)
 						.attr("height", isRotated ? 0 : state.height);
 				}
@@ -356,13 +356,13 @@ export default {
 		if (resetButton && config.zoom_type === "drag") {
 			if (!$el.zoomResetBtn) {
 				$el.zoomResetBtn = $$.$el.chart.append("div")
-					.classed(CLASS.button, true)
+					.classed($COMMON.button, true)
 					.append("span")
 					.on("click", function() {
 						isFunction(resetButton.onclick) && resetButton.onclick.bind($$.api)(this);
 						$$.api.unzoom();
 					})
-					.classed(CLASS.buttonZoomReset, true)
+					.classed($ZOOM.buttonZoomReset, true)
 					.text(resetButton.text || "Reset Zoom");
 			} else {
 				$el.zoomResetBtn.style("display", null);

--- a/src/ChartInternal/internals/color.ts
+++ b/src/ChartInternal/internals/color.ts
@@ -5,7 +5,7 @@
 import {select as d3Select} from "d3-selection";
 import {scaleOrdinal as d3ScaleOrdinal} from "d3-scale";
 import {document, window} from "../../module/browser";
-import CLASS from "../../config/classes";
+import {$ARC, $COLOR, $SHAPE} from "../../config/classes";
 import {KEY} from "../../module/Cache";
 import {notEmpty, isFunction, isObject, isString} from "../../module/util";
 
@@ -54,7 +54,7 @@ export default {
 			const delimiter = ";";
 			const span = document.createElement("span");
 
-			span.className = CLASS.colorPattern;
+			span.className = $COLOR.colorPattern;
 			span.style.display = "none";
 			body.appendChild(span);
 
@@ -214,8 +214,8 @@ export default {
 		main.selectAll(
 			isObject(d) ?
 				// when is Arc type
-				`.${CLASS.arc}${$$.getTargetSelectorSuffix(d.id)}` :
-				`.${CLASS.shape}-${d}`
+				`.${$ARC.arc}${$$.getTargetSelectorSuffix(d.id)}` :
+				`.${$SHAPE.shape}-${d}`
 		).style("fill", color);
 	}
 };

--- a/src/ChartInternal/internals/grid.ts
+++ b/src/ChartInternal/internals/grid.ts
@@ -6,7 +6,7 @@ import {
 	select as d3Select,
 	selectAll as d3SelectAll
 } from "d3-selection";
-import CLASS from "../../config/classes";
+import {$AXIS, $COMMON, $FOCUS, $GRID} from "../../config/classes";
 import {isArray, isValue} from "../../module/util";
 
 // Grid position and text anchor helpers
@@ -72,12 +72,12 @@ export default {
 		const {config, state: {clip}, $el} = $$;
 
 		if (config.grid_x_lines.length || config.grid_y_lines.length) {
-			$el.gridLines.main = $el.main.insert("g", `.${CLASS.chart}${config.grid_lines_front ? " + *" : ""}`)
+			$el.gridLines.main = $el.main.insert("g", `.${$COMMON.chart}${config.grid_lines_front ? " + *" : ""}`)
 				.attr("clip-path", clip.pathGrid)
-				.attr("class", `${CLASS.grid} ${CLASS.gridLines}`);
+				.attr("class", `${$GRID.grid} ${$GRID.gridLines}`);
 
-			$el.gridLines.main.append("g").attr("class", CLASS.xgridLines);
-			$el.gridLines.main.append("g").attr("class", CLASS.ygridLines);
+			$el.gridLines.main.append("g").attr("class", $GRID.xgridLines);
+			$el.gridLines.main.append("g").attr("class", $GRID.ygridLines);
 
 			$el.gridLines.x = d3SelectAll([]);
 		}
@@ -105,15 +105,15 @@ export default {
 			"y2": state.height,
 		};
 
-		grid.x = main.select(`.${CLASS.xgrids}`)
-			.selectAll(`.${CLASS.xgrid}`)
+		grid.x = main.select(`.${$GRID.xgrids}`)
+			.selectAll(`.${$GRID.xgrid}`)
 			.data(xgridData);
 
 		grid.x.exit().remove();
 
 		grid.x = grid.x.enter()
 			.append("line")
-			.attr("class", CLASS.xgrid)
+			.attr("class", $GRID.xgrid)
 			.merge(grid.x);
 
 		if (!withoutUpdate) {
@@ -138,8 +138,8 @@ export default {
 		const gridValues = $$.axis.y.tickValues() || $$.scale.y.ticks(config.grid_y_ticks);
 		const pos = d => Math.ceil($$.scale.y(d));
 
-		grid.y = main.select(`.${CLASS.ygrids}`)
-			.selectAll(`.${CLASS.ygrid}`)
+		grid.y = main.select(`.${$GRID.ygrids}`)
+			.selectAll(`.${$GRID.ygrid}`)
 			.data(gridValues);
 
 		grid.y.exit().remove();
@@ -147,7 +147,7 @@ export default {
 		grid.y = grid.y
 			.enter()
 			.append("line")
-			.attr("class", CLASS.ygrid)
+			.attr("class", $GRID.ygrid)
 			.merge(grid.y);
 
 		grid.y.attr("x1", isRotated ? pos : 0)
@@ -183,8 +183,8 @@ export default {
 
 		config.grid_x_show && $$.updateXGrid();
 
-		let xLines = main.select(`.${CLASS.xgridLines}`)
-			.selectAll(`.${CLASS.xgridLine}`)
+		let xLines = main.select(`.${$GRID.xgridLines}`)
+			.selectAll(`.${$GRID.xgridLine}`)
 			.data(config.grid_x_lines);
 
 		// exit
@@ -206,7 +206,7 @@ export default {
 		xLines = xgridLine.merge(xLines);
 
 		$T(xLines
-			.attr("class", d => `${CLASS.xgridLine} ${d.class || ""}`.trim())
+			.attr("class", d => `${$GRID.xgridLine} ${d.class || ""}`.trim())
 			.select("text")
 			.attr("text-anchor", getGridTextAnchor)
 			.attr("dx", getGridTextDx)
@@ -228,8 +228,8 @@ export default {
 
 		config.grid_y_show && $$.updateYGrid();
 
-		let ygridLines = $el.main.select(`.${CLASS.ygridLines}`)
-			.selectAll(`.${CLASS.ygridLine}`)
+		let ygridLines = $el.main.select(`.${$GRID.ygridLines}`)
+			.selectAll(`.${$GRID.ygridLine}`)
 			.data(config.grid_y_lines);
 
 		// exit
@@ -253,7 +253,7 @@ export default {
 		const yv = $$.yv.bind($$);
 
 		$T(ygridLines
-			.attr("class", d => `${CLASS.ygridLine} ${d.class || ""}`.trim())
+			.attr("class", d => `${$GRID.ygridLine} ${d.class || ""}`.trim())
 			.select("line"))
 			.attr("x1", isRotated ? yv : 0)
 			.attr("x2", isRotated ? yv : width)
@@ -307,32 +307,32 @@ export default {
 		const $$ = this;
 		const {config, state: {clip}, $el} = $$;
 		const isFront = config.grid_front;
-		const className = `.${CLASS[isFront && $el.gridLines.main ? "gridLines" : "chart"]}${isFront ? " + *" : ""}`;
+		const className = `.${isFront && $el.gridLines.main ? $GRID.gridLines : $COMMON.chart}${isFront ? " + *" : ""}`;
 
 		const grid = $el.main.insert("g", className)
 			.attr("clip-path", clip.pathGrid)
-			.attr("class", CLASS.grid);
+			.attr("class", $GRID.grid);
 
 		$el.grid.main = grid;
 
 		config.grid_x_show &&
-			grid.append("g").attr("class", CLASS.xgrids);
+			grid.append("g").attr("class", $GRID.xgrids);
 
 		config.grid_y_show &&
-			grid.append("g").attr("class", CLASS.ygrids);
+			grid.append("g").attr("class", $GRID.ygrids);
 
 		if (config.interaction_enabled && config.grid_focus_show) {
 			grid.append("g")
-				.attr("class", CLASS.xgridFocus)
+				.attr("class", $FOCUS.xgridFocus)
 				.append("line")
-				.attr("class", CLASS.xgridFocus);
+				.attr("class", $FOCUS.xgridFocus);
 
 			// to show xy focus grid line, should be 'tooltip.grouped=false'
 			if (config.grid_focus_y && !config.tooltip_grouped) {
 				grid.append("g")
-					.attr("class", CLASS.ygridFocus)
+					.attr("class", $FOCUS.ygridFocus)
 					.append("line")
-					.attr("class", CLASS.ygridFocus);
+					.attr("class", $FOCUS.ygridFocus);
 			}
 		}
 	},
@@ -346,7 +346,7 @@ export default {
 		const $$ = this;
 		const {config, state: {width, height}} = $$;
 		const isRotated = config.axis_rotated;
-		const focusEl = $$.$el.main.selectAll(`line.${CLASS.xgridFocus}, line.${CLASS.ygridFocus}`);
+		const focusEl = $$.$el.main.selectAll(`line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`);
 
 		const dataToShow = (data || [focusEl.datum()]).filter(d => d && isValue($$.getBaseValue(d)));
 
@@ -369,7 +369,7 @@ export default {
 				};
 				let xy;
 
-				if (el.classed(CLASS.xgridFocus)) {
+				if (el.classed($FOCUS.xgridFocus)) {
 					// will contain 'x1, y1, x2, y2' order
 					xy = isRotated ?
 						[
@@ -413,7 +413,7 @@ export default {
 		const {state: {inputType, resizing}, $el: {main}} = $$;
 
 		if (inputType === "mouse" || !resizing) {
-			main.selectAll(`line.${CLASS.xgridFocus}, line.${CLASS.ygridFocus}`)
+			main.selectAll(`line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`)
 				.style("visibility", "hidden");
 
 			$$.hideCircleFocus?.();
@@ -423,7 +423,7 @@ export default {
 	updateGridFocus(): boolean {
 		const $$ = this;
 		const {state: {inputType, width, height, resizing}, $el: {grid}} = $$;
-		const xgridFocus = grid.main.select(`line.${CLASS.xgridFocus}`);
+		const xgridFocus = grid.main.select(`line.${$FOCUS.xgridFocus}`);
 
 		if (inputType === "touch") {
 			if (xgridFocus.empty()) {
@@ -448,7 +448,7 @@ export default {
 
 	generateGridData(type: string, scale) {
 		const $$ = this;
-		const tickNum = $$.$el.main.select(`.${CLASS.axisX}`)
+		const tickNum = $$.$el.main.select(`.${$AXIS.axisX}`)
 			.selectAll(".tick")
 			.size();
 		let gridData: Date[] = [];
@@ -490,8 +490,8 @@ export default {
 		const {config, $T} = $$;
 		const toRemove = $$.getGridFilterToRemove(params);
 		const toShow = line => !toRemove(line);
-		const classLines = forX ? CLASS.xgridLines : CLASS.ygridLines;
-		const classLine = forX ? CLASS.xgridLine : CLASS.ygridLine;
+		const classLines = forX ? $GRID.xgridLines : $GRID.ygridLines;
+		const classLine = forX ? $GRID.xgridLine : $GRID.ygridLine;
 
 		$T($$.$el.main.select(`.${classLines}`)
 			.selectAll(`.${classLine}`)

--- a/src/ChartInternal/internals/legend.ts
+++ b/src/ChartInternal/internals/legend.ts
@@ -7,7 +7,7 @@ import {
 	namespaces as d3Namespaces
 } from "d3-selection";
 import {document} from "../../module/browser";
-import CLASS from "../../config/classes";
+import {$FOCUS, $GAUGE, $LEGEND} from "../../config/classes";
 import {KEY} from "../../module/Cache";
 import {callFn, isDefined, getOption, isEmpty, isFunction, notEmpty, tplProcess} from "../../module/util";
 
@@ -26,7 +26,7 @@ export default {
 		if (config.legend_show) {
 			if (!config.legend_contents_bindto) {
 				$el.legend = $$.$el.svg.append("g")
-					.classed(CLASS.legend, true)
+					.classed($LEGEND.legend, true)
 					.attr("transform", $$.getTranslate("legend"));
 			}
 
@@ -68,8 +68,8 @@ export default {
 		}
 
 		// toggle legend state
-		$el.legend.selectAll(`.${CLASS.legendItem}`)
-			.classed(CLASS.legendItemHidden, function(id) {
+		$el.legend.selectAll(`.${$LEGEND.legendItem}`)
+			.classed($LEGEND.legendItemHidden, function(id) {
 				const hide = !$$.isTargetToShow(id);
 
 				if (hide) {
@@ -209,7 +209,7 @@ export default {
 		const {legend} = this.$el;
 
 		if (legend) {
-			legend.select(`.${CLASS.legendItem}-${id} line`)
+			legend.select(`.${$LEGEND.legendItem}-${id} line`)
 				.style("stroke", color);
 		}
 	},
@@ -251,7 +251,7 @@ export default {
 	 * @private
 	 */
 	opacityForUnfocusedLegend(legendItem): string | null {
-		return legendItem.classed(CLASS.legendItemHidden) ? null : "0.3";
+		return legendItem.classed($LEGEND.legendItemHidden) ? null : "0.3";
 	},
 
 	/**
@@ -265,9 +265,9 @@ export default {
 		const {$el: {legend}, $T} = $$;
 		const targetIdz = $$.mapToTargetIds(targetIds);
 
-		legend && $T(legend.selectAll(`.${CLASS.legendItem}`)
+		legend && $T(legend.selectAll(`.${$LEGEND.legendItem}`)
 			.filter(id => targetIdz.indexOf(id) >= 0)
-			.classed(CLASS.legendItemFocused, focus))
+			.classed($FOCUS.legendItemFocused, focus))
 			.style("opacity", function() {
 				return focus ? null :
 					$$.opacityForUnfocusedLegend.call($$, d3Select(this));
@@ -282,8 +282,8 @@ export default {
 		const $$ = this;
 		const {$el: {legend}, $T} = $$;
 
-		legend && $T(legend.selectAll(`.${CLASS.legendItem}`)
-			.classed(CLASS.legendItemFocused, false))
+		legend && $T(legend.selectAll(`.${$LEGEND.legendItem}`)
+			.classed($FOCUS.legendItemFocused, false))
 			.style("opacity", null);
 	},
 
@@ -353,7 +353,7 @@ export default {
 			data = (!state.redrawing && cache.get(cacheKey)) || {};
 
 			if (!data[id]) {
-				data[id] = $$.getTextRect(textElement, CLASS.legendItem);
+				data[id] = $$.getTextRect(textElement, $LEGEND.legendItem);
 				cache.add(cacheKey, data);
 			}
 
@@ -379,7 +379,7 @@ export default {
 				const node = d3Select(this);
 				const itemClass = (!node.empty() && node.attr("class")) || "";
 
-				return itemClass + $$.generateClass(CLASS.legendItem, id);
+				return itemClass + $$.generateClass($LEGEND.legendItem, id);
 			})
 			.style("visibility", id => ($$.isLegendToShow(id) ? null : "hidden"));
 
@@ -395,7 +395,7 @@ export default {
 							api.toggle(id);
 
 							d3Select(this)
-								.classed(CLASS.legendItemFocused, false);
+								.classed($FOCUS.legendItemFocused, false);
 						}
 					}
 
@@ -405,10 +405,10 @@ export default {
 			!isTouch && item
 				.on("mouseout", function(event, id) {
 					if (!callFn(config.legend_item_onout, api, id)) {
-						d3Select(this).classed(CLASS.legendItemFocused, false);
+						d3Select(this).classed($FOCUS.legendItemFocused, false);
 
 						if (hasGauge) {
-							$$.undoMarkOverlapped($$, `.${CLASS.gaugeValue}`);
+							$$.undoMarkOverlapped($$, `.${$GAUGE.gaugeValue}`);
 						}
 
 						$$.api.revert();
@@ -416,10 +416,10 @@ export default {
 				})
 				.on("mouseover", function(event, id) {
 					if (!callFn(config.legend_item_onover, api, id)) {
-						d3Select(this).classed(CLASS.legendItemFocused, true);
+						d3Select(this).classed($FOCUS.legendItemFocused, true);
 
 						if (hasGauge) {
-							$$.markOverlapped(id, $$, `.${CLASS.gaugeValue}`);
+							$$.markOverlapped(id, $$, `.${$GAUGE.gaugeValue}`);
 						}
 
 						if (!state.transiting && $$.isTargetToShow(id)) {
@@ -567,7 +567,7 @@ export default {
 		const pos = -200;
 
 		// Define g for legend area
-		const l = legend.selectAll(`.${CLASS.legendItem}`)
+		const l = legend.selectAll(`.${$LEGEND.legendItem}`)
 			.data(targetIdz)
 			.enter()
 			.append("g");
@@ -584,7 +584,7 @@ export default {
 			.attr("y", isLegendRightOrInset ? pos : yForLegendText);
 
 		l.append("rect")
-			.attr("class", CLASS.legendItemEvent)
+			.attr("class", $LEGEND.legendItemEvent)
 			.style("fill-opacity", "0")
 			.attr("x", isLegendRightOrInset ? xForLegendRect : pos)
 			.attr("y", isLegendRightOrInset ? pos : yForLegendRect);
@@ -616,7 +616,7 @@ export default {
 
 				return document.createElementNS(d3Namespaces.svg, ("hasValidPointType" in $$) && $$.hasValidPointType(point) ? point : "use");
 			})
-				.attr("class", CLASS.legendItemPoint)
+				.attr("class", $LEGEND.legendItemPoint)
 				.style("fill", getColor)
 				.style("pointer-events", "none")
 				.attr("href", (data, idx, selection) => {
@@ -628,7 +628,7 @@ export default {
 				});
 		} else {
 			l.append("line")
-				.attr("class", CLASS.legendItemTile)
+				.attr("class", $LEGEND.legendItemTile)
 				.style("stroke", getColor)
 				.style("pointer-events", "none")
 				.attr("x1", isLegendRightOrInset ? x1ForLegendTile : pos)
@@ -639,11 +639,11 @@ export default {
 		}
 
 		// Set background for inset legend
-		background = legend.select(`.${CLASS.legendBackground} rect`);
+		background = legend.select(`.${$LEGEND.legendBackground} rect`);
 
 		if (state.isLegendInset && maxWidth > 0 && background.size() === 0) {
-			background = legend.insert("g", `.${CLASS.legendItem}`)
-				.attr("class", CLASS.legendBackground)
+			background = legend.insert("g", `.${$LEGEND.legendItem}`)
+				.attr("class", $LEGEND.legendBackground)
 				.append("rect");
 		}
 
@@ -658,7 +658,7 @@ export default {
 			.attr("x", xForLegendText)
 			.attr("y", yForLegendText);
 
-		const rects = legend.selectAll(`rect.${CLASS.legendItemEvent}`)
+		const rects = legend.selectAll(`rect.${$LEGEND.legendItemEvent}`)
 			.data(targetIdz);
 
 		$T(rects, withTransition)
@@ -668,7 +668,7 @@ export default {
 			.attr("y", yForLegendRect);
 
 		if (usePoint) {
-			const tiles = legend.selectAll(`.${CLASS.legendItemPoint}`)
+			const tiles = legend.selectAll(`.${$LEGEND.legendItemPoint}`)
 				.data(targetIdz);
 
 			$T(tiles, withTransition)
@@ -707,7 +707,7 @@ export default {
 						.attr("height", height);
 				});
 		} else {
-			const tiles = legend.selectAll(`line.${CLASS.legendItemTile}`)
+			const tiles = legend.selectAll(`line.${$LEGEND.legendItemTile}`)
 				.data(targetIdz);
 
 			$T(tiles, withTransition)

--- a/src/ChartInternal/internals/redraw.ts
+++ b/src/ChartInternal/internals/redraw.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {transition as d3Transition} from "d3-transition";
-import CLASS from "../../config/classes";
+import {$COMMON, $SELECT, $TEXT} from "../../config/classes";
 import {generateWait} from "../../module/generator";
 import {callFn, capitalize, getOption, isTabVisible, notEmpty} from "../../module/util";
 
@@ -47,7 +47,7 @@ export default {
 			$$.axis.redrawAxis(targetsToShow, wth, transitions, flow, initializing);
 
 			// Data empty label positioning and text.
-			config.data_empty_label_text && main.select(`text.${CLASS.text}.${CLASS.empty}`)
+			config.data_empty_label_text && main.select(`text.${$TEXT.text}.${$COMMON.empty}`)
 				.attr("x", state.width / 2)
 				.attr("y", state.height / 2)
 				.text(config.data_empty_label_text)
@@ -69,7 +69,7 @@ export default {
 
 
 			// circles for select
-			$el.text && main.selectAll(`.${CLASS.selectedCircles}`)
+			$el.text && main.selectAll(`.${$SELECT.selectedCircles}`)
 				.filter($$.isBarType.bind($$))
 				.selectAll("circle")
 				.remove();

--- a/src/ChartInternal/internals/region.ts
+++ b/src/ChartInternal/internals/region.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {select as d3Select} from "d3-selection"; // selection
-import CLASS from "../../config/classes";
+import {$REGION} from "../../config/classes";
 import {isValue, parseDate} from "../../module/util";
 import {AxisType} from "../../../types/types";
 
@@ -15,7 +15,7 @@ export default {
 		$el.region.main = $el.main
 			.insert("g", ":first-child")
 			.attr("clip-path", $$.state.clip.path)
-			.attr("class", CLASS.regions);
+			.attr("class", $REGION.regions);
 	},
 
 	updateRegion(): void {
@@ -31,7 +31,7 @@ export default {
 		// select <g> element
 
 		let list = region.main
-			.selectAll(`.${CLASS.region}`)
+			.selectAll(`.${$REGION.region}`)
 			.data(config.regions);
 
 		$T(list.exit())

--- a/src/ChartInternal/internals/selection.ts
+++ b/src/ChartInternal/internals/selection.ts
@@ -4,7 +4,7 @@
  */
 import {select as d3Select} from "d3-selection";
 import drag from "../interactions/drag";
-import CLASS from "../../config/classes";
+import {$SELECT, $SHAPE} from "../../config/classes";
 import {callFn} from "../../module/util";
 
 export default {
@@ -28,12 +28,12 @@ export default {
 		callFn(config.data_onselected, $$.api, d, target.node());
 
 		// add selected-circle on low layer g
-		$T(main.select(`.${CLASS.selectedCircles}${$$.getTargetSelectorSuffix(d.id)}`)
-			.selectAll(`.${CLASS.selectedCircle}-${i}`)
+		$T(main.select(`.${$SELECT.selectedCircles}${$$.getTargetSelectorSuffix(d.id)}`)
+			.selectAll(`.${$SELECT.selectedCircle}-${i}`)
 			.data([d])
 			.enter()
 			.append("circle")
-			.attr("class", () => $$.generateClass(CLASS.selectedCircle, i))
+			.attr("class", () => $$.generateClass($SELECT.selectedCircle, i))
 			.attr("cx", cx)
 			.attr("cy", cy)
 			.attr("stroke", $$.color)
@@ -55,8 +55,8 @@ export default {
 		callFn(config.data_onunselected, $$.api, d, target.node());
 
 		// remove selected-circle from low layer g
-		$T(main.select(`.${CLASS.selectedCircles}${$$.getTargetSelectorSuffix(d.id)}`)
-			.selectAll(`.${CLASS.selectedCircle}-${i}`)
+		$T(main.select(`.${$SELECT.selectedCircles}${$$.getTargetSelectorSuffix(d.id)}`)
+			.selectAll(`.${$SELECT.selectedCircle}-${i}`)
 		)
 			.attr("r", 0)
 			.remove();
@@ -153,32 +153,32 @@ export default {
 		const $$ = this;
 		const {config, $el: {main}} = $$;
 		const shape = d3Select(that);
-		const isSelected = shape.classed(CLASS.SELECTED);
+		const isSelected = shape.classed($SELECT.SELECTED);
 		const toggle = $$.getToggle(that, d).bind($$);
 		let toggledShape;
 
 		if (config.data_selection_enabled && config.data_selection_isselectable.bind($$.api)(d)) {
 			if (!config.data_selection_multiple) {
-				let selector = `.${CLASS.shapes}`;
+				let selector = `.${$SHAPE.shapes}`;
 
 				if (config.data_selection_grouped) {
 					selector += $$.getTargetSelectorSuffix(d.id);
 				}
 
 				main.selectAll(selector)
-					.selectAll(`.${CLASS.shape}`)
+					.selectAll(`.${$SHAPE.shape}`)
 					.each(function(d, i) {
 						const shape = d3Select(this);
 
-						if (shape.classed(CLASS.SELECTED)) {
+						if (shape.classed($SELECT.SELECTED)) {
 							toggledShape = shape;
-							toggle(false, shape.classed(CLASS.SELECTED, false), d, i);
+							toggle(false, shape.classed($SELECT.SELECTED, false), d, i);
 						}
 					});
 			}
 
 			if (!toggledShape || toggledShape.node() !== shape.node()) {
-				shape.classed(CLASS.SELECTED, !isSelected);
+				shape.classed($SELECT.SELECTED, !isSelected);
 				toggle(!isSelected, shape, d, i);
 			}
 		}

--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {document} from "../../module/browser";
-import CLASS from "../../config/classes";
+import {$AXIS, $SUBCHART} from "../../config/classes";
 import {isValue, ceil10, capitalize, isNumber, isEmpty} from "../../module/util";
 
 export default {
@@ -170,7 +170,7 @@ export default {
 		const $$ = this;
 		const {config, $el} = $$;
 		const hasLeftAxisRect = config.axis_rotated || (!config.axis_rotated && !config.axis_y_inner);
-		const leftAxisClass = config.axis_rotated ? CLASS.axisX : CLASS.axisY;
+		const leftAxisClass = config.axis_rotated ? $AXIS.axisX : $AXIS.axisY;
 		const leftAxis = $el.main.select(`.${leftAxisClass}`).node();
 		const svgRect = leftAxis && hasLeftAxisRect ? leftAxis.getBoundingClientRect() : {right: 0};
 		const chartRect = $el.chart.node().getBoundingClientRect();
@@ -204,7 +204,7 @@ export default {
 			.attr("height", current.height);
 
 		if (hasAxis) {
-			const brush = svg.select(`.${CLASS.brush} .overlay`);
+			const brush = svg.select(`.${$SUBCHART.brush} .overlay`);
 			const brushSize = {width: 0, height: 0};
 
 			if (brush.size()) {

--- a/src/ChartInternal/internals/text.ts
+++ b/src/ChartInternal/internals/text.ts
@@ -7,7 +7,7 @@ import {
 	selectAll as d3SelectAll
 } from "d3-selection";
 import {KEY} from "../../module/Cache";
-import CLASS from "../../config/classes";
+import {$COMMON, $TEXT} from "../../config/classes";
 import {capitalize, getBoundingRect, getRandom, isFunction, isNumber, isObject, isString, getTranslation, setTextValue} from "../../module/util";
 import {IDataRow, IArcData} from "../data/IData";
 import {AxisType} from "../../../types/types";
@@ -28,8 +28,8 @@ export default {
 	initText(): void {
 		const {$el} = this;
 
-		$el.main.select(`.${CLASS.chart}`).append("g")
-			.attr("class", CLASS.chartTexts);
+		$el.main.select(`.${$COMMON.chart}`).append("g")
+			.attr("class", $TEXT.chartTexts);
 	},
 
 	/**
@@ -43,7 +43,7 @@ export default {
 		const classTexts = $$.getClass("texts", "id");
 
 		const classFocus = $$.classFocus.bind($$);
-		const mainTextUpdate = $$.$el.main.select(`.${CLASS.chartTexts}`).selectAll(`.${CLASS.chartText}`)
+		const mainTextUpdate = $$.$el.main.select(`.${$TEXT.chartTexts}`).selectAll(`.${$TEXT.chartText}`)
 			.data(targets)
 			.attr("class", d => classChartText(d) + classFocus(d));
 
@@ -65,8 +65,8 @@ export default {
 		const {$el, $T, config} = $$;
 		const classText = $$.getClass("text", "index");
 
-		const text = $el.main.selectAll(`.${CLASS.texts}`)
-			.selectAll(`.${CLASS.text}`)
+		const text = $el.main.selectAll(`.${$TEXT.texts}`)
+			.selectAll(`.${$TEXT.text}`)
 			.data($$.labelishData.bind($$));
 
 		$T(text.exit())
@@ -475,7 +475,7 @@ export default {
 			const overlapsY = Math.ceil(Math.abs(translate.f - coordinate.f)) <
 				parseInt(textNode.style("font-size"), 10);
 
-			filteredTextNode.classed(CLASS.TextOverlapping, overlapsX && overlapsY);
+			filteredTextNode.classed($TEXT.TextOverlapping, overlapsX && overlapsY);
 		});
 	},
 
@@ -490,7 +490,7 @@ export default {
 		$$.$el.arcs.selectAll(selector)
 			.each(function() {
 				d3SelectAll([this, this.previousSibling])
-					.classed(CLASS.TextOverlapping, false);
+					.classed($TEXT.TextOverlapping, false);
 			});
 	},
 

--- a/src/ChartInternal/internals/title.ts
+++ b/src/ChartInternal/internals/title.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {isNumber, setTextValue} from "../../module/util";
-import CLASS from "../../config/classes";
+import {$TEXT} from "../../config/classes";
 
 /**
  * Get the text position
@@ -42,7 +42,7 @@ export default {
 			const text = $el.title
 				.append("text")
 				.style("text-anchor", getTextPos(config.title_position))
-				.attr("class", CLASS.title);
+				.attr("class", $TEXT.title);
 
 			setTextValue(text, config.title_text, [0.3, 1.5]);
 		}
@@ -76,7 +76,7 @@ export default {
 		const $$ = this;
 		const {config, state: {current}} = $$;
 		const position = config.title_position || "left";
-		const textRectWidth = $$.getTextRect($$.$el.title, CLASS.title).width;
+		const textRectWidth = $$.getTextRect($$.$el.title, $TEXT.title).width;
 		let x;
 
 		if (/(right|center)/.test(position)) {
@@ -103,7 +103,7 @@ export default {
 		const $$ = this;
 
 		return ($$.config.title_padding.top || 0) +
-			$$.getTextRect($$.$el.title, CLASS.title).height;
+			$$.getTextRect($$.$el.title, $TEXT.title).height;
 	},
 
 	/**

--- a/src/ChartInternal/internals/tooltip.ts
+++ b/src/ChartInternal/internals/tooltip.ts
@@ -4,7 +4,7 @@
  */
 import {select as d3Select} from "d3-selection";
 import {document} from "../../module/browser";
-import CLASS from "../../config/classes";
+import {$ARC, $TOOLTIP} from "../../config/classes";
 import {IDataRow} from "../data/IData";
 import {getPointer, isFunction, isObject, isString, isValue, callFn, sanitise, tplProcess, isUndefined, parseDate} from "../../module/util";
 
@@ -22,7 +22,7 @@ export default {
 		if ($el.tooltip.empty()) {
 			$el.tooltip = $el.chart
 				.append("div")
-				.attr("class", CLASS.tooltipContainer)
+				.attr("class", $TOOLTIP.tooltipContainer)
 				.style("position", "absolute")
 				.style("pointer-events", "none")
 				.style("display", "none");
@@ -176,7 +176,7 @@ export default {
 					sanitise(titleFormat ? titleFormat(row.x) : row.x);
 
 				text = tplProcess(tpl[0], {
-					CLASS_TOOLTIP: CLASS.tooltip,
+					CLASS_TOOLTIP: $TOOLTIP.tooltip,
 					TITLE: isValue(title) ? (
 						tplStr ? title : `<tr><th colspan="2">${title}</th></tr>`
 					) : ""
@@ -184,7 +184,7 @@ export default {
 			}
 
 			if (!row.ratio && $$.$el.arcs) {
-				row.ratio = $$.getRatio("arc", $$.$el.arcs.select(`path.${CLASS.arc}-${row.id}`).data()[0]);
+				row.ratio = $$.getRatio("arc", $$.$el.arcs.select(`path.${$ARC.arc}-${row.id}`).data()[0]);
 			}
 
 			param = [row.ratio, row.id, row.index, d];
@@ -217,7 +217,7 @@ export default {
 				const name = sanitise(nameFormat(row.name, ...param));
 				const color = getBgColor(row);
 				const contentValue = {
-					CLASS_TOOLTIP_NAME: CLASS.tooltipName + $$.getTargetSelectorSuffix(row.id),
+					CLASS_TOOLTIP_NAME: $TOOLTIP.tooltipName + $$.getTargetSelectorSuffix(row.id),
 					COLOR: (tplStr || !$$.patterns) ? color : `<svg><rect style="fill:${color}" width="10" height="10"></rect></svg>`,
 					NAME: name,
 					VALUE: value

--- a/src/ChartInternal/internals/transform.ts
+++ b/src/ChartInternal/internals/transform.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import CLASS from "../../config/classes";
+import {$ARC, $AXIS} from "../../config/classes";
 import {asHalfPixel} from "../../module/util";
 
 type TranslateParam = "main" | "context" | "legend" | "x" | "y" | "y2" | "subX" | "arc" | "radar";
@@ -60,16 +60,16 @@ export default {
 
 		const xAxis = transitions?.axisX ?
 			transitions.axisX :
-			$T(main.select(`.${CLASS.axisX}`), withTransition);
+			$T(main.select(`.${$AXIS.axisX}`), withTransition);
 
 		const yAxis = transitions?.axisY ?
 			transitions.axisY :
-			$T(main.select(`.${CLASS.axisY}`), withTransition);
+			$T(main.select(`.${$AXIS.axisY}`), withTransition);
 
 
 		const y2Axis = transitions?.axisY2 ?
 			transitions.axisY2 :
-			$T(main.select(`.${CLASS.axisY2}`), withTransition);
+			$T(main.select(`.${$AXIS.axisY2}`), withTransition);
 
 		$T(main, withTransition)
 			.attr("transform", $$.getTranslate("main"));
@@ -78,7 +78,7 @@ export default {
 		yAxis.attr("transform", $$.getTranslate("y"));
 		y2Axis.attr("transform", $$.getTranslate("y2"));
 
-		main.select(`.${CLASS.chartArcs}`)
+		main.select(`.${$ARC.chartArcs}`)
 			.attr("transform", $$.getTranslate("arc"));
 	},
 

--- a/src/ChartInternal/shape/arc.ts
+++ b/src/ChartInternal/shape/arc.ts
@@ -9,7 +9,7 @@ import {
 } from "d3-shape";
 import {interpolate as d3Interpolate} from "d3-interpolate";
 import {document} from "../../module/browser";
-import CLASS from "../../config/classes";
+import {$ARC, $COMMON, $FOCUS, $GAUGE} from "../../config/classes";
 import {callFn, endall, isFunction, isNumber, isObject, isUndefined, setTextValue} from "../../module/util";
 import {d3Selection} from "../../../types/types";
 import {IData} from "../data/IData";
@@ -364,7 +364,7 @@ export default {
 				if (!transiting) {
 					clearInterval(interval);
 
-					$el.legend.selectAll(`.${CLASS.legendItemFocused}`).size() > 0 &&
+					$el.legend.selectAll(`.${$FOCUS.legendItemFocused}`).size() > 0 &&
 						$$.expandArc(targetIds);
 				}
 			}, 10);
@@ -374,7 +374,7 @@ export default {
 
 		const newTargetIds = $$.mapToTargetIds(targetIds);
 
-		$el.svg.selectAll($$.selectorTargets(newTargetIds, `.${CLASS.chartArc}`))
+		$el.svg.selectAll($$.selectorTargets(newTargetIds, `.${$ARC.chartArc}`))
 			.each(function(d) {
 				if (!$$.shouldExpand(d.data.id)) {
 					return;
@@ -403,13 +403,13 @@ export default {
 
 		const newTargetIds = $$.mapToTargetIds(targetIds);
 
-		svg.selectAll($$.selectorTargets(newTargetIds, `.${CLASS.chartArc}`))
+		svg.selectAll($$.selectorTargets(newTargetIds, `.${$ARC.chartArc}`))
 			.selectAll("path")
 			.transition()
 			.duration(d => $$.getExpandConfig(d.data.id, "duration"))
 			.attr("d", $$.svgArc);
 
-		svg.selectAll(`${CLASS.arc}`)
+		svg.selectAll(`${$ARC.arc}`)
 			.style("opacity", null);
 	},
 
@@ -485,10 +485,10 @@ export default {
 		const classChartArc = $$.getChartClass("Arc");
 		const classArcs = $$.getClass("arcs", true);
 		const classFocus = $$.classFocus.bind($$);
-		const chartArcs = $el.main.select(`.${CLASS.chartArcs}`);
+		const chartArcs = $el.main.select(`.${$ARC.chartArcs}`);
 
 		const mainPieUpdate = chartArcs
-			.selectAll(`.${CLASS.chartArc}`)
+			.selectAll(`.${$ARC.chartArc}`)
 			.data($$.pie(targets))
 			.attr("class", d => classChartArc(d) + classFocus(d.data));
 
@@ -505,7 +505,7 @@ export default {
 			.style("text-anchor", "middle")
 			.style("pointer-events", "none");
 
-		$el.text = chartArcs.selectAll(`.${CLASS.target} text`);
+		$el.text = chartArcs.selectAll(`.${$COMMON.target} text`);
 		// MEMO: can not keep same color..., but not bad to update color in redraw
 		// mainPieUpdate.exit().remove();
 	},
@@ -514,9 +514,9 @@ export default {
 		const $$ = this;
 		const {$el} = $$;
 
-		$el.arcs = $el.main.select(`.${CLASS.chart}`)
+		$el.arcs = $el.main.select(`.${$COMMON.chart}`)
 			.append("g")
-			.attr("class", CLASS.chartArcs)
+			.attr("class", $ARC.chartArcs)
 			.attr("transform", $$.getTranslate("arc"));
 
 		$$.setArcTitle();
@@ -533,7 +533,7 @@ export default {
 
 		if (title) {
 			const text = $$.$el.arcs.append("text")
-				.attr("class", CLASS[hasGauge ? "chartArcsGaugeTitle" : "chartArcsTitle"])
+				.attr("class", hasGauge ? $GAUGE.chartArcsGaugeTitle : $ARC.chartArcsTitle)
 				.style("text-anchor", "middle");
 
 			hasGauge && text.attr("dy", "-0.3em");
@@ -548,8 +548,8 @@ export default {
 		const hasInteraction = config.interaction_enabled;
 		const isSelectable = hasInteraction && config.data_selection_isselectable;
 
-		let mainArc = main.selectAll(`.${CLASS.arcs}`)
-			.selectAll(`.${CLASS.arc}`)
+		let mainArc = main.selectAll(`.${$ARC.arcs}`)
+			.selectAll(`.${$ARC.arc}`)
 			.data($$.arcData.bind($$));
 
 		mainArc.exit()
@@ -661,19 +661,19 @@ export default {
 		const endAngle = isFullCircle ? startAngle + $$.getArcLength() : startAngle * -1;
 
 		let backgroundArc = $$.$el.arcs.select(
-			`${hasMultiArcGauge ? "g" : ""}.${CLASS.chartArcsBackground}`
+			`${hasMultiArcGauge ? "g" : ""}.${$ARC.chartArcsBackground}`
 		);
 
 		if (hasMultiArcGauge) {
 			let index = 0;
 
 			backgroundArc = backgroundArc
-				.selectAll(`path.${CLASS.chartArcsBackground}`)
+				.selectAll(`path.${$ARC.chartArcsBackground}`)
 				.data($$.data.targets);
 
 			backgroundArc.enter()
 				.append("path")
-				.attr("class", (d, i) => `${CLASS.chartArcsBackground} ${CLASS.chartArcsBackground}-${i}`)
+				.attr("class", (d, i) => `${$ARC.chartArcsBackground} ${$ARC.chartArcsBackground}-${i}`)
 				.merge(backgroundArc)
 				.style("fill", (config.gauge_background) || null)
 				.attr("d", ({id}) => {
@@ -820,10 +820,10 @@ export default {
 
 		// for gauge type, update text when has no title & multi data
 		if (!(hasGauge && $$.data.targets.length === 1 && config.gauge_title)) {
-			text = main.selectAll(`.${CLASS.chartArc}`)
+			text = main.selectAll(`.${$ARC.chartArc}`)
 				.select("text")
 				.style("opacity", "0")
-				.attr("class", d => ($$.isGaugeType(d.data) ? CLASS.gaugeValue : null))
+				.attr("class", d => ($$.isGaugeType(d.data) ? $GAUGE.gaugeValue : null))
 				.call($$.textForArcLabel.bind($$))
 				.attr("transform", $$.transformForArcLabel.bind($$))
 				.style("font-size", d => (
@@ -837,7 +837,7 @@ export default {
 			hasMultiArcGauge && text.attr("dy", "-.1em");
 		}
 
-		main.select(`.${CLASS.chartArcsTitle}`)
+		main.select(`.${$ARC.chartArcsTitle}`)
 			.style("opacity", $$.hasType("donut") || hasGauge ? null : "0");
 
 		if (hasGauge) {
@@ -846,17 +846,17 @@ export default {
 			isFullCircle && text?.attr("dy", `${hasMultiArcGauge ? 0 : Math.round(state.radius / 14)}`);
 
 			if (config.gauge_label_show) {
-				arcs.select(`.${CLASS.chartArcsGaugeUnit}`)
+				arcs.select(`.${$GAUGE.chartArcsGaugeUnit}`)
 					.attr("dy", `${isFullCircle ? 1.5 : 0.75}em`)
 					.text(config.gauge_units);
 
-				arcs.select(`.${CLASS.chartArcsGaugeMin}`)
+				arcs.select(`.${$GAUGE.chartArcsGaugeMin}`)
 					.attr("dx", `${-1 * (state.innerRadius + ((state.radius - state.innerRadius) / (isFullCircle ? 1 : 2)))}px`)
 					.attr("dy", "1.2em")
 					.text($$.textForGaugeMinMax(config.gauge_min, false));
 
 				// show max text when isn't fullCircle
-				!isFullCircle && arcs.select(`.${CLASS.chartArcsGaugeMax}`)
+				!isFullCircle && arcs.select(`.${$GAUGE.chartArcsGaugeMax}`)
 					.attr("dx", `${state.innerRadius + ((state.radius - state.innerRadius) / 2)}px`)
 					.attr("dy", "1.2em")
 					.text($$.textForGaugeMinMax(config.gauge_max, true));

--- a/src/ChartInternal/shape/area.ts
+++ b/src/ChartInternal/shape/area.ts
@@ -4,7 +4,7 @@
  */
 import {area as d3Area} from "d3-shape";
 import {select as d3Select} from "d3-selection";
-import CLASS from "../../config/classes";
+import {$AREA, $CIRCLE, $LINE} from "../../config/classes";
 import {getRandom, isFunction} from "../../module/util";
 
 export default {
@@ -13,7 +13,7 @@ export default {
 		const {config} = $$;
 
 		mainLine
-			.insert("g", `.${CLASS[config.area_front ? "circles" : "lines"]}`)
+			.insert("g", `.${config.area_front ? $CIRCLE.circles : $LINE.lines}`)
 			.attr("class", $$.getClass("areas", true));
 	},
 
@@ -72,8 +72,8 @@ export default {
 
 		config.area_linearGradient && $$.updateAreaGradient();
 
-		const area = $root.main.selectAll(`.${CLASS.areas}`)
-			.selectAll(`.${CLASS.area}`)
+		const area = $root.main.selectAll(`.${$AREA.areas}`)
+			.selectAll(`.${$AREA.area}`)
 			.data($$.lineData.bind($$));
 
 		$T(area.exit(), withTransition)

--- a/src/ChartInternal/shape/bar.ts
+++ b/src/ChartInternal/shape/bar.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {DataRow} from "../../../types/types";
-import CLASS from "../../config/classes";
+import {$BAR, $COMMON} from "../../config/classes";
 import {getRandom, isNumber} from "../../module/util";
 import {IDataRow} from "../data/IData";
 
@@ -13,10 +13,10 @@ export default {
 	initBar(): void {
 		const {$el, config, state: {clip}} = this;
 
-		$el.bar = $el.main.select(`.${CLASS.chart}`)
+		$el.bar = $el.main.select(`.${$COMMON.chart}`)
 			// should positioned at the beginning of the shape node to not overlap others
 			.insert("g", ":first-child")
-			.attr("class", CLASS.chartBars);
+			.attr("class", $BAR.chartBars);
 
 		// set clip-path attribute when condition meet
 		// https://github.com/naver/billboard.js/issues/2421
@@ -39,8 +39,8 @@ export default {
 			$$.initBar();
 		}
 
-		const mainBarUpdate = $$.$el.main.select(`.${CLASS.chartBars}`)
-			.selectAll(`.${CLASS.chartBar}`)
+		const mainBarUpdate = $$.$el.main.select(`.${$BAR.chartBars}`)
+			.selectAll(`.${$BAR.chartBar}`)
 			.data(
 				// remove
 				targets.filter(
@@ -73,8 +73,8 @@ export default {
 		const classBar = $$.getClass("bar", true);
 		const initialOpacity = $$.initialOpacity.bind($$);
 
-		const bar = $root.main.selectAll(`.${CLASS.bars}`)
-			.selectAll(`.${CLASS.bar}`)
+		const bar = $root.main.selectAll(`.${$BAR.bars}`)
+			.selectAll(`.${$BAR.bar}`)
 			.data($$.labelishData.bind($$));
 
 		$T(bar.exit(), withTransition)

--- a/src/ChartInternal/shape/candlestick.ts
+++ b/src/ChartInternal/shape/candlestick.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {select as d3Select} from "d3-selection";
-import CLASS from "../../config/classes";
+import {$CANDLESTICK, $COMMON} from "../../config/classes";
 import {getRandom, isArray, isNumber, isObject} from "../../module/util";
 
 type CandlestickData = {
@@ -18,10 +18,10 @@ export default {
 	initCandlestick(): void {
 		const {$el} = this;
 
-		$el.candlestick = $el.main.select(`.${CLASS.chart}`)
+		$el.candlestick = $el.main.select(`.${$COMMON.chart}`)
 			// should positioned at the beginning of the shape node to not overlap others
 			.append("g")
-			.attr("class", CLASS.chartCandlesticks);
+			.attr("class", $CANDLESTICK.chartCandlesticks);
 	},
 
 	/**
@@ -40,8 +40,8 @@ export default {
 			$$.initCandlestick();
 		}
 
-		const mainUpdate = $$.$el.main.select(`.${CLASS.chartCandlesticks}`)
-			.selectAll(`.${CLASS.chartCandlestick}`)
+		const mainUpdate = $$.$el.main.select(`.${$CANDLESTICK.chartCandlesticks}`)
+			.selectAll(`.${$CANDLESTICK.chartCandlestick}`)
 			.data(targets)
 			.attr("class", d => classChart(d) + classFocus(d));
 
@@ -63,8 +63,8 @@ export default {
 		const classSetter = $$.getClass("candlestick", true);
 		const initialOpacity = $$.initialOpacity.bind($$);
 
-		const candlestick = $root.main.selectAll(`.${CLASS.chartCandlestick}`)
-			.selectAll(`.${CLASS.candlestick}`)
+		const candlestick = $root.main.selectAll(`.${$CANDLESTICK.chartCandlestick}`)
+			.selectAll(`.${$CANDLESTICK.candlestick}`)
 			.data($$.labelishData.bind($$));
 
 		$T(candlestick.exit(), withTransition)
@@ -111,7 +111,7 @@ export default {
 			const indexY = +!indexX;
 
 			if (g.classed) {
-				g.classed(CLASS[isUp ? "valueUp" : "valueDown"], true);
+				g.classed($CANDLESTICK[isUp ? "valueUp" : "valueDown"], true);
 			}
 
 			const path = isRotated ?

--- a/src/ChartInternal/shape/gauge.ts
+++ b/src/ChartInternal/shape/gauge.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {select as d3Select} from "d3-selection";
-import CLASS from "../../config/classes";
+import {$ARC, $COMMON, $GAUGE} from "../../config/classes";
 import {isFunction} from "../../module/util";
 
 export default {
@@ -21,14 +21,14 @@ export default {
 			const hasMulti = $$.hasMultiArcGauge();
 
 			arcs.append(hasMulti ? "g" : "path")
-				.attr("class", CLASS.chartArcsBackground)
+				.attr("class", $ARC.chartArcsBackground)
 				.style("fill", (!hasMulti && config.gauge_background) || null);
 
-			config.gauge_units && appendText(CLASS.chartArcsGaugeUnit);
+			config.gauge_units && appendText($GAUGE.chartArcsGaugeUnit);
 
 			if (config.gauge_label_show) {
-				appendText(CLASS.chartArcsGaugeMin);
-				!config.gauge_fullCircle && appendText(CLASS.chartArcsGaugeMax);
+				appendText($GAUGE.chartArcsGaugeMin);
+				!config.gauge_fullCircle && appendText($GAUGE.chartArcsGaugeMax);
 			}
 		}
 	},
@@ -53,13 +53,13 @@ export default {
 		const {config, state, $el} = $$;
 		const {hiddenTargetIds} = $$.state;
 
-		const arcLabelLines = $el.main.selectAll(`.${CLASS.arcs}`)
-			.selectAll(`.${CLASS.arcLabelLine}`)
+		const arcLabelLines = $el.main.selectAll(`.${$ARC.arcs}`)
+			.selectAll(`.${$ARC.arcLabelLine}`)
 			.data($$.arcData.bind($$));
 
 		const mainArcLabelLine = arcLabelLines.enter()
 			.append("rect")
-			.attr("class", d => `${CLASS.arcLabelLine} ${CLASS.target} ${CLASS.target}-${d.data.id}`)
+			.attr("class", d => `${$ARC.arcLabelLine} ${$COMMON.target} ${$COMMON.target}-${d.data.id}`)
 			.merge(arcLabelLines);
 
 		mainArcLabelLine

--- a/src/ChartInternal/shape/line.ts
+++ b/src/ChartInternal/shape/line.ts
@@ -4,15 +4,15 @@
  */
 import {line as d3Line} from "d3-shape";
 import {getScale} from "../internals/scale";
-import CLASS from "../../config/classes";
+import {$COMMON, $LINE} from "../../config/classes";
 import {getPointer, getRandom, isArray, isDefined, isUndefined, isValue, parseDate} from "../../module/util";
 
 export default {
 	initLine(): void {
 		const {$el} = this;
 
-		$el.line = $el.main.select(`.${CLASS.chart}`).append("g")
-			.attr("class", CLASS.chartLines);
+		$el.line = $el.main.select(`.${$COMMON.chart}`).append("g")
+			.attr("class", $LINE.chartLines);
 	},
 
 	updateTargetsForLine(t): void {
@@ -28,8 +28,8 @@ export default {
 
 		const targets = t.filter(d => !($$.isScatterType(d) || $$.isBubbleType(d)));
 
-		const mainLineUpdate = main.select(`.${CLASS.chartLines}`)
-			.selectAll(`.${CLASS.chartLine}`)
+		const mainLineUpdate = main.select(`.${$LINE.chartLines}`)
+			.selectAll(`.${$LINE.chartLine}`)
 			.data(targets)
 			.attr("class", d => classChartLine(d) + classFocus(d));
 
@@ -62,8 +62,8 @@ export default {
 		const $root = isSub ? $el.subchart : $el;
 
 		const line = $root.main
-			.selectAll(`.${CLASS.lines}`)
-			.selectAll(`.${CLASS.line}`)
+			.selectAll(`.${$LINE.lines}`)
+			.selectAll(`.${$LINE.line}`)
 			.data($$.lineData.bind($$));
 
 		$T(line.exit(), withTransition)

--- a/src/ChartInternal/shape/point.ts
+++ b/src/ChartInternal/shape/point.ts
@@ -7,7 +7,7 @@ import {
 	select as d3Select
 } from "d3-selection";
 import {d3Selection} from "../../../types/types";
-import CLASS from "../../config/classes";
+import {$CIRCLE, $COMMON, $SELECT} from "../../config/classes";
 import {document} from "../../module/browser";
 import {getBoundingRect, getPointer, getRandom, isFunction, isObject, isObjectType, isUndefined, isValue, toArray, notEmpty} from "../../module/util";
 
@@ -58,10 +58,10 @@ export default {
 
 		$$.point = $$.generatePoint();
 
-		if (($$.hasType("bubble") || $$.hasType("scatter")) && main.select(`.${CLASS.chartCircles}`).empty()) {
-			main.select(`.${CLASS.chart}`)
+		if (($$.hasType("bubble") || $$.hasType("scatter")) && main.select(`.${$CIRCLE.chartCircles}`).empty()) {
+			main.select(`.${$COMMON.chart}`)
 				.append("g")
-				.attr("class", CLASS.chartCircles);
+				.attr("class", $CIRCLE.chartCircles);
 		}
 	},
 
@@ -86,9 +86,9 @@ export default {
 			targets = (data.targets)
 				.filter(d => this.isScatterType(d) || this.isBubbleType(d));
 
-			const mainCircle = $el.main.select(`.${CLASS.chartCircles}`)
+			const mainCircle = $el.main.select(`.${$CIRCLE.chartCircles}`)
 				.style("pointer-events", "none")
-				.selectAll(`.${CLASS.circles}`)
+				.selectAll(`.${$CIRCLE.circles}`)
 				.data(targets)
 				.attr("class", classCircles);
 
@@ -98,7 +98,7 @@ export default {
 
 		// Circles for each data point on lines
 		selectionEnabled && enterNode.append("g")
-			.attr("class", d => $$.generateClass(CLASS.selectedCircles, d.id));
+			.attr("class", d => $$.generateClass($SELECT.selectedCircles, d.id));
 
 		enterNode.append("g")
 			.attr("class", classCircles)
@@ -106,8 +106,8 @@ export default {
 
 		// Update date for selected circles
 		selectionEnabled && targets.forEach(t => {
-			$el.main.selectAll(`.${CLASS.selectedCircles}${$$.getTargetSelectorSuffix(t.id)}`)
-				.selectAll(`${CLASS.selectedCircle}`)
+			$el.main.selectAll(`.${$SELECT.selectedCircles}${$$.getTargetSelectorSuffix(t.id)}`)
+				.selectAll(`${$SELECT.selectedCircle}`)
 				.each(d => {
 					d.value = t.values[d.index].value;
 				});
@@ -121,8 +121,8 @@ export default {
 		const $root = isSub ? $el.subchart : $el;
 
 		if (config.point_show && !state.toggling) {
-			const circles = $root.main.selectAll(`.${CLASS.circles}`)
-				.selectAll(`.${CLASS.circle}`)
+			const circles = $root.main.selectAll(`.${$CIRCLE.circles}`)
+				.selectAll(`.${$CIRCLE.circle}`)
 				.data(d => (
 					($$.isLineType(d) && $$.shouldDrawPointsForLine(d)) ||
 						$$.isBubbleType(d) || $$.isRadarType(d) || $$.isScatterType(d) ?
@@ -135,7 +135,7 @@ export default {
 				.filter(Boolean)
 				.append($$.point("create", this, $$.pointR.bind($$), $$.color));
 
-			$root.circle = $root.main.selectAll(`.${CLASS.circles} .${CLASS.circle}`)
+			$root.circle = $root.main.selectAll(`.${$CIRCLE.circles} .${$CIRCLE.circle}`)
 				.style("stroke", $$.color)
 				.style("opacity", $$.initialOpacityForCircle.bind($$));
 		}
@@ -145,7 +145,7 @@ export default {
 		const $$ = this;
 		const {state: {rendered}, $el, $T} = $$;
 		const $root = isSub ? $el.subchart : $el;
-		const selectedCircles = $root.main.selectAll(`.${CLASS.selectedCircle}`);
+		const selectedCircles = $root.main.selectAll(`.${$SELECT.selectedCircle}`);
 
 		if (!$$.config.point_show) {
 			return [];
@@ -256,7 +256,7 @@ export default {
 
 		reset && $$.unexpandCircles();
 
-		const circles = $$.getShapeByIndex("circle", i, id).classed(CLASS.EXPANDED, true);
+		const circles = $$.getShapeByIndex("circle", i, id).classed($COMMON.EXPANDED, true);
 		const scale = r(circles) / $$.config.point_r;
 		const ratio = 1 - scale;
 
@@ -286,9 +286,9 @@ export default {
 
 		const circles = $$.getShapeByIndex("circle", i)
 			.filter(function() {
-				return d3Select(this).classed(CLASS.EXPANDED);
+				return d3Select(this).classed($COMMON.EXPANDED);
 			})
-			.classed(CLASS.EXPANDED, false);
+			.classed($COMMON.EXPANDED, false);
 
 		circles.attr("r", r);
 
@@ -398,8 +398,8 @@ export default {
 				circle.each(function(d) {
 					let className = $$.getClass("circle", true)(d);
 
-					if (this.getAttribute("class").indexOf(CLASS.EXPANDED) > -1) {
-						className += ` ${CLASS.EXPANDED}`;
+					if (this.getAttribute("class").indexOf($COMMON.EXPANDED) > -1) {
+						className += ` ${$COMMON.EXPANDED}`;
 					}
 
 					this.setAttribute("class", className);

--- a/src/ChartInternal/shape/radar.ts
+++ b/src/ChartInternal/shape/radar.ts
@@ -4,7 +4,7 @@
  */
 import {select as d3Select} from "d3-selection";
 import {KEY} from "../../module/Cache";
-import CLASS from "../../config/classes";
+import {$AXIS, $COMMON, $RADAR, $SHAPE, $TEXT} from "../../config/classes";
 import {getMinMax, getRange, isDefined, isEmpty, isNumber, isUndefined, setTextValue, toArray} from "../../module/util";
 
 /**
@@ -35,20 +35,20 @@ export default {
 		const {config, state: {current}, $el} = $$;
 
 		if ($$.hasType("radar")) {
-			$el.radar = $el.main.select(`.${CLASS.chart}`).append("g")
-				.attr("class", CLASS.chartRadars);
+			$el.radar = $el.main.select(`.${$COMMON.chart}`).append("g")
+				.attr("class", $RADAR.chartRadars);
 
 			// level
 			$el.radar.levels = $el.radar.append("g")
-				.attr("class", CLASS.levels);
+				.attr("class", $RADAR.levels);
 
 			// axis
 			$el.radar.axes = $el.radar.append("g")
-				.attr("class", CLASS.axis);
+				.attr("class", $AXIS.axis);
 
 			// shapes
 			$el.radar.shapes = $el.radar.append("g")
-				.attr("class", CLASS.shapes);
+				.attr("class", $SHAPE.shapes);
 
 			current.dataMax = config.radar_axis_max || $$.getMinMaxData().max[0].value;
 		}
@@ -126,7 +126,7 @@ export default {
 		// Adjust radar, circles and texts' position
 		if (translate) {
 			radar.attr("transform", translate);
-			main.select(`.${CLASS.chartTexts}`).attr("transform", translate);
+			main.select(`.${$TEXT.chartTexts}`).attr("transform", translate);
 
 			$$.generateRadarPoints();
 			$$.updateRadarLevel();
@@ -176,13 +176,13 @@ export default {
 		});
 
 		const level = radarLevels
-			.selectAll(`.${CLASS.level}`)
+			.selectAll(`.${$RADAR.level}`)
 			.data(levelData);
 
 		level.exit().remove();
 
 		const levelEnter = level.enter().append("g")
-			.attr("class", (d, i) => `${CLASS.level} ${CLASS.level}-${i}`);
+			.attr("class", (d, i) => `${$RADAR.level} ${$RADAR.level}-${i}`);
 
 		levelEnter.append("polygon")
 			.style("visibility", config.radar_level_show ? null : "hidden");
@@ -231,7 +231,7 @@ export default {
 		axis.exit().remove();
 
 		const axisEnter = axis.enter().append("g")
-			.attr("class", (d, i) => `${CLASS.axis}-${i}`);
+			.attr("class", (d, i) => `${$AXIS.axis}-${i}`);
 
 		config.radar_axis_line_show && axisEnter.append("line");
 		config.radar_axis_text_show && axisEnter.append("text");

--- a/src/Plugin/sparkline/index.ts
+++ b/src/Plugin/sparkline/index.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import CLASS from "../../config/classes";
+import {$COMMON} from "../../config/classes";
 import Plugin from "../Plugin";
 import Options from "./Options";
 import {IData} from "../../ChartInternal/data/IData";
@@ -244,7 +244,7 @@ export default class Sparkline extends Plugin {
 
 		data.map(v => v.id)
 			.forEach((id, i) => {
-				const selector = `.${CLASS.target}-${id}`;
+				const selector = `.${$COMMON.target}-${id}`;
 				const shape = $el.main.selectAll(selector);
 				let svg = el[i].querySelector("svg");
 

--- a/src/Plugin/stanford/index.ts
+++ b/src/Plugin/stanford/index.ts
@@ -6,7 +6,7 @@
 import {interpolateHslLong as d3InterpolateHslLong} from "d3-interpolate";
 import {hsl as d3Hsl} from "d3-color";
 import {scaleSequentialLog as d3ScaleSequentialLog} from "d3-scale";
-import CLASS from "../../config/classes";
+import {$TOOLTIP} from "../../config/classes";
 import {loadConfig} from "../../config/config";
 import Plugin from "../Plugin";
 import Options from "./Options";
@@ -228,7 +228,7 @@ export default class Stanford extends Plugin {
 
 		if (isEmpty(config.tooltip_contents)) {
 			config.tooltip_contents = function(d, defaultTitleFormat, defaultValueFormat, color) {
-				let html = `<table class="${CLASS.tooltip}"><tbody>`;
+				let html = `<table class="${$TOOLTIP.tooltip}"><tbody>`;
 
 				d.forEach(v => {
 					html += `<tr>
@@ -239,7 +239,7 @@ export default class Stanford extends Plugin {
 							<th>${defaultTitleFormat(v.id)}</th>
 							<th class="value">${defaultValueFormat(v.value)}</th>
 						</tr>
-						<tr class="${CLASS.tooltipName}-${v.id}">
+						<tr class="${$TOOLTIP.tooltipName}-${v.id}">
 							<td class="name"><span style="background-color:${color(v)}"></span>${defaultTitleFormat("Epochs")}</td>
 							<td class="value">${defaultValueFormat(v.epochs)}</td>
 						</tr>`;

--- a/src/Plugin/stanford/util.ts
+++ b/src/Plugin/stanford/util.ts
@@ -3,7 +3,6 @@
  * billboard.js project is licensed under the MIT license
  * @ignore
  */
-
 import {getRange, isEmpty, isFunction, isString, parseDate} from "../../module/util";
 
 /**

--- a/src/config/classes.ts
+++ b/src/config/classes.ts
@@ -6,108 +6,196 @@
  * CSS class names definition
  * @private
  */
-export default {
+export const $COMMON = {
+	button: "bb-button",
+	chart: "bb-chart",
+	empty: "bb-empty",
+	main: "bb-main",
+	target: "bb-target",
+	EXPANDED: "_expanded_"
+};
+
+export const $ARC = {
 	arc: "bb-arc",
 	arcLabelLine: "bb-arc-label-line",
 	arcs: "bb-arcs",
+	chartArc: "bb-chart-arc",
+	chartArcs: "bb-chart-arcs",
+	chartArcsBackground: "bb-chart-arcs-background",
+	chartArcsTitle: "bb-chart-arcs-title"
+};
+
+export const $AREA = {
 	area: "bb-area",
-	areas: "bb-areas",
+	areas: "bb-areas"
+};
+
+export const $AXIS = {
 	axis: "bb-axis",
 	axisX: "bb-axis-x",
 	axisXLabel: "bb-axis-x-label",
 	axisY: "bb-axis-y",
 	axisY2: "bb-axis-y2",
 	axisY2Label: "bb-axis-y2-label",
-	axisYLabel: "bb-axis-y-label",
+	axisYLabel: "bb-axis-y-label"
+};
+
+export const $BAR = {
 	bar: "bb-bar",
 	bars: "bb-bars",
-	brush: "bb-brush",
-	button: "bb-button",
-	buttonZoomReset: "bb-zoom-reset",
+	chartBar: "bb-chart-bar",
+	chartBars: "bb-chart-bars"
+};
+
+export const $CANDLESTICK = {
 	candlestick: "bb-candlestick",
 	candlesticks: "bb-candlesticks",
-	chart: "bb-chart",
-	chartArc: "bb-chart-arc",
-	chartArcs: "bb-chart-arcs",
-	chartArcsBackground: "bb-chart-arcs-background",
+	chartCandlestick: "bb-chart-candlestick",
+	chartCandlesticks: "bb-chart-candlesticks",
+	valueDown: "bb-value-down",
+	valueUp: "bb-value-up"
+};
+
+export const $CIRCLE = {
+	chartCircles: "bb-chart-circles",
+	circle: "bb-circle",
+	circles: "bb-circles"
+};
+
+export const $COLOR = {
+	colorPattern: "bb-color-pattern",
+	colorScale: "bb-colorscale"
+};
+
+export const $DRAG = {
+	dragarea: "bb-dragarea",
+	INCLUDED: "_included_"
+};
+
+export const $GAUGE = {
 	chartArcsGaugeMax: "bb-chart-arcs-gauge-max",
 	chartArcsGaugeMin: "bb-chart-arcs-gauge-min",
 	chartArcsGaugeUnit: "bb-chart-arcs-gauge-unit",
-	chartArcsTitle: "bb-chart-arcs-title",
 	chartArcsGaugeTitle: "bb-chart-arcs-gauge-title",
-	chartBar: "bb-chart-bar",
-	chartBars: "bb-chart-bars",
-	chartCandlestick: "bb-chart-candlestick",
-	chartCandlesticks: "bb-chart-candlesticks",
-	chartCircles: "bb-chart-circles",
-	chartLine: "bb-chart-line",
-	chartLines: "bb-chart-lines",
-	chartRadar: "bb-chart-radar",
-	chartRadars: "bb-chart-radars",
-	chartText: "bb-chart-text",
-	chartTexts: "bb-chart-texts",
-	circle: "bb-circle",
-	circles: "bb-circles",
-	colorPattern: "bb-color-pattern",
-	colorScale: "bb-colorscale",
-	defocused: "bb-defocused",
-	dragarea: "bb-dragarea",
-	empty: "bb-empty",
-	eventRect: "bb-event-rect",
-	eventRects: "bb-event-rects",
-	eventRectsMultiple: "bb-event-rects-multiple",
-	eventRectsSingle: "bb-event-rects-single",
-	focused: "bb-focused",
-	gaugeValue: "bb-gauge-value",
-	grid: "bb-grid",
-	gridLines: "bb-grid-lines",
+	gaugeValue: "bb-gauge-value"
+};
+
+export const $LEGEND = {
 	legend: "bb-legend",
 	legendBackground: "bb-legend-background",
 	legendItem: "bb-legend-item",
 	legendItemEvent: "bb-legend-item-event",
-	legendItemFocused: "bb-legend-item-focused",
 	legendItemHidden: "bb-legend-item-hidden",
 	legendItemPoint: "bb-legend-item-point",
-	legendItemTile: "bb-legend-item-tile",
-	level: "bb-level",
-	levels: "bb-levels",
+	legendItemTile: "bb-legend-item-tile"
+};
+
+export const $LINE = {
+	chartLine: "bb-chart-line",
+	chartLines: "bb-chart-lines",
 	line: "bb-line",
-	lines: "bb-lines",
-	main: "bb-main",
-	region: "bb-region",
-	regions: "bb-regions",
-	selectedCircle: "bb-selected-circle",
-	selectedCircles: "bb-selected-circles",
-	shape: "bb-shape",
-	shapes: "bb-shapes",
-	stanfordElements: "bb-stanford-elements",
-	stanfordLine: "bb-stanford-line",
-	stanfordLines: "bb-stanford-lines",
-	stanfordRegion: "bb-stanford-region",
-	stanfordRegions: "bb-stanford-regions",
-	subchart: "bb-subchart",
-	target: "bb-target",
-	text: "bb-text",
-	texts: "bb-texts",
-	title: "bb-title",
-	tooltip: "bb-tooltip",
-	tooltipContainer: "bb-tooltip-container",
-	tooltipName: "bb-tooltip-name",
-	valueDown: "bb-value-down",
-	valueUp: "bb-value-up",
-	xgrid: "bb-xgrid",
+	lines: "bb-lines"
+};
+
+export const $EVENT = {
+	eventRect: "bb-event-rect",
+	eventRects: "bb-event-rects",
+	eventRectsMultiple: "bb-event-rects-multiple",
+	eventRectsSingle: "bb-event-rects-single",
+
+};
+
+export const $FOCUS = {
+	focused: "bb-focused",
+	defocused: "bb-defocused",
+	legendItemFocused: "bb-legend-item-focused",
 	xgridFocus: "bb-xgrid-focus",
+	ygridFocus: "bb-ygrid-focus"
+};
+
+export const $GRID = {
+	grid: "bb-grid",
+	gridLines: "bb-grid-lines",
+	xgrid: "bb-xgrid",
 	xgridLine: "bb-xgrid-line",
 	xgridLines: "bb-xgrid-lines",
 	xgrids: "bb-xgrids",
 	ygrid: "bb-ygrid",
-	ygridFocus: "bb-ygrid-focus",
 	ygridLine: "bb-ygrid-line",
 	ygridLines: "bb-ygrid-lines",
-	ygrids: "bb-ygrids",
-	zoomBrush: "bb-zoom-brush",
-	EXPANDED: "_expanded_",
-	SELECTED: "_selected_",
-	INCLUDED: "_included_",
+	ygrids: "bb-ygrids"
+};
+
+export const $RADAR = {
+	chartRadar: "bb-chart-radar",
+	chartRadars: "bb-chart-radars",
+	level: "bb-level",
+	levels: "bb-levels"
+};
+
+export const $REGION = {
+	region: "bb-region",
+	regions: "bb-regions"
+};
+
+export const $SELECT = {
+	selectedCircle: "bb-selected-circle",
+	selectedCircles: "bb-selected-circles",
+	SELECTED: "_selected_"
+};
+
+export const $SHAPE = {
+	shape: "bb-shape",
+	shapes: "bb-shapes",
+};
+
+export const $SUBCHART = {
+	brush: "bb-brush",
+	subchart: "bb-subchart"
+};
+
+export const $TEXT = {
+	chartText: "bb-chart-text",
+	chartTexts: "bb-chart-texts",
+	text: "bb-text",
+	texts: "bb-texts",
+	title: "bb-title",
 	TextOverlapping: "text-overlapping"
+};
+
+export const $TOOLTIP = {
+	tooltip: "bb-tooltip",
+	tooltipContainer: "bb-tooltip-container",
+	tooltipName: "bb-tooltip-name"
+};
+
+export const $ZOOM = {
+	buttonZoomReset: "bb-zoom-reset",
+	zoomBrush: "bb-zoom-brush"
+};
+
+export default {
+	...$COMMON,
+	...$ARC,
+	...$AREA,
+	...$AXIS,
+	...$BAR,
+	...$CANDLESTICK,
+	...$CIRCLE,
+	...$COLOR,
+	...$DRAG,
+	...$GAUGE,
+	...$LEGEND,
+	...$LINE,
+	...$EVENT,
+	...$FOCUS,
+	...$GRID,
+	...$RADAR,
+	...$REGION,
+	...$SELECT,
+	...$SHAPE,
+	...$SUBCHART,
+	...$TEXT,
+	...$TOOLTIP,
+	...$ZOOM
 };

--- a/src/module/util.ts
+++ b/src/module/util.ts
@@ -7,7 +7,6 @@ import {pointer as d3Pointer} from "d3-selection";
 import {brushSelection as d3BrushSelection} from "d3-brush";
 import {d3Selection} from "../../types/types";
 import {document, window} from "./browser";
-import CLASS from "../config/classes";
 
 export {
 	asHalfPixel,
@@ -284,7 +283,7 @@ function getBrushSelection(ctx) {
 	if (event && event.type === "brush") {
 		selection = event.selection;
 	// check from brush area selection
-	} else if (main && (selection = main.select(`.${CLASS.brush}`).node())) {
+	} else if (main && (selection = main.select(".bb-brush").node())) {
 		selection = d3BrushSelection(selection);
 	}
 

--- a/test/api/axis-spec.ts
+++ b/test/api/axis-spec.ts
@@ -6,8 +6,7 @@
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
-import axis from "../../src/Chart/api/axis";
+import {$AXIS} from "../../src/config/classes";
 
 describe("API axis", function() {
 	let chart;
@@ -56,7 +55,7 @@ describe("API axis", function() {
 			const labels = chart.axis.labels(axisLabel);
 
 			setTimeout(() => {
-				const label = main.select(`.${CLASS.axisYLabel}`);
+				const label = main.select(`.${$AXIS.axisYLabel}`);
 
 				expect(label.text()).to.be.equal("New Y Axis Label");
 				expect(label.attr("dx")).to.be.equal("-0.5em");
@@ -78,7 +77,7 @@ describe("API axis", function() {
 			});
 
 			setTimeout(() => {
-				const label = main.select(`.${CLASS.axisY2Label}`);
+				const label = main.select(`.${$AXIS.axisY2Label}`);
 
 				expect(label.text()).to.be.equal("New Y2 Axis Label");
 				expect(label.attr("dx")).to.be.equal("-0.5em");
@@ -98,7 +97,7 @@ describe("API axis", function() {
 
 	describe("axis.min/max()", () => {
 		it("should update axis min value", done => {
-			const xAxisTick = main.select(`.${CLASS.axisX} .tick`).node();
+			const xAxisTick = main.select(`.${$AXIS.axisX} .tick`).node();
 			const xTickValue = +xAxisTick.getAttribute("transform").replace(rx, "$1");
 			const x = -1;
 			const y = 0;
@@ -117,13 +116,13 @@ describe("API axis", function() {
 				expect(xTickValue).to.be.below(+xAxisTick.getAttribute("transform").replace(rx, "$1"));
 
 				// check for y max value
-				tspan = main.selectAll(`.${CLASS.axisY} tspan`).filter(function() {
+				tspan = main.selectAll(`.${$AXIS.axisY} tspan`).filter(function() {
 					return +d3Select(this).text() === y;
 				});
 
 				expect(tspan.empty()).to.be.false;
 
-				tspan = main.selectAll(`.${CLASS.axisY2} tspan`).filter(function() {
+				tspan = main.selectAll(`.${$AXIS.axisY2} tspan`).filter(function() {
 					return +d3Select(this).text() === y2;
 				});
 
@@ -134,7 +133,7 @@ describe("API axis", function() {
 		});
 
 		it("should update axis max value", done => {
-			const xAxisTick = main.selectAll(`.${CLASS.axisX} .tick`).nodes();
+			const xAxisTick = main.selectAll(`.${$AXIS.axisX} .tick`).nodes();
 			const lastIndex = xAxisTick.length - 1;
 
 			const lastXTickValue = +xAxisTick[lastIndex].getAttribute("transform").replace(rx, "$1");
@@ -155,11 +154,11 @@ describe("API axis", function() {
 				expect(lastXTickValue).to.be.above(+xAxisTick[lastIndex].getAttribute("transform").replace(rx, "$1"));
 
 				// check for y max value
-				tspan = main.selectAll(`.${CLASS.axisY} tspan`).nodes();
+				tspan = main.selectAll(`.${$AXIS.axisY} tspan`).nodes();
 				expect(+tspan[tspan.length - 1].innerHTML).to.be.equal(y);
 
 				// check for y2 max value
-				tspan = main.selectAll(`.${CLASS.axisY2} tspan`).nodes();
+				tspan = main.selectAll(`.${$AXIS.axisY2} tspan`).nodes();
 				expect(+tspan[tspan.length - 1].innerHTML).to.be.equal(y2);
 
 				done();
@@ -169,7 +168,7 @@ describe("API axis", function() {
 
 	describe("axis.range()", () => {
 		it("should update axis min/max value", done => {
-			const xAxisTick = main.selectAll(`.${CLASS.axisX} .tick`).nodes();
+			const xAxisTick = main.selectAll(`.${$AXIS.axisX} .tick`).nodes();
 			const xTickValueMin = +xAxisTick[0].getAttribute("transform").replace(rx, "$1");
 			const xTickValueMax = +xAxisTick[xAxisTick.length - 1].getAttribute("transform").replace(rx, "$1");
 
@@ -205,7 +204,7 @@ describe("API axis", function() {
 				expect(xTickValueMax).to.be.above(+xAxisTick[xAxisTick.length - 1].getAttribute("transform").replace(rx, "$1"));
 
 				// check for y value
-				tspan = main.selectAll(`.${CLASS.axisY} tspan`).filter(function() {
+				tspan = main.selectAll(`.${$AXIS.axisY} tspan`).filter(function() {
 					const val = +d3Select(this).text();
 
 					return val === min.y || val === max.y;
@@ -214,7 +213,7 @@ describe("API axis", function() {
 				expect(tspan.size()).to.be.equal(2);
 
 				// check for y2 value
-				tspan = main.selectAll(`.${CLASS.axisY2} tspan`).filter(function() {
+				tspan = main.selectAll(`.${$AXIS.axisY2} tspan`).filter(function() {
 					const val = +d3Select(this).text();
 
 					return val === min.y2 || val === max.y2;

--- a/test/api/category-spec.ts
+++ b/test/api/category-spec.ts
@@ -6,7 +6,7 @@
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS} from "../../src/config/classes";
 
 describe("API category", () => {
 	let chart;
@@ -44,7 +44,7 @@ describe("API category", () => {
 		const name = ["aa","bb","cc", "dd", "ee"];
 		chart.categories(name);
 
-		chart.$.main.selectAll(`.${CLASS.axisX} tspan`).each(function(d, i) {
+		chart.$.main.selectAll(`.${$AXIS.axisX} tspan`).each(function(d, i) {
 			expect(d3Select(this).text()).to.be.equal(name[i]);
 		});
 	});
@@ -62,7 +62,7 @@ describe("API category", () => {
 		});
 
 		// check if <tspan> element value has changed
-		chart.$.main.selectAll(`.${CLASS.axisX} tspan`).each(function(d, i) {
+		chart.$.main.selectAll(`.${$AXIS.axisX} tspan`).each(function(d, i) {
 			expect(d3Select(this).text()).to.be.equal(name[i]);
 		});
 	});

--- a/test/api/chart-spec.ts
+++ b/test/api/chart-spec.ts
@@ -6,7 +6,7 @@
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $BAR, $GAUGE} from "../../src/config/classes";
 import bb from "../../src";
 
 describe("API chart", () => {
@@ -47,7 +47,7 @@ describe("API chart", () => {
 
 		it("should update groups correctly", done => {
 			const main = chart.$.main;
-			const path = main.select(`.${CLASS.bars}-data1 path`);
+			const path = main.select(`.${$BAR.bars}-data1 path`);
 			const barWidth = util.getBBox(path).width;
 
 			chart.groups([
@@ -199,7 +199,7 @@ describe("API chart", () => {
 			max = +chart.config("gauge.max", expected, true);
 
 			expect(max).to.be.equal(expected);
-			expect(+chart.$.arc.select(`.${CLASS.chartArcsGaugeMax}`).text()).to.be.equal(expected);
+			expect(+chart.$.arc.select(`.${$GAUGE.chartArcsGaugeMax}`).text()).to.be.equal(expected);
 		});
 
 		it("set options", () => {
@@ -220,7 +220,7 @@ describe("API chart", () => {
 		});
 
 		it("check for the axis config update", () => {
-			const axisYTick = chart.$.main.selectAll(`.${CLASS.axisY} .tick`);
+			const axisYTick = chart.$.main.selectAll(`.${$AXIS.axisY} .tick`);
 			const expected = [];
 
 			// axis y tick is outer

--- a/test/api/data-spec.ts
+++ b/test/api/data-spec.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 import {expect} from "chai";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $LEGEND, $LINE} from "../../src/config/classes";
 
 describe("API data", function() {
 	let chart;
@@ -204,16 +204,16 @@ describe("API data", function() {
 			setTimeout(() => {
 				const svg = chart.$.svg;
 
-				expect(toHex(svg.select(`.${CLASS.line}-data`).style("stroke")))
+				expect(toHex(svg.select(`.${$LINE.line}-data`).style("stroke")))
 					.to.be.equal("#00ff00");
 
-				expect(toHex(svg.select(`.${CLASS.line}-data2`).style("stroke")))
+				expect(toHex(svg.select(`.${$LINE.line}-data2`).style("stroke")))
 					.to.be.equal("#ff0000");
 
-				expect(toHex(svg.select(`.${CLASS.legendItem}-data .${CLASS.legendItem}-tile`).style("stroke")))
+				expect(toHex(svg.select(`.${$LEGEND.legendItem}-data .${$LEGEND.legendItem}-tile`).style("stroke")))
 					.to.be.equal("#00ff00");
 
-				expect(toHex(svg.select(`.${CLASS.legendItem}-data2 .${CLASS.legendItem}-tile`).style("stroke")))
+				expect(toHex(svg.select(`.${$LEGEND.legendItem}-data2 .${$LEGEND.legendItem}-tile`).style("stroke")))
 					.to.be.equal("#ff0000");
 
 				done();
@@ -230,10 +230,10 @@ describe("API data", function() {
 			expect(results.data).to.be.equal("y");
 			expect(results.data2).to.be.equal("y2");
 
-			expect(main.select(`.${CLASS.axisY} g.tick text`).text())
+			expect(main.select(`.${$AXIS.axisY} g.tick text`).text())
 				.to.be.equal("0");
 
-			expect(main.select(`.${CLASS.axisY2} g.tick text`).text())
+			expect(main.select(`.${$AXIS.axisY2} g.tick text`).text())
 				.to.be.equal("1000");
 		});
 
@@ -248,10 +248,10 @@ describe("API data", function() {
 				expect(results.data).to.be.equal("y2");
 				expect(results.data2).to.be.equal("y");
 
-				expect(main.select(`.${CLASS.axisY} g.tick text`).text())
+				expect(main.select(`.${$AXIS.axisY} g.tick text`).text())
 					.to.be.equal("1000");
 
-				expect(main.select(`.${CLASS.axisY2} g.tick text`).text())
+				expect(main.select(`.${$AXIS.axisY2} g.tick text`).text())
 					.to.be.equal("0");
 
 				done();

--- a/test/api/flow-spec.ts
+++ b/test/api/flow-spec.ts
@@ -6,7 +6,7 @@
 import {expect} from "chai";
 import sinon from "sinon";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $LINE} from "../../src/config/classes";
 import {window} from "../../src/module/browser";
 
 describe("API flow", () => {
@@ -45,7 +45,7 @@ describe("API flow", () => {
 					["data3", 200, 120]
 				],
 				done: function () {
-					const lineSize = this.internal.$el.main.selectAll(`.${CLASS.chartLines} > g`).size();
+					const lineSize = this.internal.$el.main.selectAll(`.${$LINE.chartLines} > g`).size();
 
 					expect(lineSize).to.be.equal(this.data().length);
 					done();
@@ -55,7 +55,7 @@ describe("API flow", () => {
 
 		it("should flow correctly with options", done => {
 			const spy = sinon.spy(function() {
-				chart.internal.$el.main.selectAll(`.${CLASS.axisX} .tick tspan`).each(function(d, i) {
+				chart.internal.$el.main.selectAll(`.${$AXIS.axisX} .tick tspan`).each(function(d, i) {
 					expect(this.textContent).to.be.equal(tickText[i]);
 					expect(d.splitted).to.be.equal(tickText[i]);
 				});
@@ -89,7 +89,7 @@ describe("API flow", () => {
 				done: spy
 			});
 
-			const lastTickText = chart.$.main.selectAll(`.${CLASS.axisX} .tick tspan`)
+			const lastTickText = chart.$.main.selectAll(`.${$AXIS.axisX} .tick tspan`)
 				.nodes().pop().innerHTML;
 
 			// when tab is not visible, it shouldn't be executed

--- a/test/api/focus-spec.ts
+++ b/test/api/focus-spec.ts
@@ -6,7 +6,7 @@
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$COMMON, $FOCUS, $LEGEND, $LINE} from "../../src/config/classes";
 
 describe("API focus", function() {
 	let chart;
@@ -14,9 +14,9 @@ describe("API focus", function() {
 	let main;
 
 	// focus class name
-	const focused = CLASS.focused;
-	const defocused = CLASS.defocused;
-	const itemFocused = CLASS.legendItemFocused;
+	const focused = $FOCUS.focused;
+	const defocused = $FOCUS.defocused;
+	const itemFocused = $FOCUS.legendItemFocused;
 
 	// get fixed number
 	const getFixed = (val, len = 1) => +(+val).toFixed(len);
@@ -151,8 +151,8 @@ describe("API focus", function() {
 
 
 		it("should defocus one target", () => {
-			const targets = main.selectAll(`.${CLASS.chartLine}.${CLASS.target}`);
-			const legendItems = legend.selectAll(`.${CLASS.legendItem}`);
+			const targets = main.selectAll(`.${$LINE.chartLine}.${$COMMON.target}`);
+			const legendItems = legend.selectAll(`.${$LEGEND.legendItem}`);
 
 			chart.focus();
 			chart.defocus("data2");
@@ -183,8 +183,8 @@ describe("API focus", function() {
 		});
 
 		it("should defocus multiple targets", done => {
-			const targets = main.selectAll(`.${CLASS.chartLine}.${CLASS.target}`);
-			const legendItems = legend.selectAll(`.${CLASS.legendItem}`);
+			const targets = main.selectAll(`.${$LINE.chartLine}.${$COMMON.target}`);
+			const legendItems = legend.selectAll(`.${$LEGEND.legendItem}`);
 
 			chart.focus();
 			chart.defocus(["data1", "data2"]);
@@ -223,7 +223,7 @@ describe("API focus", function() {
 			setTimeout(() => {
 				chart.defocus(["data1", "data2"]);
 				setTimeout(() => {
-					const className = `.${CLASS.chartLine}.${CLASS.target}.${CLASS.target}-data`;
+					const className = `.${$LINE.chartLine}.${$COMMON.target}.${$COMMON.target}-data`;
 					const targets = {
 						data1: main.select(`${className}1`),
 						data2: main.select(`${className}2`),
@@ -231,9 +231,9 @@ describe("API focus", function() {
 					};
 
 					const legendItems = {
-						data1: legend.select(`.${CLASS.legendItem}-data1`),
-						data2: legend.select(`.${CLASS.legendItem}-data2`),
-						data3: legend.select(`.${CLASS.legendItem}-data3`)
+						data1: legend.select(`.${$LEGEND.legendItem}-data1`),
+						data2: legend.select(`.${$LEGEND.legendItem}-data2`),
+						data3: legend.select(`.${$LEGEND.legendItem}-data3`)
 					};
 
 					expect(targets.data1.classed(defocused)).to.be.ok;
@@ -267,8 +267,8 @@ describe("API focus", function() {
 				chart.revert();
 
 				setTimeout(() => {
-					const targets = main.selectAll(`.${CLASS.chartLine}.${CLASS.target}`);
-					const legendItems = legend.selectAll(`.${CLASS.legendItem}`);
+					const targets = main.selectAll(`.${$LINE.chartLine}.${$COMMON.target}`);
+					const legendItems = legend.selectAll(`.${$LEGEND.legendItem}`);
 
 					targets.each(function() {
 						const line = d3Select(this);
@@ -296,8 +296,8 @@ describe("API focus", function() {
 				chart.revert();
 
 				setTimeout(function () {
-					const targets = main.selectAll(`.${CLASS.chartLine}.${CLASS.target}`);
-					const legendItems = legend.selectAll(`.${CLASS.legendItem}`);
+					const targets = main.selectAll(`.${$LINE.chartLine}.${$COMMON.target}`);
+					const legendItems = legend.selectAll(`.${$LEGEND.legendItem}`);
 
 					targets.each(function () {
 						const line = d3Select(this);
@@ -325,7 +325,7 @@ describe("API focus", function() {
 				chart.revert("data2");
 
 				setTimeout(() => {
-					const className = `.${CLASS.chartLine}.${CLASS.target}.${CLASS.target}-data`;
+					const className = `.${$LINE.chartLine}.${$COMMON.target}.${$COMMON.target}-data`;
 					const targets = {
 						data1: main.select(`${className}1`),
 						data2: main.select(`${className}2`),
@@ -333,9 +333,9 @@ describe("API focus", function() {
 					};
 
 					const legendItems = {
-						data1: legend.select(`.${CLASS.legendItem}-data1`),
-						data2: legend.select(`.${CLASS.legendItem}-data2`),
-						data3: legend.select(`.${CLASS.legendItem}-data3`)
+						data1: legend.select(`.${$LEGEND.legendItem}-data1`),
+						data2: legend.select(`.${$LEGEND.legendItem}-data2`),
+						data3: legend.select(`.${$LEGEND.legendItem}-data3`)
 					};
 
 					expect(targets.data1.classed(focused)).to.be.ok;
@@ -373,7 +373,7 @@ describe("API focus", function() {
 				chart.revert("data2");
 
 				setTimeout(() => {
-					const className = `.${CLASS.chartLine}.${CLASS.target}.${CLASS.target}-data`;
+					const className = `.${$LINE.chartLine}.${$COMMON.target}.${$COMMON.target}-data`;
 					const targets = {
 						data1: main.select(`${className}1`),
 						data2: main.select(`${className}2`),
@@ -381,9 +381,9 @@ describe("API focus", function() {
 					};
 
 					const legendItems = {
-						data1: legend.select(`.${CLASS.legendItem}-data1`),
-						data2: legend.select(`.${CLASS.legendItem}-data2`),
-						data3: legend.select(`.${CLASS.legendItem}-data3`)
+						data1: legend.select(`.${$LEGEND.legendItem}-data1`),
+						data2: legend.select(`.${$LEGEND.legendItem}-data2`),
+						data3: legend.select(`.${$LEGEND.legendItem}-data3`)
 					};
 
 					expect(targets.data1.classed(defocused)).to.be.ok;
@@ -415,7 +415,7 @@ describe("API focus", function() {
 				chart.revert(["data1", "data2"]);
 
 				setTimeout(() => {
-					const className = `.${CLASS.chartLine}.${CLASS.target}.${CLASS.target}-data`;
+					const className = `.${$LINE.chartLine}.${$COMMON.target}.${$COMMON.target}-data`;
 					const targets = {
 						data1: main.select(`${className}1`),
 						data2: main.select(`${className}2`),
@@ -423,9 +423,9 @@ describe("API focus", function() {
 					};
 
 					const legendItems = {
-						data1: legend.select(`.${CLASS.legendItem}-data1`),
-						data2: legend.select(`.${CLASS.legendItem}-data2`),
-						data3: legend.select(`.${CLASS.legendItem}-data3`)
+						data1: legend.select(`.${$LEGEND.legendItem}-data1`),
+						data2: legend.select(`.${$LEGEND.legendItem}-data2`),
+						data3: legend.select(`.${$LEGEND.legendItem}-data3`)
 					};
 
 					expect(targets.data1.classed(focused)).to.not.be.ok;
@@ -463,7 +463,7 @@ describe("API focus", function() {
 				chart.revert(["data1", "data2"]);
 
 				setTimeout(() => {
-					const className = `.${CLASS.chartLine}.${CLASS.target}.${CLASS.target}-data`;
+					const className = `.${$LINE.chartLine}.${$COMMON.target}.${$COMMON.target}-data`;
 					const targets = {
 						data1: main.select(`${className}1`),
 						data2: main.select(`${className}2`),
@@ -471,9 +471,9 @@ describe("API focus", function() {
 					};
 
 					const legendItems = {
-						data1: legend.select(`.${CLASS.legendItem}-data1`),
-						data2: legend.select(`.${CLASS.legendItem}-data2`),
-						data3: legend.select(`.${CLASS.legendItem}-data3`)
+						data1: legend.select(`.${$LEGEND.legendItem}-data1`),
+						data2: legend.select(`.${$LEGEND.legendItem}-data2`),
+						data3: legend.select(`.${$LEGEND.legendItem}-data3`)
 					};
 
 					expect(targets.data1.classed(defocused)).to.not.be.ok;
@@ -531,7 +531,7 @@ describe("API focus", function() {
 			chart.focus();
 
 			setTimeout(() => {
-				const targets = main.select(`.${CLASS.chartLine}.${CLASS.target}`);
+				const targets = main.select(`.${$LINE.chartLine}.${$COMMON.target}`);
 
 				targets.each(function() {
 					const line = d3Select(this);
@@ -570,7 +570,7 @@ describe("API focus", function() {
 				chart.revert();
 
 				setTimeout(() => {
-					const targets = main.select(`.${CLASS.chartLine}.${CLASS.target}`);
+					const targets = main.select(`.${$LINE.chartLine}.${$COMMON.target}`);
 
 					targets.each(function() {
 						const line = d3Select(this);

--- a/test/api/grid-spec.ts
+++ b/test/api/grid-spec.ts
@@ -6,7 +6,7 @@
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$GRID} from "../../src/config/classes";
 
 describe("API grid", function() {
 	let chart;
@@ -42,7 +42,7 @@ describe("API grid", function() {
 			chart.ygrids.add(expectedGrids);
 
 			setTimeout(() => {
-				grids = main.selectAll(`.${CLASS.ygridLine}`);
+				grids = main.selectAll(`.${$GRID.ygridLine}`);
 
 				expect(grids.size()).to.be.equal(expectedGrids.length);
 
@@ -60,7 +60,7 @@ describe("API grid", function() {
 				chart.ygrids.remove(expectedGrids);
 
 				setTimeout(() => {
-					grids = main.selectAll(`.${CLASS.ygridLine}`);
+					grids = main.selectAll(`.${$GRID.ygridLine}`);
 
 					expect(grids.size()).to.be.equal(0);
 					done();
@@ -92,7 +92,7 @@ describe("API grid", function() {
 
 				// for xgrids()
 				setTimeout(() => {
-					grids = main.selectAll(`.${CLASS.xgridLine}`);
+					grids = main.selectAll(`.${$GRID.xgridLine}`);
 
 					expect(grids.size()).to.be.equal(expectedGrids.length);
 
@@ -116,7 +116,7 @@ describe("API grid", function() {
 
 					// for xgrids.remove()
 					setTimeout(() => {
-						grids = main.selectAll(`.${CLASS.xgridLine}`);
+						grids = main.selectAll(`.${$GRID.xgridLine}`);
 
 						expect(grids.size()).to.be.equal(0);
 						done();
@@ -150,7 +150,7 @@ describe("API grid", function() {
 			chart.xgrids([gridData]);
 
 			setTimeout(() => {
-				const xgrid = chart.$.main.select(`.${CLASS.xgridLine}`);
+				const xgrid = chart.$.main.select(`.${$GRID.xgridLine}`);
 
 				expect(xgrid.classed(gridData.class)).to.be.true;
 
@@ -222,7 +222,7 @@ describe("API grid", function() {
 			chart.ygrids([gridData]);
 
 			setTimeout(() => {
-				const ygrid = chart.$.main.select(`.${CLASS.ygridLine}`);
+				const ygrid = chart.$.main.select(`.${$GRID.ygridLine}`);
 
 				expect(ygrid.classed(gridData.class)).to.be.true;
 

--- a/test/api/legend-spec.ts
+++ b/test/api/legend-spec.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 import {expect} from "chai";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$LEGEND} from "../../src/config/classes";
 
 describe("API legend", () => {
 	let chart;
@@ -34,7 +34,7 @@ describe("API legend", () => {
 	it("it should hide all legends", () => {
 		chart.legend.hide();
 
-		chart.internal.$el.svg.selectAll(`.${CLASS.legendItem}`).each(function() {
+		chart.internal.$el.svg.selectAll(`.${$LEGEND.legendItem}`).each(function() {
 			expect(+this.style.opacity).to.be.equal(0);
 		});
 	});
@@ -43,7 +43,7 @@ describe("API legend", () => {
 		chart.legend.show();
 
 		setTimeout(() => {
-			chart.internal.$el.svg.selectAll(`.${CLASS.legendItem}`).each(function() {
+			chart.internal.$el.svg.selectAll(`.${$LEGEND.legendItem}`).each(function() {
 
 				expect(this.style.opacity).to.be.equal("");
 			});
@@ -55,7 +55,7 @@ describe("API legend", () => {
 	it("it should hide 'data1' legend", () => {
 		chart.legend.hide("data1");
 
-		chart.internal.$el.svg.selectAll(`.${CLASS.legendItem}`).each(function(v) {
+		chart.internal.$el.svg.selectAll(`.${$LEGEND.legendItem}`).each(function(v) {
 			expect(this.style.opacity).to.be.equal(v === "data1" ? "0" : "");
 		});
 	});
@@ -65,7 +65,7 @@ describe("API legend", () => {
 		chart.legend.show("data1");
 
 		setTimeout(() => {
-			chart.internal.$el.svg.selectAll(`.${CLASS.legendItem}`).each(function(v) {
+			chart.internal.$el.svg.selectAll(`.${$LEGEND.legendItem}`).each(function(v) {
 				expect(this.style.opacity).to.be.equal("");
 			});
 

--- a/test/api/load-spec.ts
+++ b/test/api/load-spec.ts
@@ -6,9 +6,8 @@
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import {format as d3Format} from "d3-format";
-import CLASS from "../../src/config/classes";
+import {$AREA, $AXIS, $COMMON, $CIRCLE, $LEGEND, $LINE} from "../../src/config/classes";
 import util from "../assets/util";
-import { area } from "../../src/config/resolver/shape";
 
 describe("API load", function() {
 	let chart;
@@ -90,7 +89,7 @@ describe("API load", function() {
 						const main = chart.$.main;
 
 						// updated classname?
-						expect(main.select(`.${CLASS.target}-data1.${CLASS.target}-${className}`).empty()).to.be.false;
+						expect(main.select(`.${$COMMON.target}-data1.${$COMMON.target}-${className}`).empty()).to.be.false;
 
 						// updated category?
 						expect(chart.categories()).to.deep.equal(categories);
@@ -121,9 +120,9 @@ describe("API load", function() {
 					["data3", 800, 500, 900, 500, 1000, 700]
 				],
 				done: () => {
-					const target = main.select(`.${CLASS.chartLine}.${CLASS.target}.${CLASS.target}-data3`);
-					const legendItem = legend.select(`.${CLASS.legendItem}.${CLASS.legendItem}-data3`);
-					const circles = main.selectAll(`.${CLASS.circles}.${CLASS.circles}-data3 circle`);
+					const target = main.select(`.${$LINE.chartLine}.${$COMMON.target}.${$COMMON.target}-data3`);
+					const legendItem = legend.select(`.${$LEGEND.legendItem}.${$LEGEND.legendItem}-data3`);
+					const circles = main.selectAll(`.${$CIRCLE.circles}.${$CIRCLE.circles}-data3 circle`);
 
 					expect(target.size()).to.be.equal(1);
 					expect(legendItem.size()).to.be.equal(1);
@@ -169,10 +168,10 @@ describe("API load", function() {
 					["data3", 400, 500, 450]
 				],
 				done: () => {
-					const target = main.select(`.${CLASS.chartLine}.${CLASS.target}.${CLASS.target}-data3`);
-					const legendItem = legend.select(`.${CLASS.legendItem}.${CLASS.legendItem}-data3`);
-					const circles = main.selectAll(`.${CLASS.circles}.${CLASS.circles}-data3 circle`);
-					const tickTexts = main.selectAll(`.${CLASS.axisX} g.tick text`);
+					const target = main.select(`.${$LINE.chartLine}.${$COMMON.target}.${$COMMON.target}-data3`);
+					const legendItem = legend.select(`.${$LEGEND.legendItem}.${$LEGEND.legendItem}-data3`);
+					const circles = main.selectAll(`.${$CIRCLE.circles}.${$CIRCLE.circles}-data3 circle`);
+					const tickTexts = main.selectAll(`.${$AXIS.axisX} g.tick text`);
 
 					expect(target.size()).to.be.equal(1);
 					expect(legendItem.size()).to.be.equal(1);
@@ -220,9 +219,9 @@ describe("API load", function() {
 						["data3", 800, 500, 900]
 					],
 					done: () => {
-						const target = main.select(`.${CLASS.chartLine}.${CLASS.target}.${CLASS.target}-data3`);
-						const legendItem = legend.select(`.${CLASS.legendItem}.${CLASS.legendItem}-data3`);
-						const tickTexts = main.selectAll(`.${CLASS.axisX} g.tick text`);
+						const target = main.select(`.${$LINE.chartLine}.${$COMMON.target}.${$COMMON.target}-data3`);
+						const legendItem = legend.select(`.${$LEGEND.legendItem}.${$LEGEND.legendItem}-data3`);
+						const tickTexts = main.selectAll(`.${$AXIS.axisX} g.tick text`);
 						const expected = ["cat1", "cat2", "cat3", "cat4", "cat5", "cat6"];
 
 						expect(target.size()).to.be.equal(1);
@@ -250,9 +249,9 @@ describe("API load", function() {
 						["data3", 800, 500, 900, 500, 1000, 700]
 					],
 					done: () => {
-						const target = main.select(`.${CLASS.chartLine}.${CLASS.target}.${CLASS.target}-data3`);
-						const legendItem = legend.select(`.${CLASS.legendItem}.${CLASS.legendItem}-data3`);
-						const tickTexts = main.selectAll(`.${CLASS.axisX} g.tick text`);
+						const target = main.select(`.${$LINE.chartLine}.${$COMMON.target}.${$COMMON.target}-data3`);
+						const legendItem = legend.select(`.${$LEGEND.legendItem}.${$LEGEND.legendItem}-data3`);
+						const tickTexts = main.selectAll(`.${$AXIS.axisX} g.tick text`);
 						const expected = ["new1", "new2", "new3", "new4", "new5", "new6"];
 
 						expect(target.size()).to.be.equal(1);
@@ -379,7 +378,7 @@ describe("API load", function() {
 		});
 
 		it("should be updated the axis label position ", done => {
-			const axisLabel = chart.$.main.select(`.${CLASS.axisYLabel}`);
+			const axisLabel = chart.$.main.select(`.${$AXIS.axisYLabel}`);
 			const dy = +axisLabel.attr("dy");
 
 			chart.load({
@@ -569,7 +568,7 @@ describe("API load", function() {
 						expect(areas && !areas.empty()).to.be.true;
 
 						// check for duplicated node appends
-						expect(chart.$.main.selectAll(`.${CLASS.areas}`).size()).to.be.equal(1);
+						expect(chart.$.main.selectAll(`.${$AREA.areas}`).size()).to.be.equal(1);
 						done();
 					}
 				});
@@ -618,7 +617,7 @@ describe("API load", function() {
 					data3: "area-spline-range"
 				},
 				done: function() {
-					expect(this.$.line.areas.filter(`.${CLASS.area}-data3`).size()).to.be.equal(1);
+					expect(this.$.line.areas.filter(`.${$AREA.area}-data3`).size()).to.be.equal(1);
 
 					done();
 				}

--- a/test/api/region-spec.ts
+++ b/test/api/region-spec.ts
@@ -6,7 +6,7 @@
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$REGION} from "../../src/config/classes";
 
 describe("API region", function() {
 	let chart;
@@ -63,7 +63,7 @@ describe("API region", function() {
 			chart.regions(expectedRegions);
 
 			setTimeout(() => {
-				regions = main.selectAll(`.${CLASS.region}`);
+				regions = main.selectAll(`.${$REGION.region}`);
 
 				expect(regions.size()).to.be.equal(expectedRegions.length);
 
@@ -162,7 +162,7 @@ describe("API region", function() {
 			chart.regions(expectedRegions);
 
 			setTimeout(() => {
-				regions = main.selectAll(`.${CLASS.region}`);
+				regions = main.selectAll(`.${$REGION.region}`);
 
 				expect(regions.size()).to.be.equal(expectedRegions.length);
 
@@ -268,7 +268,7 @@ describe("API region", function() {
 			chart.regions(expectedRegions);
 
 			setTimeout(() => {
-				regions = main.selectAll(`.${CLASS.region}`);
+				regions = main.selectAll(`.${$REGION.region}`);
 
 				expect(regions.size()).to.be.equal(expectedRegions.length);
 
@@ -326,7 +326,7 @@ describe("API region", function() {
 
 			// regions should be positioned behind the chart elements
 			// https://github.com/naver/billboard.js/issues/2067
-			expect(chart.$.main.select(":first-child").classed(CLASS.regions)).to.be.true;
+			expect(chart.$.main.select(":first-child").classed($REGION.regions)).to.be.true;
 
 			expect(chart.regions()).to.deep.equal(regions);
 

--- a/test/api/selection-spec.ts
+++ b/test/api/selection-spec.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 import {expect} from "chai";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$BAR, $SELECT, $SHAPE} from "../../src/config/classes";
 
 describe("API select", () => {
 	let chart;
@@ -31,7 +31,7 @@ describe("API select", () => {
 		it("should select all data points", () => {
 			chart.select();
 
-			const selected = main.selectAll(`.${CLASS.selectedCircle}`);
+			const selected = main.selectAll(`.${$SELECT.selectedCircle}`);
 			const dataLen = chart.data.values("data1").length + chart.data.values("data2").length;
 
 			expect(selected.size()).to.be.equal(dataLen);
@@ -43,8 +43,8 @@ describe("API select", () => {
 			chart.unselect(["data1", "data2"], [indice]);
 
 			setTimeout(() => {
-				const unselected = main.selectAll(`.${CLASS.selectedCircle}`)
-					.filter(`.${CLASS.selectedCircle}-${indice}`);
+				const unselected = main.selectAll(`.${$SELECT.selectedCircle}`)
+					.filter(`.${$SELECT.selectedCircle}-${indice}`);
 
 				expect(unselected.empty()).to.be.ok;
 
@@ -56,7 +56,7 @@ describe("API select", () => {
 			chart.unselect();
 
 			setTimeout(() => {
-				const unselected = main.selectAll(`.${CLASS.selectedCircle}`);
+				const unselected = main.selectAll(`.${$SELECT.selectedCircle}`);
 
 				expect(unselected.empty()).to.be.ok;
 
@@ -72,7 +72,7 @@ describe("API select", () => {
 			const selected = chart.selected();
 
 			setTimeout(() => {
-				main.selectAll(`.${CLASS.selectedCircles}-data1 circle`).each((v, i) => {
+				main.selectAll(`.${$SELECT.selectedCircles}-data1 circle`).each((v, i) => {
 					expect(v).to.be.equal(selected[i]);
 					expect(v.index).to.be.equal(indice[i]);
 				});
@@ -92,7 +92,7 @@ describe("API select", () => {
 		it("should select all data points", () => {
 			chart.select();
 
-			const selected = main.selectAll(`.${CLASS.SELECTED}`);
+			const selected = main.selectAll(`.${$SELECT.SELECTED}`);
 			const dataLen = chart.data.values("data1").length + chart.data.values("data2").length;
 
 			expect(selected.size()).to.be.equal(dataLen);
@@ -104,8 +104,8 @@ describe("API select", () => {
 			chart.unselect(["data1", "data2"], [indice]);
 
 			setTimeout(() => {
-				const unselected = main.selectAll(`.${CLASS.SELECTED}`)
-					.filter(`.${CLASS.bar}-${indice}`);
+				const unselected = main.selectAll(`.${$SELECT.SELECTED}`)
+					.filter(`.${$BAR.bar}-${indice}`);
 
 				expect(unselected.empty()).to.be.ok;
 
@@ -117,7 +117,7 @@ describe("API select", () => {
 			chart.unselect();
 
 			setTimeout(() => {
-				const unselected = main.selectAll(`.${CLASS.SELECTED}`);
+				const unselected = main.selectAll(`.${$SELECT.SELECTED}`);
 
 				expect(unselected.empty()).to.be.ok;
 
@@ -134,7 +134,7 @@ describe("API select", () => {
 			const selected = chart.selected();
 
 			setTimeout(() => {
-				main.selectAll(`.${CLASS.shapes}-data1 path.${CLASS.SELECTED}`).each(function(v, i) {
+				main.selectAll(`.${$SHAPE.shapes}-data1 path.${$SELECT.SELECTED}`).each(function(v, i) {
 					expect(v).to.be.equal(selected[i]);
 					expect(v.index).to.be.equal(indice[i]);
 

--- a/test/api/show-spec.ts
+++ b/test/api/show-spec.ts
@@ -6,7 +6,7 @@
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$BAR, $COMMON, $LINE, $LEGEND} from "../../src/config/classes";
 
 describe("API show", () => {
 	let chart;
@@ -31,12 +31,12 @@ describe("API show", () => {
 			chart.hide("data1");
 
 			setTimeout(() => {
-				const selector = `.${CLASS.chartLine}.${CLASS.target}`;
+				const selector = `.${$LINE.chartLine}.${$COMMON.target}`;
 
 				expect(+main.select(`${selector}-data1`).style("opacity")).to.be.equal(0);
 				expect(+main.select(`${selector}-data2`).style("opacity")).to.be.equal(1);
 
-				expect(+internal.$el.svg.selectAll(`.${CLASS.legendItemHidden}`).size()).to.be.equal(1);
+				expect(+internal.$el.svg.selectAll(`.${$LEGEND.legendItemHidden}`).size()).to.be.equal(1);
 
 				done();
 			}, 500);
@@ -49,11 +49,11 @@ describe("API show", () => {
 			chart.hide();
 
 			setTimeout(() => {
-				main.selectAll(`.${CLASS.chartLine}`).each(function() {
+				main.selectAll(`.${$LINE.chartLine}`).each(function() {
 					expect(+this.style.opacity).to.be.equal(0);
 				});
 
-				const legend = chart.$.svg.selectAll(`.${CLASS.legendItemHidden}`);
+				const legend = chart.$.svg.selectAll(`.${$LEGEND.legendItemHidden}`);
 
 				expect(+legend.size()).to.be.equal(chart.data().length);
 
@@ -71,7 +71,7 @@ describe("API show", () => {
 
 			setTimeout(() => {
 				chart.$.svg
-					.selectAll(`.${CLASS.legendItemHidden}`)
+					.selectAll(`.${$LEGEND.legendItemHidden}`)
 					.each(function() {
 						expect(+d3Select(this).style("opacity")).to.be.closeTo(0.15, 0.15);
 					});
@@ -95,7 +95,7 @@ describe("API show", () => {
 
 			setTimeout(() => {
 				expect(
-					chart.$.main.select(`.${CLASS.target}-data1`).style("display")
+					chart.$.main.select(`.${$COMMON.target}-data1`).style("display")
 				).to.be.equal("none");
 				done();
 			}, 500);
@@ -103,13 +103,13 @@ describe("API show", () => {
 
 		it("legend items should be hidden", () => {
 			const {legend} = chart.$;
-			const item = legend.select(`.${CLASS.legendItem}-data1`).style("opacity", 1);
+			const item = legend.select(`.${$LEGEND.legendItem}-data1`).style("opacity", 1);
 	
 			// when
 			chart.hide();
 
 			expect(item.style("opacity")).to.be.equal("0.15");
-			expect(item.classed(CLASS.legendItemHidden)).to.be.true;
+			expect(item.classed($LEGEND.legendItemHidden)).to.be.true;
 		})
 	});
 
@@ -122,12 +122,12 @@ describe("API show", () => {
 			chart.show("data1");
 
 			setTimeout(() => {
-				const selector = `.${CLASS.chartLine}.${CLASS.target}`;
+				const selector = `.${$LINE.chartLine}.${$COMMON.target}`;
 
 				expect(+main.select(`${selector}-data1`).style("opacity")).to.be.equal(1);
 				expect(+main.select(`${selector}-data2`).style("opacity")).to.be.equal(0);
 
-				expect(+internal.$el.svg.selectAll(`.${CLASS.legendItemHidden}`).size()).to.be.equal(1);
+				expect(+internal.$el.svg.selectAll(`.${$LEGEND.legendItemHidden}`).size()).to.be.equal(1);
 
 				done();
 			}, 500);
@@ -141,18 +141,18 @@ describe("API show", () => {
 			// hide all data
 			chart.hide();
 
-			legend = internal.$el.svg.selectAll(`.${CLASS.legendItemHidden}`);
+			legend = internal.$el.svg.selectAll(`.${$LEGEND.legendItemHidden}`);
 			expect(+legend.size()).to.be.equal(chart.data().length);
 
 			// show all data
 			chart.show();
 
 			setTimeout(() => {
-				main.selectAll(`.${CLASS.chartLine}`).each(function() {
+				main.selectAll(`.${$LINE.chartLine}`).each(function() {
 					expect(this.style.opacity).to.be.equal("");
 				});
 
-				legend = internal.$el.svg.selectAll(`.${CLASS.legendItemHidden}`);
+				legend = internal.$el.svg.selectAll(`.${$LEGEND.legendItemHidden}`);
 
 				expect(+legend.size()).to.be.equal(0);
 
@@ -175,15 +175,15 @@ describe("API show", () => {
 			chart.show(null, {withLegend: false});
 
 			setTimeout(() => {
-				main.selectAll(`.${CLASS.chartLine}`).each(function() {
+				main.selectAll(`.${$LINE.chartLine}`).each(function() {
 					expect(this.style.opacity).to.be.equal("");
 				});
 
-				const legend = internal.$el.svg.selectAll(`.${CLASS.legendItemHidden}`);
+				const legend = internal.$el.svg.selectAll(`.${$LEGEND.legendItemHidden}`);
 
 				expect(+legend.size()).to.be.equal(0);
 
-				internal.$el.svg.selectAll(`.${CLASS.legendItem}`).each(function() {
+				internal.$el.svg.selectAll(`.${$LEGEND.legendItem}`).each(function() {
 					expect(this.style.opacity).to.be.equal("");
 				});
 
@@ -202,11 +202,11 @@ describe("API show", () => {
 			chart.toggle();
 
 			setTimeout(() => {
-				main.selectAll(`.${CLASS.chartLine}`).each(function() {
+				main.selectAll(`.${$LINE.chartLine}`).each(function() {
 					expect(+this.style.opacity).to.be.below(1);
 				});
 
-				legend = internal.$el.svg.selectAll(`.${CLASS.legendItemHidden}`);
+				legend = internal.$el.svg.selectAll(`.${$LEGEND.legendItemHidden}`);
 
 				expect(+legend.size()).to.be.equal(chart.data().length);
 
@@ -219,11 +219,11 @@ describe("API show", () => {
 			}, 100);
 
 			setTimeout(() => {
-				main.selectAll(`.${CLASS.chartLine}`).each(function() {
+				main.selectAll(`.${$LINE.chartLine}`).each(function() {
 					expect(this.style.opacity).to.be.equal("");
 				});
 
-				legend = internal.$el.svg.selectAll(`.${CLASS.legendItemHidden}`);
+				legend = internal.$el.svg.selectAll(`.${$LEGEND.legendItemHidden}`);
 
 				expect(+legend.size()).to.be.equal(0);
 
@@ -268,12 +268,12 @@ describe("API show", () => {
 
 		it("should correctly rendered having same width", done => {
 			const main = chart.$.main;
-			const barWidth = Math.round(util.getBBox(main.select(`.${CLASS.bars}-${ids[0]}`)).width);
+			const barWidth = Math.round(util.getBBox(main.select(`.${$BAR.bars}-${ids[0]}`)).width);
 
 			chart.toggle(ids.concat().splice(1));
 
 			setTimeout(() => {
-				main.selectAll(`.${CLASS.bars}-${ids[0]}, .${CLASS.bars}-${ids[2]}`)
+				main.selectAll(`.${$BAR.bars}-${ids[0]}, .${$BAR.bars}-${ids[2]}`)
 					.each(function() {
 						expect(Math.round(util.getBBox(this).width)).to.be.equal(barWidth);
 					});

--- a/test/api/tooltip-spec.ts
+++ b/test/api/tooltip-spec.ts
@@ -6,7 +6,7 @@
 import {expect} from "chai";
 import {timeFormat as d3TimeFormat} from "d3-time-format";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$TOOLTIP} from "../../src/config/classes";
 import sinon from "sinon";
 
 describe("API tooltip", () => {
@@ -52,7 +52,7 @@ describe("API tooltip", () => {
 			// check if tooltip data are correctly rendered
 			chart.data().forEach(v => {
 				const id = v.id;
-				const data = tooltip.select(`.${CLASS.tooltipName}-${id}`);
+				const data = tooltip.select(`.${$TOOLTIP.tooltipName}-${id}`);
 				const value = chart.data(id)[0].values[x];
 
 				expect(id).to.be.equal(v.id);

--- a/test/api/x-spec.ts
+++ b/test/api/x-spec.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 import {expect} from "chai";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS} from "../../src/config/classes";
 
 describe("API x", () => {
 	let chart;
@@ -40,7 +40,7 @@ describe("API x", () => {
 			xValue = [2,5,8];
 			Object.keys(chart.x(xValue)).forEach(checkFn);
 
-			chart.$.main.selectAll(`.${CLASS.axisX} .tick tspan`).each(function(v, i) {
+			chart.$.main.selectAll(`.${$AXIS.axisX} .tick tspan`).each(function(v, i) {
 				expect(+this.textContent).to.be.equal(xValue[i]);
 			});
 		});
@@ -72,7 +72,7 @@ describe("API x", () => {
 			xValue = ["d", "e", "f"];
 			expect(chart.x(xValue)).to.be.deep.equal(xValue);
 
-			chart.$.main.selectAll(`.${CLASS.axisX} .tick tspan`).each(function(v, i) {
+			chart.$.main.selectAll(`.${$AXIS.axisX} .tick tspan`).each(function(v, i) {
 				expect(this.textContent).to.be.equal(xValue[i]);
 			});
 		});
@@ -118,7 +118,7 @@ describe("API x", () => {
 
 			xsValue = xsValue.data1.concat(xsValue.data2).sort();
 
-			chart.$.main.selectAll(`.${CLASS.axisX} .tick tspan`).each(function(v, i) {
+			chart.$.main.selectAll(`.${$AXIS.axisX} .tick tspan`).each(function(v, i) {
 				expect(+this.textContent).to.be.equal(xsValue[i]);
 			});
 		});

--- a/test/api/zoom-spec.ts
+++ b/test/api/zoom-spec.ts
@@ -7,7 +7,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import {parseDate} from "../../src/module/util";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $EVENT} from "../../src/config/classes";
 
 describe("API zoom", function() {
 	let chart;
@@ -216,7 +216,7 @@ describe("API zoom", function() {
 		});
 
 		it("should be zoomed properly", done => {
-			const rectlist = chart.$.main.selectAll(`.${CLASS.eventRect}`).nodes();
+			const rectlist = chart.$.main.selectAll(`.${$EVENT.eventRect}`).nodes();
 			const rect = [];
 
 			// when
@@ -305,11 +305,11 @@ describe("API zoom", function() {
 			// when disable zoom
 			chart.zoom.enable(false);
 
-			//const selector = `.${CLASS.eventRect}-1`;
+			//const selector = `.${$EVENT.eventRect}-1`;
 			const xValue = coords[1].x;
 			const tickTransform = [];
 
-			main.selectAll(`.${CLASS.axisX} .tick`).each(function() {
+			main.selectAll(`.${$AXIS.axisX} .tick`).each(function() {
 				tickTransform.push(this.getAttribute("transform"));
 			});
 
@@ -321,7 +321,7 @@ describe("API zoom", function() {
 			expect(coords[1].x).to.be.equal(xValue);
 
 			// check x Axis to not be zoomed
-			main.selectAll(`.${CLASS.axisX} .tick`).each(function(i) {
+			main.selectAll(`.${$AXIS.axisX} .tick`).each(function(i) {
 				expect(this.getAttribute("transform")).to.be.equal(tickTransform[i]);
 			});
 
@@ -355,7 +355,7 @@ describe("API zoom", function() {
 			expect(Math.round(zoomRange[0])).to.be.equal(range);
 
 			setTimeout(() => {
-				expect(+chart.$.main.select(`.${CLASS.axisX} .tick`).attr("transform").match(/\d+/)[0]).to.be.above(250);
+				expect(+chart.$.main.select(`.${$AXIS.axisX} .tick`).attr("transform").match(/\d+/)[0]).to.be.above(250);
 				done();
 			}, 300);
 		});
@@ -367,7 +367,7 @@ describe("API zoom", function() {
 			expect(Math.round(zoomRange[1])).to.be.equal(range);
 
 			setTimeout(() => {
-				const tick = chart.$.main.selectAll(`.${CLASS.axisX} .tick`);
+				const tick = chart.$.main.selectAll(`.${$AXIS.axisX} .tick`);
 
 				expect(+tick.filter(`:nth-child(${tick.size() + 1})`).attr("transform").match(/\d+/)[0]).to.be.below(500);
 				done();
@@ -385,7 +385,7 @@ describe("API zoom", function() {
 			let zoomRange = chart.zoom([-2, 1]);
 
 			expect(Math.round(zoomRange[0])).to.be.equal(range.min);
-			expect(+main.select(`.${CLASS.axisX} .tick`).attr("transform").match(/\d+/)[0]).to.be.above(350);
+			expect(+main.select(`.${$AXIS.axisX} .tick`).attr("transform").match(/\d+/)[0]).to.be.above(350);
 
 			// check the max range
 			zoomRange = chart.zoom([5, 7]);
@@ -393,7 +393,7 @@ describe("API zoom", function() {
 			expect(Math.round(zoomRange[1])).to.be.equal(range.max);
 
 			setTimeout(() => {
-				const tick = main.selectAll(`.${CLASS.axisX} .tick`);
+				const tick = main.selectAll(`.${$AXIS.axisX} .tick`);
 
 				expect(+tick.filter(`:nth-child(${tick.size() + 1})`).attr("transform").match(/\d+/)[0]).to.be.below(5);
 				done();

--- a/test/assets/config/classes.ts
+++ b/test/assets/config/classes.ts
@@ -3,6 +3,5 @@
  */
 /* eslint-disable */
 // @ts-nocheck
-import CLASS from "../../../src/config/classes";
-
-export default CLASS;
+export * from "../../../src/config/classes";
+export {default} from "../../../src/config/classes";

--- a/test/esm/esm-spec.ts
+++ b/test/esm/esm-spec.ts
@@ -6,7 +6,7 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import * as bb from "../../src/index.esm";
-import CLASS from "../../src/config/classes";
+import {$RADAR} from "../../src/config/classes";
 
 describe("ESM build", function() {
     let chart;
@@ -72,7 +72,7 @@ describe("ESM build", function() {
 
                     } else if (v === "radar") {
                         path = chart.$.main
-                            .select(`.${CLASS.chartRadar} polygon`)
+                            .select(`.${$RADAR.chartRadar} polygon`)
                             .attr("points");
                 
                     } else if (v === "scatter") {

--- a/test/esm/radar-spec.ts
+++ b/test/esm/radar-spec.ts
@@ -6,7 +6,7 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import bb, {radar} from "../../src/index.esm";
-import CLASS from "../../src/config/classes";
+import {$AXIS} from "../../src/config/classes";
 
 describe("ESM radar", function() {
     let chart;
@@ -45,7 +45,7 @@ describe("ESM radar", function() {
 
         expect(categories.length === args.data.columns[0].length - 1).to.be.true;
 
-        chart.$.main.selectAll(`.${CLASS.axis} text`).each(function(d, i) {
+        chart.$.main.selectAll(`.${$AXIS.axis} text`).each(function(d, i) {
             expect(this.textContent).to.be.equal(categories[i]);
         });
     });

--- a/test/esm/scatter-spec.ts
+++ b/test/esm/scatter-spec.ts
@@ -8,7 +8,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import bb, {scatter} from "../../src/index.esm";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$EVENT} from "../../src/config/classes";
 
 describe("ESM scatter", function() {
     let chart;
@@ -33,7 +33,7 @@ describe("ESM scatter", function() {
 	});
 
     it("check data.onclick for scatter type", () => {
-        const rect = chart.$.main.select(`rect.${CLASS.eventRect}`).node();
+        const rect = chart.$.main.select(`rect.${$EVENT.eventRect}`).node();
         const circle = chart.$.circles.nodes()[0];
         const pos = util.getBBox(circle);
 

--- a/test/interactions/drag-spec.ts
+++ b/test/interactions/drag-spec.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
-import CLASS from "../../src/config/classes";
+import {$DRAG, $SELECT} from "../../src/config/classes";
 import util from "../assets/util";
 
 describe("DRAG", function() {
@@ -57,8 +57,8 @@ describe("DRAG", function() {
 			internal.drag([186.5, 320.5]);
 
 			// circles are selected?
-			expect(main.selectAll(`.${CLASS.selectedCircles}`).size()).to.be.equal(2);
-			expect(main.selectAll(`.${CLASS.INCLUDED}`).size()).to.be.equal(3);
+			expect(main.selectAll(`.${$SELECT.selectedCircles}`).size()).to.be.equal(2);
+			expect(main.selectAll(`.${$DRAG.INCLUDED}`).size()).to.be.equal(3);
 		});
 
 		it("selected points should be unselected and drag area should be removed", done => {
@@ -69,10 +69,10 @@ describe("DRAG", function() {
 			internal.dragend();
 
 			setTimeout(() => {
-				expect(main.selectAll(`.${CLASS.INCLUDED}`).size()).to.be.equal(0);
+				expect(main.selectAll(`.${$DRAG.INCLUDED}`).size()).to.be.equal(0);
 
 				// check for selection rect
-				expect(main.select(`.${CLASS.dragarea}`).empty()).to.be.true;
+				expect(main.select(`.${$DRAG.dragarea}`).empty()).to.be.true;
 
 				// dragging flag to be set false
 				expect(internal.state.dragging).to.be.false;
@@ -112,7 +112,7 @@ describe("DRAG", function() {
 			});
 
 			setTimeout(() => {
-				const selectedCircle = $el.chart.selectAll(`.${CLASS.selectedCircles}`);
+				const selectedCircle = $el.chart.selectAll(`.${$SELECT.selectedCircles}`);
 
 				expect(selectedCircle.size()).to.be.equal(2);
 				done();

--- a/test/interactions/interaction-spec.ts
+++ b/test/interactions/interaction-spec.ts
@@ -8,7 +8,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$ARC, $AXIS, $BAR, $CIRCLE, $COMMON, $FOCUS, $EVENT, $SELECT, $SHAPE} from "../../src/config/classes";
 import bb from "../../src";
 
 describe("INTERACTION", () => {
@@ -64,7 +64,7 @@ describe("INTERACTION", () => {
 			});
 
 			it("should have 1 event rects properly", () => {
-				const eventRects = chart.$.main.selectAll(`.${CLASS.eventRect}`);
+				const eventRects = chart.$.main.selectAll(`.${$EVENT.eventRect}`);
 
 				expect(eventRects.size()).to.be.equal(1);
 
@@ -115,7 +115,7 @@ describe("INTERACTION", () => {
 			});
 
 			it("should have 1 event rects properly", () => {
-				const eventRects = chart.$.main.selectAll(`.${CLASS.eventRect}`);
+				const eventRects = chart.$.main.selectAll(`.${$EVENT.eventRect}`);
 
 				expect(eventRects.size()).to.be.equal(1);
 
@@ -207,7 +207,7 @@ describe("INTERACTION", () => {
 					expect(circles.size()).to.be.equal(dataLen);
 
 					circles.each(function(d, i) {
-						expect(this.classList.contains(`${CLASS.shape}-${i}`)).to.be.true;
+						expect(this.classList.contains(`${$SHAPE.shape}-${i}`)).to.be.true;
 						expect(d.index).to.be.equal(i);
 					});
 				});
@@ -254,12 +254,12 @@ describe("INTERACTION", () => {
 					expect(sampleCircle.size()).to.be.equal(dataLen);
 
 					sampleCircle.each(function(d, i) {
-						expect(this.classList.contains(`${CLASS.circle}-${i}`)).to.be.true;
+						expect(this.classList.contains(`${$CIRCLE.circle}-${i}`)).to.be.true;
 						expect(d.index).to.be.equal(i);
 					});
 
 					sample2Circle.each(function(d, i) {
-						expect(this.classList.contains(`${CLASS.circle}-${i}`)).to.be.true;
+						expect(this.classList.contains(`${$CIRCLE.circle}-${i}`)).to.be.true;
 						expect(d.index).to.be.equal(i);
 					});
 				});
@@ -281,7 +281,7 @@ describe("INTERACTION", () => {
 						expect(circles.size()).to.be.equal(dataLen);
 
 						circles.each(function(d, i) {
-							expect(this.classList.contains(`${CLASS.circle}-${i}`)).to.be.true;
+							expect(this.classList.contains(`${$CIRCLE.circle}-${i}`)).to.be.true;
 							expect(d.index).to.be.equal(i);
 						});
 
@@ -304,7 +304,7 @@ describe("INTERACTION", () => {
 				it("rect elements should be positioned without gaps", () => {
 					const rect = [];
 
-					chart.$.main.selectAll(`.${CLASS.eventRect}`).each(function(d, i) {
+					chart.$.main.selectAll(`.${$EVENT.eventRect}`).each(function(d, i) {
 						const x = +this.getAttribute("x");
 						const width = +this.getAttribute("width");
 
@@ -350,8 +350,8 @@ describe("INTERACTION", () => {
 							duration: 500,
 							done: function() {
 								const {coords, data} = chart.internal.state.eventReceiver;
-								const circlesData1 = chart.$.main.selectAll(`.${CLASS.circles}-data1 circle`);
-								const circlesData2 = chart.$.main.selectAll(`.${CLASS.circles}-data2 circle`);
+								const circlesData1 = chart.$.main.selectAll(`.${$CIRCLE.circles}-data1 circle`);
+								const circlesData2 = chart.$.main.selectAll(`.${$CIRCLE.circles}-data2 circle`);
 
 								data.forEach((d, i) => {
 									expect(d.index).to.be.equal(i);
@@ -363,7 +363,7 @@ describe("INTERACTION", () => {
 
 								[circlesData1, circlesData2].forEach(v => {
 									v.each(function(d, i) {
-										expect(this.classList.contains(`${CLASS.circle}-${i}`)).to.be.true;
+										expect(this.classList.contains(`${$CIRCLE.circle}-${i}`)).to.be.true;
 										expect(d.index).to.be.equal(i);
 									});
 								});
@@ -410,7 +410,7 @@ describe("INTERACTION", () => {
 					const index = 1;
 					const rect = chart.internal.$el.eventRect.node();
 					chart.internal.state.eventReceiver.coords[index];
-					//chart.$.main.select(`.${CLASS.eventRect}-${index}`).node();
+					//chart.$.main.select(`.${$EVENT.eventRect}-${index}`).node();
 
 					util.fireEvent(rect, "mousemove", {
 						clientX: 174,
@@ -515,7 +515,7 @@ describe("INTERACTION", () => {
 			it("check for data click for line", () => {
 				const main = chart.$.main;
 				const {eventRect} = chart.internal.$el;
-				const circle = util.getBBox(main.select(`.${CLASS.circles}-data1 circle`));
+				const circle = util.getBBox(main.select(`.${$CIRCLE.circles}-data1 circle`));
 
 				util.fireEvent(eventRect.node(), "click", {
 					clientX: circle.x,
@@ -534,8 +534,8 @@ describe("INTERACTION", () => {
 
 			it("check for data click for rectangle data point", () => {
 				const main = chart.$.main;
-				const rect = main.select(`.${CLASS.eventRect}.${CLASS.eventRect}`).node();
-				const circle = util.getBBox(main.select(`.${CLASS.circles}-data1 rect`));
+				const rect = main.select(`.${$EVENT.eventRect}.${$EVENT.eventRect}`).node();
+				const circle = util.getBBox(main.select(`.${$CIRCLE.circles}-data1 rect`));
 
 				util.fireEvent(rect, "click", {
 					clientX: circle.x,
@@ -557,8 +557,8 @@ describe("INTERACTION", () => {
 
 			it("check for data click for polygon data point", () => {
 				const main = chart.$.main;
-				const rect = main.select(`.${CLASS.eventRect}.${CLASS.eventRect}`).node();
-				const circle = util.getBBox(main.select(`.${CLASS.circles}-data2 use`));
+				const rect = main.select(`.${$EVENT.eventRect}.${$EVENT.eventRect}`).node();
+				const circle = util.getBBox(main.select(`.${$CIRCLE.circles}-data2 use`));
 
 				util.fireEvent(rect, "click", {
 					clientX: circle.x,
@@ -580,7 +580,7 @@ describe("INTERACTION", () => {
 			it("check for data click for area", () => {
 				const main = chart.$.main;
 				const {eventRect} = chart.internal.$el;
-				const circle = util.getBBox(main.select(`.${CLASS.circles}-data1 circle`));
+				const circle = util.getBBox(main.select(`.${$CIRCLE.circles}-data1 circle`));
 
 				util.fireEvent(eventRect.node(), "click", {
 					clientX: circle.x,
@@ -600,7 +600,7 @@ describe("INTERACTION", () => {
 			it("check for data click for scatter", () => {
 				const main = chart.$.main;
 				const {eventRect} = chart.internal.$el;
-				const circle = util.getBBox(main.select(`.${CLASS.circles}-data2 circle`));
+				const circle = util.getBBox(main.select(`.${$CIRCLE.circles}-data2 circle`));
 
 				util.fireEvent(eventRect.node(), "click", {
 					clientX: circle.x,
@@ -620,7 +620,7 @@ describe("INTERACTION", () => {
 			it("check for data click for bubble", () => {
 				const main = chart.$.main;
 				const {eventRect} = chart.internal.$el;
-				const circle = util.getBBox(main.select(`.${CLASS.circles}-data2 circle`));
+				const circle = util.getBBox(main.select(`.${$CIRCLE.circles}-data2 circle`));
 				const delta = 50;
 
 				util.fireEvent(eventRect.node(), "click", {
@@ -641,7 +641,7 @@ describe("INTERACTION", () => {
 			it("check for data click for bar", () => {
 				const main = chart.$.main;
 				const {eventRect} = chart.internal.$el;
-				const path = util.getBBox(main.select(`.${CLASS.bars}-data1 path`));
+				const path = util.getBBox(main.select(`.${$BAR.bars}-data1 path`));
 
 				util.fireEvent(eventRect.node(), "click", {
 					clientX: path.x,
@@ -660,7 +660,7 @@ describe("INTERACTION", () => {
 
 			it("check for data click for pie", () => {
 				const main = chart.$.main;
-				const path = main.select(`.${CLASS.arcs}-data1 path`).node();
+				const path = main.select(`.${$ARC.arcs}-data1 path`).node();
 				const box = path.getBBox();
 
 				util.fireEvent(path, "click", {
@@ -680,7 +680,7 @@ describe("INTERACTION", () => {
 
 			it("check for data click for gauge", () => {
 				const main = chart.$.main;
-				const path = main.select(`.${CLASS.arcs}-data1 path`).node();
+				const path = main.select(`.${$ARC.arcs}-data1 path`).node();
 				const box = path.getBBox();
 
 				util.fireEvent(path, "click", {
@@ -720,7 +720,7 @@ describe("INTERACTION", () => {
 			it("check for data click for multiple xs", () => {
 				const main = chart.$.main;
 				const {eventRect} = chart.internal.$el;
-				const circle = util.getBBox(main.select(`.${CLASS.circles}.${CLASS.circles}-data1 circle`));
+				const circle = util.getBBox(main.select(`.${$CIRCLE.circles}.${$CIRCLE.circles}-data1 circle`));
 
 				util.fireEvent(eventRect.node(), "click", {
 					clientX: circle.x,
@@ -846,7 +846,7 @@ describe("INTERACTION", () => {
 				expect(svg.on("mouseenter")).to.not.be.null;
 				expect(svg.on("mouseleave")).to.not.be.null;
 
-				main.selectAll(`.${CLASS.eventRect}`).each(function() {
+				main.selectAll(`.${$EVENT.eventRect}`).each(function() {
 					const el = d3Select(this);
 
 					expect(el.on("mouseenter")).to.not.be.null;
@@ -867,7 +867,7 @@ describe("INTERACTION", () => {
 				expect(svg.on("mouseenter")).to.be.undefined;
 				expect(svg.on("mouseleave")).to.be.undefined;
 
-				main.selectAll(`.${CLASS.eventRect}`).each(function() {
+				main.selectAll(`.${$EVENT.eventRect}`).each(function() {
 					const el = d3Select(this);
 
 					expect(el.on("mouseenter")).to.be.undefined;
@@ -895,7 +895,7 @@ describe("INTERACTION", () => {
 				expect(svg.on("mouseenter")).to.be.undefined;
 				expect(svg.on("mouseleave")).to.be.undefined;
 
-				main.selectAll(`.${CLASS.eventRect}`).each(function() {
+				main.selectAll(`.${$EVENT.eventRect}`).each(function() {
 					const el = d3Select(this);
 
 					expect(el.on("mouseenter")).to.be.undefined;
@@ -907,8 +907,8 @@ describe("INTERACTION", () => {
 			});
 
 			it("Focus grid line and event rect shouldn't be generated", () => {
-				expect(chart.$.grid.main.select(`.${CLASS.xgridFocus}`).empty()).to.be.true;
-				expect(chart.$.main.select(`.${CLASS.eventRects}`).empty()).to.be.true;
+				expect(chart.$.grid.main.select(`.${$FOCUS.xgridFocus}`).empty()).to.be.true;
+				expect(chart.$.main.select(`.${$EVENT.eventRects}`).empty()).to.be.true;
 			});
 
 			it("Event listener shouldn't be set for legend", () => {
@@ -932,7 +932,7 @@ describe("INTERACTION", () => {
 			});
 
 			it("data point circle should be selected and unselected", () => {
-				const circle: any = d3Select(`.${CLASS.shape}-2`).node();
+				const circle: any = d3Select(`.${$SHAPE.shape}-2`).node();
 				const {eventRect} = chart.internal.$el;
 
 				const box = circle.getBBox();
@@ -943,13 +943,13 @@ describe("INTERACTION", () => {
 					clientX, clientY
 				}, chart);
 
-				expect(d3Select(circle).classed(CLASS.SELECTED)).to.be.true;
+				expect(d3Select(circle).classed($SELECT.SELECTED)).to.be.true;
 
 				util.fireEvent(eventRect.node(), "click", {
 					clientX, clientY
 				}, chart);
 
-				expect(d3Select(circle).classed(CLASS.SELECTED)).to.be.false;
+				expect(d3Select(circle).classed($SELECT.SELECTED)).to.be.false;
 			});
 		});
 
@@ -1067,7 +1067,7 @@ describe("INTERACTION", () => {
 				chart.tooltip.hide();
 
 				setTimeout(() => {
-					const points = chart.$.circles.filter(`.${CLASS.circle}-${x}`);
+					const points = chart.$.circles.filter(`.${$CIRCLE.circle}-${x}`);
 
 					expect(+points.attr("r")).to.be.equal(chart.config("point.r"));
 					done();
@@ -1110,7 +1110,7 @@ describe("INTERACTION", () => {
 				setTimeout(resolve, 300);
 			}).then(() => {
 				setTimeout(() => {
-					const xGridFocus = chart.$.main.select(`.${CLASS.xgridFocus} line`);
+					const xGridFocus = chart.$.main.select(`.${$FOCUS.xgridFocus} line`);
 					const x = chart.internal.xx(xGridFocus.datum());
 	
 					expect(x).to.be.equal(+xGridFocus.attr("x1"));
@@ -1212,18 +1212,18 @@ describe("INTERACTION", () => {
 		it("should be called callbacks for mouse events", () => {
 			const index = 2;
 			const main = chart.$.main;
-			const text = main.select(`.${CLASS.axis}-${index} text`).node();
+			const text = main.select(`.${$AXIS.axis}-${index} text`).node();
 
 			util.fireEvent(text, "mouseover");
 			expect(spy1.calledTwice).to.be.true;
 
-			main.selectAll(`.${CLASS.EXPANDED}`).each(d => {
+			main.selectAll(`.${$COMMON.EXPANDED}`).each(d => {
 				expect(d.index).to.be.equal(index);
 			});
 
 			util.fireEvent(text, "mouseout");
 			expect(spy2.calledTwice).to.be.true;
-			expect(main.selectAll(`.${CLASS.EXPANDED}`).size()).to.be.equal(0);
+			expect(main.selectAll(`.${$COMMON.EXPANDED}`).size()).to.be.equal(0);
 		});
 	});
 

--- a/test/interactions/subchart-spec.ts
+++ b/test/interactions/subchart-spec.ts
@@ -6,7 +6,7 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AREA, $AXIS, $BAR, $FOCUS, $LINE, $SUBCHART} from "../../src/config/classes";
 
 describe("SUBCHART", () => {
 	let chart;
@@ -61,9 +61,9 @@ describe("SUBCHART", () => {
 
 			expect(children.length).to.be.equal(3);
 
-			expect(children[0].querySelectorAll(`.${CLASS.chartBars}, .${CLASS.chartLines}`).length).to.be.equal(2);
-			expect(children[1].classList.contains(CLASS.brush)).to.be.true;
-			expect(children[2].classList.contains(CLASS.axisX)).to.be.true;
+			expect(children[0].querySelectorAll(`.${$BAR.chartBars}, .${$LINE.chartLines}`).length).to.be.equal(2);
+			expect(children[1].classList.contains($SUBCHART.brush)).to.be.true;
+			expect(children[2].classList.contains($AXIS.axisX)).to.be.true;
 		});
 
 		it("set options subchart.size={height:80}", () => {
@@ -77,7 +77,7 @@ describe("SUBCHART", () => {
 		});
 
 		it("should generate tick nodes", () => {
-			const axis = chart.$.svg.selectAll(`.${CLASS.axisX}`).nodes()[1];
+			const axis = chart.$.svg.selectAll(`.${$AXIS.axisX}`).nodes()[1];
 
 			expect(axis.querySelectorAll(".tick").length).to.be.equal(3);
 			expect(axis.querySelectorAll(".tick line").length).to.be.equal(3);
@@ -89,7 +89,7 @@ describe("SUBCHART", () => {
 		});
 
 		it("shouldn't be generating tick lines", () => {
-			const axis = chart.$.svg.selectAll(`.${CLASS.axisX}`).nodes()[1];
+			const axis = chart.$.svg.selectAll(`.${$AXIS.axisX}`).nodes()[1];
 
 			expect(axis.querySelectorAll(".tick line").length).to.be.equal(0);
 		});
@@ -100,7 +100,7 @@ describe("SUBCHART", () => {
 		});
 
 		it("shouldn't be generating tick text", () => {
-			const axis = chart.$.svg.selectAll(`.${CLASS.axisX}`).nodes()[1];
+			const axis = chart.$.svg.selectAll(`.${$AXIS.axisX}`).nodes()[1];
 
 			expect(axis.querySelectorAll(".tick line").length).to.be.equal(3);
 			expect(axis.querySelectorAll(".tick text").length).to.be.equal(0);
@@ -114,7 +114,7 @@ describe("SUBCHART", () => {
 			const subchart = chart.$.svg.selectAll("[clip-path]").filter(function() {
 				return /subchart/.test(this.getAttribute("clip-path"))
 			}).node().parentNode;
-			const axis = subchart.querySelector(`.${CLASS.axisX}`).children;
+			const axis = subchart.querySelector(`.${$AXIS.axisX}`).children;
 
 			expect(axis.length).to.be.equal(1);
 			expect(axis[0].classList.contains("domain")).to.be.true;
@@ -357,14 +357,14 @@ describe("SUBCHART", () => {
 		};
 
 		it("check for area-spline", () => {
-			checkPath(`.${CLASS.line} path`, [
+			checkPath(`.${$LINE.line} path`, [
 				'M6,56.448321599836746C6,56.448321599836746,201.16666666666669,55.645682413359175,299,55.244362820120394C396.8333333333333,54.84304322688161,593,54.04040404040404,593,54.04040404040404',
 				'M6,52.896643199673505C6,52.896643199673505,201.16666666666669,51.291364826718365,299,50.488725640240794C396.8333333333333,49.686086453763224,593,48.08080808080808,593,48.08080808080808',
 				'M6,42.241607999183756C6,42.241607999183756,201.16666666666669,38.2284120667959,299,36.221814100601975C396.8333333333333,34.21521613440805,593,30.202020202020208,593,30.202020202020208',
 				'M6,28.03489439853076C6,28.03489439853076,201.16666666666669,20.81114172023262,299,17.199265381083556C396.8333333333333,13.587389041934493,593,6.363636363636374,593,6.363636363636374'
 			]);
 
-			checkPath(`.${CLASS.area} path`, [
+			checkPath(`.${$AREA.area} path`, [
 				'M6,56.448321599836746C6,56.448321599836746,201.16666666666669,55.645682413359175,299,55.244362820120394C396.8333333333333,54.84304322688161,593,54.04040404040404,593,54.04040404040404L593,60C593,60,396.8333333333333,60,299,60C201.16666666666669,60,6,60,6,60Z',
 				'M6,52.896643199673505C6,52.896643199673505,201.16666666666669,51.291364826718365,299,50.488725640240794C396.8333333333333,49.686086453763224,593,48.08080808080808,593,48.08080808080808L593,60C593,60,396.8333333333333,60,299,60C201.16666666666669,60,6,60,6,60Z',
 				'M6,42.241607999183756C6,42.241607999183756,201.16666666666669,38.2284120667959,299,36.221814100601975C396.8333333333333,34.21521613440805,593,30.202020202020208,593,30.202020202020208L593,48.08080808080808C593,48.08080808080808,396.8333333333333,49.686086453763224,299,50.488725640240794C201.16666666666669,51.291364826718365,6,52.896643199673505,6,52.896643199673505Z',
@@ -377,14 +377,14 @@ describe("SUBCHART", () => {
 		});
 
 		it("check for area-step type", () => {
-			checkPath(`.${CLASS.line} path`, [
+			checkPath(`.${$LINE.line} path`, [
 				'M6,56.448321599836746L152.5,56.448321599836746L152.5,55.244362820120394L446,55.244362820120394L446,54.04040404040404L593,54.04040404040404',
 				'M6,52.896643199673505L152.5,52.896643199673505L152.5,50.488725640240794L446,50.488725640240794L446,48.08080808080808L593,48.08080808080808',
 				'M6,42.241607999183756L152.5,42.241607999183756L152.5,36.221814100601975L446,36.221814100601975L446,30.202020202020208L593,30.202020202020208',
 				'M6,28.03489439853076L152.5,28.03489439853076L152.5,17.199265381083556L446,17.199265381083556L446,6.363636363636374L593,6.363636363636374'
 			]);
 
-			checkPath(`.${CLASS.area} path`, [
+			checkPath(`.${$AREA.area} path`, [
 				'M6,56.448321599836746L152.5,56.448321599836746L152.5,55.244362820120394L446,55.244362820120394L446,54.04040404040404L593,54.04040404040404L593,60L446,60L446,60L152.5,60L152.5,60L6,60Z',
 				'M6,52.896643199673505L152.5,52.896643199673505L152.5,50.488725640240794L446,50.488725640240794L446,48.08080808080808L593,48.08080808080808L593,60L446,60L446,60L152.5,60L152.5,60L6,60Z',
 				'M6,42.241607999183756L152.5,42.241607999183756L152.5,36.221814100601975L446,36.221814100601975L446,30.202020202020208L593,30.202020202020208L593,48.08080808080808L446,48.08080808080808L446,50.488725640240794L152.5,50.488725640240794L152.5,52.896643199673505L6,52.896643199673505Z',
@@ -397,7 +397,7 @@ describe("SUBCHART", () => {
 		});
 
 		it("check for bar type", () => {
-			checkPath(`.${CLASS.bar} path`, [
+			checkPath(`.${$BAR.bar} path`, [
 				"M39.96666666666666,60V56.448321599836746 H99.66666666666666 V60z",
 				"M239.3,60V55.244362820120394 H299 V60z",
 				"M438.6333333333334,60V54.04040404040404 H498.33333333333337 V60z",
@@ -419,7 +419,7 @@ describe("SUBCHART", () => {
 		});
 
 		it("check for non-grouped line type", () => {
-			checkPath(`.${CLASS.line} path`, [
+			checkPath(`.${$LINE.line} path`, [
 				'M6,55.083333333333336L299,52.16543026706231L593,49.24752720079129',
 				'M6,46.47551928783382L299,40.63971315529179L593,34.80390702274976',
 				'M6,37.867705242334324L299,29.11399604352127L593,20.36028684470821',
@@ -462,12 +462,12 @@ describe("SUBCHART", () => {
 		});
 
 		it("check for area-line-range type", () => {
-			checkPath(`.${CLASS.line} path`, [
+			checkPath(`.${$LINE.line} path`, [
 				'M6,44.981818181818184L124,46.054545454545455L241,45.518181818181816L358,47.12727272727273L475,43.909090909090914L593,42.836363636363636',
 				'M6,46.054545454545455L124,23.527272727272727L241,38.54545454545455L358,6.363636363636366L475,33.18181818181818L593,22.454545454545457'
 			]);
 
-			checkPath(`.${CLASS.area} path`, [
+			checkPath(`.${$AREA.area} path`, [
 				'M6,48.2L124,47.663636363636364L241,47.12727272727273L358,48.2L475,46.054545454545455L593,46.590909090909086L593,38.65272727272727L475,40.690909090909095L358,45.518181818181816L241,42.836363636363636L124,43.372727272727275L6,43.909090909090914Z',
 				'M 6 256.81818181818187'
 			]);
@@ -513,7 +513,7 @@ describe("SUBCHART", () => {
 			expect(selection.attr("height")).to.be.null;
 
 			expect(tooltip.style("display")).to.be.equal("none");
-			expect(main.selectAll(`line.${CLASS.xgridFocus}`).style("visibility")).to.be.equal("hidden");
+			expect(main.selectAll(`line.${$FOCUS.xgridFocus}`).style("visibility")).to.be.equal("hidden");
 		});
 	});
 
@@ -579,7 +579,7 @@ describe("SUBCHART", () => {
 				],
 				done: function() {
 					expect(
-						this.internal.$el.subchart.main.selectAll(`.${CLASS.line}-data1`).size()
+						this.internal.$el.subchart.main.selectAll(`.${$LINE.line}-data1`).size()
 					).to.be.equal(1);
 				}
 			});
@@ -596,11 +596,11 @@ describe("SUBCHART", () => {
 					const {main} = this.internal.$el.subchart;
 
 					expect(
-						main.selectAll(`.${CLASS.line}-data1`).empty()
+						main.selectAll(`.${$LINE.line}-data1`).empty()
 					).to.be.true;
 
 					expect(
-						main.selectAll(`.${CLASS.line}-data2`).size()
+						main.selectAll(`.${$LINE.line}-data2`).size()
 					).to.be.equal(1);
 				}
 			});

--- a/test/interactions/zoom-spec.ts
+++ b/test/interactions/zoom-spec.ts
@@ -6,7 +6,7 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import sinon from "sinon";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $EVENT, $GRID, $REGION, $ZOOM} from "../../src/config/classes";
 import util from "../assets/util";
 
 describe("ZOOM", function() {
@@ -183,7 +183,7 @@ describe("ZOOM", function() {
 			const main = chart.$.main;
 			const rx = /H(\d+)/;
 
-			const domain = main.select(`.${CLASS.axisX} > .domain`);
+			const domain = main.select(`.${$AXIS.axisX} > .domain`);
 			const pathValue = +domain.attr("d").match(rx)[1];
 
 			chart.zoom([0,4]);
@@ -196,7 +196,7 @@ describe("ZOOM", function() {
 			const main = chart.$.main;
 			const rx = /H(\d+)/;
 
-			const domain = main.select(`.${CLASS.axisX} > .domain`);
+			const domain = main.select(`.${$AXIS.axisX} > .domain`);
 			const pathValue = +domain.attr("d").match(rx)[1];
 
 			chart.zoom([0,4]);  // zoom in
@@ -330,7 +330,7 @@ describe("ZOOM", function() {
 				y: chart.internal.scale.y.domain()
 			};
 			const eventRect = chart.internal.$el.eventRect.node();
-			const xGridLine = chart.$.main.select(`.${CLASS.xgridLine} line`);
+			const xGridLine = chart.$.main.select(`.${$GRID.xgridLine} line`);
 			const xPos = {x1: +xGridLine.attr("x1"), x2: +xGridLine.attr("x2")};
 
 			// when zoom in
@@ -382,9 +382,9 @@ describe("ZOOM", function() {
 
 			setTimeout(() => {
 				expect(
-					getX(`.${CLASS.xgrids} line:nth-child(2)`)
+					getX(`.${$GRID.xgrids} line:nth-child(2)`)
 				).to.be.equal(
-					getX(`.${CLASS.axisX} g.tick:nth-child(5) line`)
+					getX(`.${$AXIS.axisX} g.tick:nth-child(5) line`)
 				);
 
 				done();
@@ -477,7 +477,7 @@ describe("ZOOM", function() {
 			const main = chart.$.main;
 			const rx = /H(\d+)/;
 
-			const domain = main.select(`.${CLASS.axisX} > .domain`);
+			const domain = main.select(`.${$AXIS.axisX} > .domain`);
 			const pathValue = +domain.attr("d").match(rx)[1];
 
 			chart.zoom([0, 4]);
@@ -490,7 +490,7 @@ describe("ZOOM", function() {
 			const main = chart.$.main;
 			const rx = /H(\d+)/;
 
-			const domain = main.select(`.${CLASS.axisX} > .domain`);
+			const domain = main.select(`.${$AXIS.axisX} > .domain`);
 			const pathValue = +domain.attr("d").match(rx)[1];
 
 			chart.zoom([0, 4]);  // zoom in
@@ -509,7 +509,7 @@ describe("ZOOM", function() {
 			// when
 			chart.zoom([0, 4]);
 
-			const resetBtn = chart.$.chart.select(`.${CLASS.buttonZoomReset}`);
+			const resetBtn = chart.$.chart.select(`.${$ZOOM.buttonZoomReset}`);
 
 			expect(resetBtn.empty()).to.be.false;
 
@@ -529,7 +529,7 @@ describe("ZOOM", function() {
 			// when
 			chart.zoom([0, 4]);
 
-			const resetBtn = chart.$.chart.select(`.${CLASS.buttonZoomReset}`);
+			const resetBtn = chart.$.chart.select(`.${$ZOOM.buttonZoomReset}`);
 
 			expect(resetBtn.empty()).to.be.false;
 			expect(resetBtn.text()).to.be.equal("test");
@@ -543,7 +543,7 @@ describe("ZOOM", function() {
 			// when
 			chart.zoom([0, 4]);
 
-			const resetBtn = chart.$.chart.select(`.${CLASS.buttonZoomReset}`).node();
+			const resetBtn = chart.$.chart.select(`.${$ZOOM.buttonZoomReset}`).node();
 
 			util.fireEvent(resetBtn, "click", {
 				clientX: 0,
@@ -559,7 +559,7 @@ describe("ZOOM", function() {
 		});
 
 		it("check for the y axis rescale", () => {
-			const axisY = chart.$.main.select(`.${CLASS.axisY}`);
+			const axisY = chart.$.main.select(`.${$AXIS.axisY}`);
 
 			// when
 			chart.zoom([0, 2]);
@@ -636,7 +636,7 @@ describe("ZOOM", function() {
 
 		it("region area should be resized on zoom", done => {
 			const main = chart.$.main;
-			const regionRect = main.select(`.${CLASS.region}-0 rect`);
+			const regionRect = main.select(`.${$REGION.region}-0 rect`);
 			const lineWidth = util.getBBox(chart.$.line.lines).width;
 
 			const size = {
@@ -683,7 +683,7 @@ describe("ZOOM", function() {
 			// when
 			chart.zoom(zoomDomain);
 
-			const eventRect = main.select(`.${CLASS.eventRect}-2`).node();
+			const eventRect = main.select(`.${$EVENT.eventRect}-2`).node();
 			const zoomedDomain = internal.zoom.getDomain().map(Math.round);
 
 			expect(zoomedDomain).to.be.deep.equal(zoomDomain);
@@ -779,7 +779,7 @@ describe("ZOOM", function() {
 		});
 
 		it("check zoom-in tick format for timeseries", () => {
-			const selector = `.${CLASS.axisX} .tick text`;
+			const selector = `.${$AXIS.axisX} .tick text`;
 
 			chart.$.main.selectAll(selector).each(function(d, i) {
 				expect(+this.textContent).to.be.equal(2015 + i);
@@ -835,8 +835,8 @@ describe("ZOOM", function() {
 					clientY: 100
 				}, chart);
 
-				brush = main.select(`.${CLASS.zoomBrush}`);
-				yAxisTickText = +chart.$.main.selectAll(`.${CLASS.axisY} .tick tspan`).nodes().pop().textContent;
+				brush = main.select(`.${$ZOOM.zoomBrush}`);
+				yAxisTickText = +chart.$.main.selectAll(`.${$AXIS.axisY} .tick tspan`).nodes().pop().textContent;
 
 				size.w = +brush.attr("width");
 				size.h = +brush.attr("height");
@@ -865,7 +865,7 @@ describe("ZOOM", function() {
 					}, chart);
 
 					// y axis rescaled?
-					const tickText = +main.selectAll(`.${CLASS.axisY} .tick tspan`).nodes().pop().textContent;
+					const tickText = +main.selectAll(`.${$AXIS.axisY} .tick tspan`).nodes().pop().textContent;
 
 					expect(tickText).to.be.below(yAxisTickText);
 					expect(tickText).to.be.equal(400);
@@ -974,7 +974,7 @@ describe("ZOOM", function() {
 
 		it("check on wheel zooming", () => {
 			const internal = chart.internal;
-			const eventRect = chart.$.main.select(`.${CLASS.eventRect}`).node();
+			const eventRect = chart.$.main.select(`.${$EVENT.eventRect}`).node();
 			const value = args.data.columns[0][2];
 
 			// when zoom in
@@ -1061,7 +1061,7 @@ describe("ZOOM", function() {
 		it("check y Axis culling after zoom", () => {
 			chart.zoom([4,5]);
 
-			const tickTexts = chart.$.main.selectAll(`.${CLASS.axisY} .tick text`)
+			const tickTexts = chart.$.main.selectAll(`.${$AXIS.axisY} .tick text`)
 				.filter(function() { return this.style.display === ""});
 
 			expect(tickTexts.size()).to.be.equal(args.axis.y.tick.culling.max);

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -10,9 +10,8 @@ import {timeMinute as d3TimeMinute} from "d3-time";
 import util from "../assets/util";
 import {getBoundingRect} from "../../src/module/util";
 import bb from "../../src";
-import CLASS from "../../src/config/classes";
+import {$AXIS} from "../../src/config/classes";
 import AxisRendererHelper from "../../src/ChartInternal/Axis/AxisRendererHelper";
-import { stratify } from "d3";
 //import getSizeFor1Char from "exports-loader?getSizeFor1Char!../../src/axis/bb.axis";
 
 describe("AXIS", function() {
@@ -62,7 +61,7 @@ describe("AXIS", function() {
 		});
 
 		it("should have only 3 tick on x axis", () => {
-			const ticks = chart.$.main.select(`.${CLASS.axisX}`).selectAll("g.tick");
+			const ticks = chart.$.main.select(`.${$AXIS.axisX}`).selectAll("g.tick");
 
 			expect(ticks.size()).to.be.equal(3);
 			expect(ticks.data()).to.be.deep.equal([0,3,5]);
@@ -71,7 +70,7 @@ describe("AXIS", function() {
 		it("x Axis ticks should be positioned correctly", () => {
 			const expectedXPos = [50, 349, 549];
 
-			chart.$.main.selectAll(`.${CLASS.axisX} .tick`).each(function(d, i) {
+			chart.$.main.selectAll(`.${$AXIS.axisX} .tick`).each(function(d, i) {
 				expect(
 					util.parseNum(this.getAttribute("transform").split(",")[0])
 				).to.be.equal(expectedXPos[i]);
@@ -96,7 +95,7 @@ describe("AXIS", function() {
 		});
 
 		it("should have only 1 tick on y axis", () => {
-			const ticksSize = chart.$.main.select(`.${CLASS.axisY}`).selectAll("g.tick").size();
+			const ticksSize = chart.$.main.select(`.${$AXIS.axisY}`).selectAll("g.tick").size();
 
 			expect(ticksSize).to.be.equal(1);
 		});
@@ -106,7 +105,7 @@ describe("AXIS", function() {
 		});
 
 		it("should have 2 ticks on y axis", () => {
-			const ticksSize = chart.$.main.select(`.${CLASS.axisY}`)
+			const ticksSize = chart.$.main.select(`.${$AXIS.axisY}`)
 				.selectAll("g.tick").size();
 
 			expect(ticksSize).to.be.equal(2);
@@ -117,7 +116,7 @@ describe("AXIS", function() {
 		});
 
 		it("should have 3 ticks on y axis", () => {
-			const ticksSize = chart.$.main.select(`.${CLASS.axisY}`)
+			const ticksSize = chart.$.main.select(`.${$AXIS.axisY}`)
 				.selectAll("g.tick").size();
 
 			expect(ticksSize).to.be.equal(3);
@@ -139,14 +138,14 @@ describe("AXIS", function() {
 		});
 
 		it("should have only 2 tick on y axis", () => {
-			const ticksSize = chart.$.main.select(`.${CLASS.axisY}`)
+			const ticksSize = chart.$.main.select(`.${$AXIS.axisY}`)
 				.selectAll("g.tick").size();
 
 			expect(ticksSize).to.be.equal(2);
 		});
 
 		it("should have specified tick texts", () => {
-			chart.$.main.select(`.${CLASS.axisY}`).selectAll("g.tick").each(function(d, i) {
+			chart.$.main.select(`.${$AXIS.axisY}`).selectAll("g.tick").each(function(d, i) {
 				const text = d3Select(this)
 					.select("text").text();
 
@@ -175,7 +174,7 @@ describe("AXIS", function() {
 
 		it("tick values should be shown correctly", () => {
 			chart.$.main
-				.select(`.${CLASS.axisY}`)
+				.select(`.${$AXIS.axisY}`)
 				.selectAll("g.tick").each((v, i) => {
 				i > 0 && expect(v > 0).to.be.true;
 			});
@@ -318,7 +317,7 @@ describe("AXIS", function() {
 
  		const checkAnchor = value => {
 			["x", "y", "y2"].forEach(v => {
-				const anchor = chart.$.main.select(`.${CLASS[`axis${v.toUpperCase()}Label`]}`);
+				const anchor = chart.$.main.select(`.${$AXIS[`axis${v.toUpperCase()}Label`]}`);
 
  				expect(anchor.style("text-anchor")).to.be.equal(value);
 			});
@@ -399,7 +398,7 @@ describe("AXIS", function() {
 		});
 
 		const getRect = id => {
-			const axis = chart.$.main.select(`.${CLASS[`axis${id.toUpperCase()}`]}`);
+			const axis = chart.$.main.select(`.${$AXIS[`axis${id.toUpperCase()}`]}`);
 			const tick = axis.select(".tick").node().getBoundingClientRect();
 			const label = axis.select("text").node().getBoundingClientRect();
 			
@@ -478,7 +477,7 @@ describe("AXIS", function() {
 		});
 
 		it("should have 7 ticks on y axis", () => {
-			const ticksSize = chart.$.main.select(`.${CLASS.axisY}`)
+			const ticksSize = chart.$.main.select(`.${$AXIS.axisY}`)
 				.selectAll("g.tick").size();
 
 			// the count starts at initial value and increments by the set interval
@@ -488,7 +487,7 @@ describe("AXIS", function() {
 		it("should have specified 30 second intervals", () => {
 			let prevValue;
 
-			chart.$.main.select(`.${CLASS.axisY}`)
+			chart.$.main.select(`.${$AXIS.axisY}`)
 				.selectAll("g.tick")
 				.each((d, i) => {
 					if (i !== 0) {
@@ -510,7 +509,7 @@ describe("AXIS", function() {
 		it("should have specified 60 second intervals", () => {
 			let prevValue;
 
-			chart.$.main.select(`.${CLASS.axisY}`).selectAll("g.tick").each((d, i) => {
+			chart.$.main.select(`.${$AXIS.axisY}`).selectAll("g.tick").each((d, i) => {
 				if (i !== 0) {
 					let result = d - prevValue;
 
@@ -547,7 +546,7 @@ describe("AXIS", function() {
 			});
 
 			it("should use 'function' to generate ticks", () => {
-				chart.$.main.select(`.${CLASS.axisX}`)
+				chart.$.main.select(`.${$AXIS.axisX}`)
 					.selectAll("g.tick")
 					.each(function(d, i) {
 						const tick = d3Select(this).select("text").text();
@@ -581,7 +580,7 @@ describe("AXIS", function() {
 				});
 
 				it("should construct indexed x axis properly", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisX}`).selectAll("g.tick");
+					const ticks = chart.$.main.select(`.${$AXIS.axisX}`).selectAll("g.tick");
 					const expectedX = "0";
 					const expectedDy = ".71em";
 
@@ -611,7 +610,7 @@ describe("AXIS", function() {
 				});
 
 				it("should split x axis tick text to multiple lines", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisX}`).selectAll("g.tick");
+					const ticks = chart.$.main.select(`.${$AXIS.axisX}`).selectAll("g.tick");
 					const expectedTexts = ["very long tick", "text on x axis"];
 					const expectedX = "0";
 
@@ -638,7 +637,7 @@ describe("AXIS", function() {
 				});
 
 				it("should construct y axis properly", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisY}`).selectAll("g.tick");
+					const ticks = chart.$.main.select(`.${$AXIS.axisY}`).selectAll("g.tick");
 					const expectedX = "-9";
 					const expectedDy = "3";
 
@@ -660,7 +659,7 @@ describe("AXIS", function() {
 				});
 
 				it("should construct y2 axis properly", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisY2}`).selectAll("g.tick");
+					const ticks = chart.$.main.select(`.${$AXIS.axisY2}`).selectAll("g.tick");
 					const expectedX = "9";
 					const expectedDy = "3";
 
@@ -689,7 +688,7 @@ describe("AXIS", function() {
 				});
 
 				it("should not split y axis tick text to multiple lines", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisY2}`)
+					const ticks = chart.$.main.select(`.${$AXIS.axisY2}`)
 						.selectAll("g.tick");
 
 					ticks.each(function() {
@@ -707,7 +706,7 @@ describe("AXIS", function() {
 				});
 
 				it("should split x axis tick text to multiple lines", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisX}`).selectAll("g.tick");
+					const ticks = chart.$.main.select(`.${$AXIS.axisX}`).selectAll("g.tick");
 					const expectedTexts = ["very long tick", "text on x axis"];
 					const expectedX = "-9";
 
@@ -734,7 +733,7 @@ describe("AXIS", function() {
 				});
 
 				it("should not split y axis tick text to multiple lines", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisY}`).selectAll("g.tick");
+					const ticks = chart.$.main.select(`.${$AXIS.axisY}`).selectAll("g.tick");
 					const expectedTexts = [
 						"0",
 						"500000000000000",
@@ -791,7 +790,7 @@ describe("AXIS", function() {
 				});
 
 				it("should locate ticks properly", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisX}`)
+					const ticks = chart.$.main.select(`.${$AXIS.axisX}`)
 						.selectAll("g.tick");
 
 					ticks.each(function(d, i) {
@@ -813,7 +812,7 @@ describe("AXIS", function() {
 				});
 
 				it("should split tick text properly", () => {
-					const tick = chart.$.main.select(`.${CLASS.axisX}`).select("g.tick");
+					const tick = chart.$.main.select(`.${$AXIS.axisX}`).select("g.tick");
 					const tspans = tick.selectAll("tspan");
 					const expectedTickTexts = [
 							"this is a very",
@@ -841,7 +840,7 @@ describe("AXIS", function() {
 				});
 
 				it("should set tooltip", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisX}`)
+					const ticks = chart.$.main.select(`.${$AXIS.axisX}`)
 						.selectAll("g.tick");
 					const categories = chart.categories();
 
@@ -859,7 +858,7 @@ describe("AXIS", function() {
 							["data1", 130, 120, 150, 140]							
 						],
 						done: function() {
-							chart.$.main.selectAll(`.${CLASS.axisX} .tick text`).each(function() { 
+							chart.$.main.selectAll(`.${$AXIS.axisX} .tick text`).each(function() { 
 								expect(d3Select(this).selectAll("title").size()).to.be.equal(1);
 							});
 
@@ -875,7 +874,7 @@ describe("AXIS", function() {
 				});
 
 				it("should locate ticks on rotated axis properly", () => {
-					const ticks = chart.$.main.select(`.${CLASS.axisX}`).selectAll("g.tick");
+					const ticks = chart.$.main.select(`.${$AXIS.axisX}`).selectAll("g.tick");
 
 					ticks.each(function(d, i) {
 						const texts = d3Select(this).selectAll("text");
@@ -907,7 +906,7 @@ describe("AXIS", function() {
 				});
 
 				it("should split tick text on rotated axis properly", () => {
-					const tick = chart.$.main.select(`.${CLASS.axisX}`).select("g.tick");
+					const tick = chart.$.main.select(`.${$AXIS.axisX}`).select("g.tick");
 					const tspans = tick.selectAll("tspan");
 					const expectedTickTexts = [
 							"this is a very",
@@ -939,7 +938,7 @@ describe("AXIS", function() {
 				});
 
 				it("should locate tick texts on rotated axis properly", () => {
-					const ticksText = chart.$.main.select(`.${CLASS.axisX}`).selectAll("g.tick text");
+					const ticksText = chart.$.main.select(`.${$AXIS.axisX}`).selectAll("g.tick text");
 
 					ticksText.each(function() {
 						expect(+this.getAttribute("y")).to.be.equal(37);
@@ -956,7 +955,7 @@ describe("AXIS", function() {
 					});
 
 					it("should split x tick", () => {
-						const tick = chart.$.main.select(`.${CLASS.axisX}`).select("g.tick");
+						const tick = chart.$.main.select(`.${$AXIS.axisX}`).select("g.tick");
 						const tspans = tick.selectAll("tspan");
 
 						expect(tspans.size()).to.be.equal(1);
@@ -972,7 +971,7 @@ describe("AXIS", function() {
 					});
 
 					it("should split x tick to 2 lines properly", () => {
-						const tick = chart.$.main.select(`.${CLASS.axisX}`).select("g.tick");
+						const tick = chart.$.main.select(`.${$AXIS.axisX}`).select("g.tick");
 						const tspans = tick.selectAll("tspan");
 						const expectedTickTexts = [
 								"this is a very long tick",
@@ -1008,7 +1007,7 @@ describe("AXIS", function() {
 			});
 
 			it("should have multiline tick text", () => {
-				const tick = chart.$.main.select(`.${CLASS.axisX}`).select("g.tick");
+				const tick = chart.$.main.select(`.${$AXIS.axisX}`).select("g.tick");
 				const tspans = tick.selectAll("tspan");
 
 				expect(tspans.size()).to.be.equal(tickTexts.length);
@@ -1029,7 +1028,7 @@ describe("AXIS", function() {
 			});
 
 			it("should have multiline tick text", () => {
-				const tick = chart.$.main.select(`.${CLASS.axisX}`).select("g.tick");
+				const tick = chart.$.main.select(`.${$AXIS.axisX}`).select("g.tick");
 				const tspans = tick.selectAll("tspan");
 				const lineBreaks = tickText.split("\n");
 
@@ -1051,7 +1050,7 @@ describe("AXIS", function() {
 			});
 
 			it("should have multiline tick text", () => {
-				const tick = chart.$.main.select(`.${CLASS.axisX}`).select("g.tick");
+				const tick = chart.$.main.select(`.${$AXIS.axisX}`).select("g.tick");
 				const tspans = tick.selectAll("tspan");
 
 				tspans.each(function() {
@@ -1135,7 +1134,7 @@ describe("AXIS", function() {
 			});
 
 			it("should rotate tick texts", () => {
-				chart.$.main.selectAll(`.${CLASS.axisX} g.tick`).each(function() {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function() {
 					const tick = d3Select(this);
 					const text = tick.select("text");
 					const tspan = text.select("tspan");
@@ -1148,7 +1147,7 @@ describe("AXIS", function() {
 
 			it("should have automatically calculated x axis height", () => {
 				const internal = chart.internal;
-				const box = internal.$el.main.select(`.${CLASS.axisX}`).node().getBoundingClientRect();
+				const box = internal.$el.main.select(`.${$AXIS.axisX}`).node().getBoundingClientRect();
 				const height = internal.getHorizontalAxisHeight("x");
 
 				expect(box.height).to.be.above(50);
@@ -1180,7 +1179,7 @@ describe("AXIS", function() {
 			});
 
 			it("should rotate tick texts", () => {
-				chart.$.main.selectAll(`.${CLASS.axisX} g.tick`).each(function() {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function() {
 					const tick = d3Select(this);
 					const text = tick.select("text");
 					const tspan = text.select("tspan");
@@ -1193,7 +1192,7 @@ describe("AXIS", function() {
 
 			it("should have automatically calculated x axis height", () => {
 				const internal = chart.internal;
-				const box = internal.$el.main.select(`.${CLASS.axisX}`).node().getBoundingClientRect();
+				const box = internal.$el.main.select(`.${$AXIS.axisX}`).node().getBoundingClientRect();
 				const height = internal.getHorizontalAxisHeight("x");
 
 				expect(box.height).to.be.above(50);
@@ -1208,7 +1207,7 @@ describe("AXIS", function() {
 
 		function compare(expectedXAxisTickRotate, expectedXAxisBoundingClientRect, expectedHorizontalXAxisHeight, expectedXAxisTickTextY2Overflow) {
 			const internal = chart.internal;
-			const xAxisBoundingClientRect = internal.$el.main.select(`.${CLASS.axisX}`).node().getBoundingClientRect();
+			const xAxisBoundingClientRect = internal.$el.main.select(`.${$AXIS.axisX}`).node().getBoundingClientRect();
 			const horizontalXAxisHeight = internal.getHorizontalAxisHeight("x");
 			const xAxisTickRotate = internal.getAxisTickRotate("x");
 
@@ -1264,7 +1263,7 @@ describe("AXIS", function() {
 			});
 
 			it("should not rotate tick texts if there is enough space between ticks", () => {
-				chart.$.main.selectAll(`.${CLASS.axisX} g.tick`).each(function() {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function() {
 						const tick = d3Select(this);
 						const text = tick.select("text");
 						const tspan = text.select("tspan");
@@ -1291,7 +1290,7 @@ describe("AXIS", function() {
 			});
 
 			it("should rotate tick texts if there is not enough space between ticks", () => {
-				chart.$.main.selectAll(`.${CLASS.axisX} g.tick`).each(function() {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function() {
 						const tick = d3Select(this);
 						const text = tick.select("text");
 						const tspan = text.select("tspan");
@@ -1376,13 +1375,13 @@ describe("AXIS", function() {
 			});
 
 			it("axis X should maintain its position on legend toggle", done => {
-				const axisXTransform = chart.$.main.select(`.${CLASS.axisX}`).attr("transform");
+				const axisXTransform = chart.$.main.select(`.${$AXIS.axisX}`).attr("transform");
 
 				// when
 				chart.toggle();
 
 				setTimeout(() => {
-					expect(chart.$.main.select(`.${CLASS.axisX}`).attr("transform")).to.be.equal(axisXTransform);
+					expect(chart.$.main.select(`.${$AXIS.axisX}`).attr("transform")).to.be.equal(axisXTransform);
 					done();
 				})
 			});
@@ -1418,7 +1417,7 @@ describe("AXIS", function() {
 			});
 
 			it("should not rotate tick texts if there is enough space between ticks", () => {
-				chart.$.main.selectAll(`.${CLASS.axisX} g.tick`).each(function() {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function() {
 					const tick = d3Select(this);
 					const text = tick.select("text");
 					const tspan = text.select("tspan");
@@ -1436,7 +1435,7 @@ describe("AXIS", function() {
 			});
 
 			it("should rotate tick texts if there is not enough space between ticks", () => {
-				chart.$.main.selectAll(`.${CLASS.axisX} g.tick`).each(function() {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function() {
 					const tick = d3Select(this);
 					const text = tick.select("text");
 					const tspan = text.select("tspan");
@@ -1468,7 +1467,7 @@ describe("AXIS", function() {
 			it("should rotate tick texts and show all 48 ticks", () => {
 				let shownTicks = 0;
 
-				chart.$.main.selectAll(`.${CLASS.axisX} g.tick`).each(function(d, i) {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function(d, i) {
 					const tick = d3Select(this);
 					const text = tick.select("text");
 					const tspan = text.select("tspan");
@@ -1492,7 +1491,7 @@ describe("AXIS", function() {
 			it("should rotate tick texts and show 16 ticks without overflow", () => {
 				let shownTicks = 0;
 
-				chart.$.main.selectAll(`.${CLASS.axisX} g.tick`).each(function(d, i) {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function(d, i) {
 					const tick = d3Select(this);
 					const text = tick.select("text");
 					const tspan = text.select("tspan");
@@ -1557,13 +1556,13 @@ describe("AXIS", function() {
 			});
 
 			it("axis X should maintain its position on legend toggle", done => {
-				const axisXTransform = chart.$.main.select(`.${CLASS.axisX}`).attr("transform");
+				const axisXTransform = chart.$.main.select(`.${$AXIS.axisX}`).attr("transform");
 
 				// when
 				chart.toggle();
 
 				setTimeout(() => {
-					expect(chart.$.main.select(`.${CLASS.axisX}`).attr("transform")).to.be.equal(axisXTransform);
+					expect(chart.$.main.select(`.${$AXIS.axisX}`).attr("transform")).to.be.equal(axisXTransform);
 					done();
 				})
 			});
@@ -1593,7 +1592,7 @@ describe("AXIS", function() {
 
 			it("should rotate tick texts", done => {
 				setTimeout(() => {
-					chart.$.main.selectAll(`.${CLASS.axisY} g.tick`).each(function() {
+					chart.$.main.selectAll(`.${$AXIS.axisY} g.tick`).each(function() {
 						const tick = d3Select(this);
 						const text = tick.select("text");
 						const tspan = text.select("tspan");
@@ -1611,7 +1610,7 @@ describe("AXIS", function() {
 			});
 
 			it("should have automatically calculated y axis width", () => {
-				const box = chart.$.main.select(`.${CLASS.axisY}`)
+				const box = chart.$.main.select(`.${$AXIS.axisY}`)
 					.node().getBoundingClientRect();
 
 				expect(box.width).to.be.closeTo(590, 1);
@@ -1641,7 +1640,7 @@ describe("AXIS", function() {
 
 			it("should rotate tick texts", done => {
 				setTimeout(() => {
-					chart.$.main.selectAll(`.${CLASS.axisY2} g.tick`).each(function() {
+					chart.$.main.selectAll(`.${$AXIS.axisY2} g.tick`).each(function() {
 						const tick = d3Select(this);
 						const text = tick.select("text");
 						const tspan = text.select("tspan");
@@ -1659,7 +1658,7 @@ describe("AXIS", function() {
 			});
 
 			it("should have automatically calculated y axis width", () => {
-				const box = chart.$.main.select(`.${CLASS.axisY2}`)
+				const box = chart.$.main.select(`.${$AXIS.axisY2}`)
 					.node().getBoundingClientRect();
 
 				expect(box.width).to.be.closeTo(590, 1);
@@ -1683,7 +1682,7 @@ describe("AXIS", function() {
 			});
 
 			it("should show fitted ticks on indexed data", () => {
-				const ticks = chart.$.main.selectAll(`.${CLASS.axisX} g.tick`);
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`);
 
 				expect(ticks.size()).to.be.equal(6);
 			});
@@ -1703,7 +1702,7 @@ describe("AXIS", function() {
 			});
 
 			it("should show fitted ticks on indexed data", () => {
-				const ticks = chart.$.main.selectAll(`.${CLASS.axisX} g.tick`);
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`);
 
 				expect(ticks.size()).to.be.equal(6);
 			});
@@ -1712,7 +1711,7 @@ describe("AXIS", function() {
 				chart.hide();
 				chart.show();
 
-				const ticks = chart.$.main.selectAll(`.${CLASS.axisX} g.tick`);
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`);
 
 				expect(ticks.size()).to.be.equal(6);
 			});
@@ -1740,7 +1739,7 @@ describe("AXIS", function() {
 			});
 
 			it("should show fitted ticks on indexed data", () => {
-				const ticks = chart.$.main.selectAll(`.${CLASS.axisX} g.tick`);
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`);
 
 				expect(ticks.size()).to.be.equal(11);
 			});
@@ -1758,7 +1757,7 @@ describe("AXIS", function() {
 			});
 
 			it("should show fitted ticks on indexed data", () => {
-				const ticks = chart.$.main.selectAll(`.${CLASS.axisX} g.tick`);
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`);
 
 				expect(ticks.size()).to.be.equal(10);
 			});
@@ -1767,7 +1766,7 @@ describe("AXIS", function() {
 				chart.hide();
 				chart.show();
 
-				const ticks = chart.$.main.selectAll(`.${CLASS.axisX} g.tick`);
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`);
 
 				expect(ticks.size()).to.be.equal(10);
 			});
@@ -1801,7 +1800,7 @@ describe("AXIS", function() {
 
 		it("should not have inner y axis", () => {
 			const paddingLeft = chart.internal.getCurrentPaddingLeft();
-			const tickTexts = chart.$.main.selectAll(`.${CLASS.axisY} g.tick text`);
+			const tickTexts = chart.$.main.selectAll(`.${$AXIS.axisY} g.tick text`);
 
 			expect(paddingLeft).to.be.above(19);
 
@@ -1816,7 +1815,7 @@ describe("AXIS", function() {
 
 		it("should have inner y axis", () => {
 			const paddingLeft = chart.internal.getCurrentPaddingLeft();
-			const tickTexts = chart.$.main.selectAll(`.${CLASS.axisY} g.tick text`);
+			const tickTexts = chart.$.main.selectAll(`.${$AXIS.axisY} g.tick text`);
 
 			expect(paddingLeft).to.be.equal(1);
 
@@ -1847,7 +1846,7 @@ describe("AXIS", function() {
 
 		it("should not have inner y axis", () => {
 			const paddingRight = chart.internal.getCurrentPaddingRight();
-			const tickTexts = chart.$.main.selectAll(`.${CLASS.axisY2} g.tick text`);
+			const tickTexts = chart.$.main.selectAll(`.${$AXIS.axisY2} g.tick text`);
 
 			expect(paddingRight).to.be.above(19);
 
@@ -1862,7 +1861,7 @@ describe("AXIS", function() {
 
 		it("should have inner y axis", () => {
 			const paddingRight = chart.internal.getCurrentPaddingRight();
-			const tickTexts = chart.$.main.selectAll(`.${CLASS.axisY2} g.tick text`);
+			const tickTexts = chart.$.main.selectAll(`.${$AXIS.axisY2} g.tick text`);
 
 			expect(paddingRight).to.be.equal(2);
 
@@ -1898,7 +1897,7 @@ describe("AXIS", function() {
 		});
 
 		it("should render ticks of rotated axis inside bar position range", () => {
-			const ticks = chart.$.main.select(`.${CLASS.axisX}`).selectAll("g.tick").nodes();
+			const ticks = chart.$.main.select(`.${$AXIS.axisX}`).selectAll("g.tick").nodes();
 
 			chart.internal.state.eventReceiver.coords.forEach((d, idx) => {
 				const tick = d3Select(ticks[idx]);
@@ -1967,7 +1966,7 @@ describe("AXIS", function() {
 
 		it("axes tick shouldn't be shown", () => {
 			["x", "y", "y2"].forEach(id => {
-				const axis = chart.$.main.select(`.${CLASS.axis}-${id}`);
+				const axis = chart.$.main.select(`.${$AXIS.axis}-${id}`);
 
 				expect(axis.select(".tick").empty()).to.be.true;
 			});
@@ -1979,7 +1978,7 @@ describe("AXIS", function() {
 
 		it("axes tick line should be shown", () => {
 			["x", "y", "y2"].forEach(id => {
-				const axis = chart.$.main.select(`.${CLASS.axis}-${id}`);
+				const axis = chart.$.main.select(`.${$AXIS.axis}-${id}`);
 
 				expect(axis.selectAll(".tick line").empty()).to.be.false;
 				expect(axis.selectAll(".tick text").size()).to.be.equal(0);
@@ -1993,7 +1992,7 @@ describe("AXIS", function() {
 
 		it("axes tick text should be shown", () => {
 			["x", "y", "y2"].forEach(id => {
-				const axis = chart.$.main.select(`.${CLASS.axis}-${id}`);
+				const axis = chart.$.main.select(`.${$AXIS.axis}-${id}`);
 
 				expect(axis.selectAll(".tick text").empty()).to.be.false;
 				expect(axis.selectAll(".tick line").size()).to.be.equal(0);
@@ -2024,7 +2023,7 @@ describe("AXIS", function() {
 			// should not contain unrounded float numbers: ex) 0.30000000000000004
 			const rx = /\d+\.\d+0{5,}\d$/;
 
-			chart.$.main.selectAll(`.${CLASS.axisY} tspan`).each(v => {
+			chart.$.main.selectAll(`.${$AXIS.axisY} tspan`).each(v => {
 				expect(rx.test(v.splitted)).to.be.false;
 			});
 		});
@@ -2084,7 +2083,7 @@ describe("AXIS", function() {
 			["x", "y", "y2"].forEach(v => {
 				const pos = args.axis[v].tick.text.position;
 
-				main.selectAll(`.${CLASS[`axis${v.toUpperCase()}`]} tspan`).each(function() {
+				main.selectAll(`.${$AXIS[`axis${v.toUpperCase()}`]} tspan`).each(function() {
 					const tspan = d3Select(this);
 
 					expect(+tspan.attr("dx")).to.be.equal(pos.x);
@@ -2103,7 +2102,7 @@ describe("AXIS", function() {
 			["x", "y", "y2"].forEach(v => {
 				const pos = args.axis[v].tick.text.position;
 
-				main.selectAll(`.${CLASS[`axis${v.toUpperCase()}`]} tspan`).each(function() {
+				main.selectAll(`.${$AXIS[`axis${v.toUpperCase()}`]} tspan`).each(function() {
 					const tspan = d3Select(this);
 
 					expect(+tspan.attr("dx")).to.be.equal(pos.x);
@@ -2120,7 +2119,7 @@ describe("AXIS", function() {
 
 		it("shouldn't be set 'clipPath' attribute", () => {
 			chart.$.main
-				.selectAll(`.${CLASS.axisX},.${CLASS.axisY}`).each(function() {
+				.selectAll(`.${$AXIS.axisX},.${$AXIS.axisY}`).each(function() {
 					expect(this.getAttribute("clip-path")).to.be.null;
 				});
 		});
@@ -2145,7 +2144,7 @@ describe("AXIS", function() {
 		});
 
 		it("only one tick should be generated even counts are greater than 1", () => {
-			const ticks = chart.$.main.selectAll(`.${CLASS.axisY} .tick`);
+			const ticks = chart.$.main.selectAll(`.${$AXIS.axisY} .tick`);
 
 			expect(ticks.size()).to.be.equal(1);
 		});
@@ -2242,8 +2241,8 @@ describe("AXIS", function() {
 
 		const checkXAxes = (rotated?) => {
 			const main = chart.$.main;
-			const xAxisY = util.parseNum(main.select(`.${CLASS.axis}-x`).attr("transform"));
-			const axis1 = main.select(`.${CLASS.axis}-x-1`);
+			const xAxisY = util.parseNum(main.select(`.${$AXIS.axis}-x`).attr("transform"));
+			const axis1 = main.select(`.${$AXIS.axis}-x-1`);
 
 			expect(util.parseNum(axis1.attr("transform"))).to.be[rotated ? "below" : "above"](xAxisY);
 
@@ -2257,11 +2256,11 @@ describe("AXIS", function() {
 
 		const checkYAxes = (rotated?) => {
 			const main = chart.$.main;
-			const yAxisY = util.parseNum(main.select(`.${CLASS.axis}-y`).attr("transform"));
+			const yAxisY = util.parseNum(main.select(`.${$AXIS.axis}-y`).attr("transform"));
 			let yAxes = chart.internal.axis.axesList.y;
 			const toBeMethod = rotated ? "above" : "below";
 
-			yAxes = yAxes.map((v, i) => main.select(`.${CLASS.axis}-y-${i + 1}`));
+			yAxes = yAxes.map((v, i) => main.select(`.${$AXIS.axis}-y-${i + 1}`));
 
 			yAxes.map(v => util.parseNum(v.attr("transform")))
 				.reduce((p, curr) => {
@@ -2285,8 +2284,8 @@ describe("AXIS", function() {
 
 		const checkY2Axes = (rotated?) => {
 			const main = chart.$.main;
-			const yAxisY = util.parseNum(main.select(`.${CLASS.axis}-y2`).attr("transform"));
-			const axis1 = main.select(`.${CLASS.axis}-y2-1`);
+			const yAxisY = util.parseNum(main.select(`.${$AXIS.axis}-y2`).attr("transform"));
+			const axis1 = main.select(`.${$AXIS.axis}-y2-1`);
 
 			expect(util.parseNum(axis1.attr("transform"))).to.be[rotated ? "below" : "above"](yAxisY);
 
@@ -2305,7 +2304,7 @@ describe("AXIS", function() {
 
 			["x", "y", "y2"].forEach(id => {
 				axesList[id].forEach((v, i) => {
-					expect(main.select(`.${CLASS.axis}-${id}-${i + 1}`).empty()).to.be.false;
+					expect(main.select(`.${$AXIS.axis}-${id}-${i + 1}`).empty()).to.be.false;
 				});
 			});
 		});
@@ -2370,7 +2369,7 @@ describe("AXIS", function() {
 			["x", "y", "y2"].forEach(id => {
 				chart.internal.axis.axesList[id]
 					.forEach((v, i) => {
-						const axis = main.select(`.${CLASS.axis}-${id}-${i + 1}`);
+						const axis = main.select(`.${$AXIS.axis}-${id}-${i + 1}`);
 						const domain = v.scale().domain();
 
 						expect(domain).to.be.deep.equal(args.axis[id].axes[i].domain);
@@ -2401,7 +2400,7 @@ describe("AXIS", function() {
 		});
 
 		it("check y Axis width sizing", () => {
-			const axisY = chart.$.main.select(`.${CLASS.axisY}`);
+			const axisY = chart.$.main.select(`.${$AXIS.axisY}`);
 
 			expect(axisY.node().getBoundingClientRect().width).to.be.equal(
 				axisY.select(".tick:nth-child(12)").node().getBoundingClientRect().width
@@ -2649,7 +2648,7 @@ describe("AXIS", function() {
 		});
 
 		it("check if x axis min/max is fitten.", () => {
-			const yAxisRect = getBoundingRect(chart.$.main.select(`.${CLASS.axisY}`).node());
+			const yAxisRect = getBoundingRect(chart.$.main.select(`.${$AXIS.axisY}`).node());
 			const lineRect = getBoundingRect(chart.$.line.lines.node());
 
 			// check min
@@ -2664,7 +2663,7 @@ describe("AXIS", function() {
 		});
 
 		it("check if x axis min/max is not fitten.", () => {
-			const yAxisRect = getBoundingRect(chart.$.main.select(`.${CLASS.axisY}`).node());
+			const yAxisRect = getBoundingRect(chart.$.main.select(`.${$AXIS.axisY}`).node());
 			const lineRect = getBoundingRect(chart.$.line.lines.node());
 
 			// check min
@@ -2689,7 +2688,7 @@ describe("AXIS", function() {
 		it("check if x axis min/max is not fitten.", () => {
 			const currWidth = chart.internal.state.current.width;
 
-			chart.$.main.selectAll(`.${CLASS.axisX} .tick`).each(function(d, i) {
+			chart.$.main.selectAll(`.${$AXIS.axisX} .tick`).each(function(d, i) {
 				const xPos = +util.parseNum(this.getAttribute("transform")) / 10;
 
 				if (i === 0) { // check min
@@ -2863,7 +2862,7 @@ describe("AXIS", function() {
 			const {state: {current}} = chart.internal;
 
 			const maxTickWidth = current.maxTickWidths.x.size;
-			const tickWdith = chart.$.main.select(`.${CLASS.axisX} tspan`).node().getBoundingClientRect().width;
+			const tickWdith = chart.$.main.select(`.${$AXIS.axisX} tspan`).node().getBoundingClientRect().width;
 
 			expect(maxTickWidth).to.be.equal(tickWdith);
 		});

--- a/test/internals/bb-spec.ts
+++ b/test/internals/bb-spec.ts
@@ -7,7 +7,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import bb from "../../src";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $COMMON} from "../../src/config/classes";
 import Chart from "../../src/Chart/Chart";
 import {convertInputType, extend} from "../../src/module/util";
 
@@ -326,7 +326,7 @@ describe("Interface & initialization", () => {
 			expect(bb.defaults()).deep.equal(args);
 			expect(chart.config("data.types")).to.be.deep.equal(args.data.types);
 
-			chart.$.main.selectAll(`.${CLASS.axisX} .tick text`).each(function(d, i) {
+			chart.$.main.selectAll(`.${$AXIS.axisX} .tick text`).each(function(d, i) {
 				expect(this.textContent).to.be.equal(`${tickPrefix}${i}`);
 			})
 		});
@@ -359,7 +359,7 @@ describe("Interface & initialization", () => {
 				Object.assign({}, bb.defaults().data.types, args.data.types)
 			);
 
-			chart.$.main.selectAll(`.${CLASS.axisX} .tick text`).each(function(d, i) {
+			chart.$.main.selectAll(`.${$AXIS.axisX} .tick text`).each(function(d, i) {
 				expect(this.textContent).to.be.equal(`${tickPrefix}${i}`);
 			});
 		});
@@ -590,7 +590,7 @@ describe("Interface & initialization", () => {
 
 			const element = chart.$.main.select(".myBgClass");
 
-			expect(element.node().nextSibling.getAttribute("class")).to.be.equal(CLASS.chart);
+			expect(element.node().nextSibling.getAttribute("class")).to.be.equal($COMMON.chart);
 		});
 
 		it("set option background.color=red", () => {
@@ -616,7 +616,7 @@ describe("Interface & initialization", () => {
 
 			const element = chart.$.main.select(".myBgClass");
 
-			expect(element.node().nextSibling.getAttribute("class")).to.be.equal(CLASS.chart);
+			expect(element.node().nextSibling.getAttribute("class")).to.be.equal($COMMON.chart);
 		});
 	});
 });

--- a/test/internals/color-spec.ts
+++ b/test/internals/color-spec.ts
@@ -10,7 +10,7 @@ import {
 } from "d3-selection";
 import {expect} from "chai";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$ARC, $BAR, $COLOR, $COMMON, $EVENT, $LEGEND, $SHAPE, $TOOLTIP} from "../../src/config/classes";
 import {KEY as CACHE_KEY} from "../../src/module/Cache";
 import {isFunction, isObject, isString} from "../../src/module/util";
 
@@ -43,7 +43,7 @@ describe("COLOR", () => {
 		const styleSheet = document.createElement("style");
 
 		before(() => {
-			styleSheet.innerHTML = `.${CLASS.colorPattern} {
+			styleSheet.innerHTML = `.${$COLOR.colorPattern} {
 				background-image: url("${pattern.join(";")}");
 			}`;
 
@@ -65,7 +65,7 @@ describe("COLOR", () => {
 		});
 
 		it("check if color pattern applied to data elements", () => {
-			chart.$.main.selectAll(`.${CLASS.chartBars} .${CLASS.target} path:first-child`)
+			chart.$.main.selectAll(`.${$BAR.chartBars} .${$COMMON.target} path:first-child`)
 				.each(function(v, i) {
 					expect(this.style.fill).to.be.equal(util.hexToRgb(pattern[i]));
 				});
@@ -138,7 +138,7 @@ describe("COLOR", () => {
 		it("check for legend color tiles", () => {
 			const colors = [chart.color("data1"), chart.color("data2")];
 
-			chart.$.legend.selectAll(`.${CLASS.legendItemTile}`)
+			chart.$.legend.selectAll(`.${$LEGEND.legendItemTile}`)
 				.each(function(v, i) {
 					const stroke = d3Select(this).style("stroke").replace(/\"/g, "");
 
@@ -149,7 +149,7 @@ describe("COLOR", () => {
 		it("check for tooltip color tiles", () => {
 			const colors = [chart.color("data1"), chart.color("data2")];
 			const eventRect = chart.$.main
-				.select(`.${CLASS.eventRect}-1`)
+				.select(`.${$EVENT.eventRect}-1`)
 				.node();
 
 			util.fireEvent(eventRect, "mousemove", {
@@ -158,7 +158,7 @@ describe("COLOR", () => {
 			}, chart);
 
 			d3Select(chart.element)
-				.selectAll(`.${CLASS.tooltip} td rect`)
+				.selectAll(`.${$TOOLTIP.tooltip} td rect`)
 				.each(function(v, i) {
 					const fill = d3Select(this).style("fill").replace(/\"/g, "");
 
@@ -197,7 +197,7 @@ describe("COLOR", () => {
 				chart.data().forEach(v => {
 					const id = v.id;
 					const isLine = internal.isTypeOf(id, ["line", "spline", "step"]) || !internal.config.data_types[id];
-					const stroke = internal.$el.main.select(`.${CLASS.shapes}-${id} path`).style("fill");
+					const stroke = internal.$el.main.select(`.${$SHAPE.shapes}-${id} path`).style("fill");
 					// @ts-ignore
 					expect(rx.test(stroke)).to.be[!isLine];
 				})
@@ -269,7 +269,7 @@ describe("COLOR", () => {
 		const checkColor = (chart, colorOnover) => {
 			const {$: {main}, internal: {$el}} = chart;
 			const eventRect = $el.eventRect.node();
-			const shape = main.selectAll(`.${CLASS.shape}-1`);
+			const shape = main.selectAll(`.${$SHAPE.shape}-1`);
 			const originalColor = [];
 
 			shape.each(function() {
@@ -358,7 +358,7 @@ describe("COLOR", () => {
 		it("check for the arc type", done => {
 			setTimeout(() => {
 				const {main} = chart.$;
-				const arc = main.select(`.${CLASS.arc}-data1`).node();
+				const arc = main.select(`.${$ARC.arc}-data1`).node();
 				const originalColor = arc.style.fill;
 
 				util.fireEvent(arc, "mouseover");
@@ -392,7 +392,7 @@ describe("COLOR", () => {
 		});
 
 		it("check for color update", done => {
-			const path = chart.$.arc.select(`path.${CLASS.arc}-data`);
+			const path = chart.$.arc.select(`path.${$ARC.arc}-data`);
 			let i = 0;
 
 			expect(path.style("fill")).to.be.equal(args.color.pattern[i++]);
@@ -436,7 +436,7 @@ describe("COLOR", () => {
 
 
 			["data1", "data2"].forEach(v => {
-				expect(chart.$.tooltip.selectAll(`.${CLASS.tooltipName}-${v} .name span`).style("background-color")).to.be.equal(c[v]);
+				expect(chart.$.tooltip.selectAll(`.${$TOOLTIP.tooltipName}-${v} .name span`).style("background-color")).to.be.equal(c[v]);
 			});
 		});
 
@@ -447,7 +447,7 @@ describe("COLOR", () => {
 		it("arc should apply correct color values", () => {
 			chart.$.arc.selectAll("path").each(function(d) {
 				expect(this.style.fill).to.be.equal(
-					chart.internal.$el.legend.select(`.${CLASS.legendItem}-${d.data.id} line`).style("stroke")
+					chart.internal.$el.legend.select(`.${$LEGEND.legendItem}-${d.data.id} line`).style("stroke")
 				);
 			});
 		})

--- a/test/internals/core-spec.ts
+++ b/test/internals/core-spec.ts
@@ -7,7 +7,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $COMMON, $GRID} from "../../src/config/classes";
 import {window, document} from "../../src/module/browser";
 
 describe("CORE", function() {
@@ -56,7 +56,7 @@ describe("CORE", function() {
 		});
 
 		it("y2 Axis shouldn't be generated", () => {
-			const y2 = chart.$.main.select(`.${CLASS.axisY2}`);
+			const y2 = chart.$.main.select(`.${$AXIS.axisY2}`);
 
 			expect(y2.empty()).to.be.true;
 		});
@@ -251,7 +251,7 @@ describe("CORE", function() {
 		});
 
 		it("should generate a chart", () => {
-			const ticks = chart.$.main.select(`.${CLASS.axisX}`)
+			const ticks = chart.$.main.select(`.${$AXIS.axisX}`)
 				.selectAll("g.tick");
 
 			expect(ticks.size()).to.be.equal(0);
@@ -278,7 +278,7 @@ describe("CORE", function() {
 		});
 
 		it("should generate a chart", () => {
-			const ticks = chart.$.main.select(`.${CLASS.axisX}`)
+			const ticks = chart.$.main.select(`.${$AXIS.axisX}`)
 				.selectAll("g.tick");
 
 			expect(ticks.size()).to.be.equal(0);
@@ -299,7 +299,7 @@ describe("CORE", function() {
 		});
 
 		it("chart should have clip-path property", () => {
-			const main = chart.$.main.select(`.${CLASS.chart}`);
+			const main = chart.$.main.select(`.${$COMMON.chart}`);
 
 			expect(main.attr("clip-path")).to.not.be.null;
 		});
@@ -313,7 +313,7 @@ describe("CORE", function() {
 		});
 
 		it("check for chart node's position", () => {
-			const next = chart.$.main.select(`.${CLASS.axisY2}`).node().nextSibling;
+			const next = chart.$.main.select(`.${$AXIS.axisY2}`).node().nextSibling;
 
 			// axis element should be the last positioned
 			expect(next).to.be.null;
@@ -324,16 +324,16 @@ describe("CORE", function() {
 		});
 
 		it("clip-path property should be null", () => {
-			const main = chart.$.main.select(`.${CLASS.chart}`);
+			const main = chart.$.main.select(`.${$COMMON.chart}`);
 
 			expect(main.attr("clip-path")).to.be.null;
 		});
 
 		it("check for chart node's position", () => {
-			const previous = chart.$.main.select(`.${CLASS.chart}`).node().previousSibling;
+			const previous = chart.$.main.select(`.${$COMMON.chart}`).node().previousSibling;
 
 			// chart element should positioned after axis element
-			expect(d3Select(previous).classed(CLASS.grid)).to.be.true;
+			expect(d3Select(previous).classed($GRID.grid)).to.be.true;
 		});
 	});
 

--- a/test/internals/data-spec.ts
+++ b/test/internals/data-spec.ts
@@ -8,7 +8,7 @@ import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import sinon from "sinon";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AREA, $AXIS, $BAR, $CIRCLE, $COMMON, $LINE, $SHAPE, $TEXT} from "../../src/config/classes";
 import {isNumber} from "../../src/module/util";
 
 describe("DATA", () => {
@@ -54,7 +54,7 @@ describe("DATA", () => {
 			const expectedCx = [6, 299, 593];
 			const expectedCy = [371, 391, 332];
 
-			chart.$.main.selectAll(`.${CLASS.circles}-data1 .${CLASS.circle}`)
+			chart.$.main.selectAll(`.${$CIRCLE.circles}-data1 .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx, expectedCy));
 		});
 	});
@@ -93,10 +93,10 @@ describe("DATA", () => {
 			const expectedCy = {443: [194, 351, 36], 995: [391, 0, 351]};
 			const main = chart.$.main;
 
-			main.selectAll(`.${CLASS.circles}-443 .${CLASS.circle}`)
+			main.selectAll(`.${$CIRCLE.circles}-443 .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx[443], expectedCy[443]));
 
-			main.selectAll(`.${CLASS.circles}-995 .${CLASS.circle}`)
+			main.selectAll(`.${$CIRCLE.circles}-995 .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx[995], expectedCy[995]));
 		});
 	});
@@ -161,25 +161,25 @@ describe("DATA", () => {
 				"778.889": [347, 376, 340]
 			};
 
-			main.selectAll(`.${CLASS.circles}-443 .${CLASS.circle}`)
+			main.selectAll(`.${$CIRCLE.circles}-443 .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx, expectedCy[443]));
 
-			main.selectAll(`.${CLASS.circles}-995-996 .${CLASS.circle}`)
+			main.selectAll(`.${$CIRCLE.circles}-995-996 .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx, expectedCy[995]));
 
-			main.selectAll(`.${CLASS.circles}-112-0- .${CLASS.circle}`)
+			main.selectAll(`.${$CIRCLE.circles}-112-0- .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx, expectedCy[112]));
 
-			main.selectAll(`.${CLASS.circles}-223-0--224 .${CLASS.circle}`)
+			main.selectAll(`.${$CIRCLE.circles}-223-0--224 .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx, expectedCy[223]));
 
-			main.selectAll(`.${CLASS.circles}-334-1--0--335 .${CLASS.circle}`)
+			main.selectAll(`.${$CIRCLE.circles}-334-1--0--335 .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx, expectedCy[334]));
 
-			main.selectAll(`.${CLASS.circles}-556-557-558-0- .${CLASS.circle}`)
+			main.selectAll(`.${$CIRCLE.circles}-556-557-558-0- .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx, expectedCy[556]));
 
-			main.selectAll(`.${CLASS.circles}-778-889 .${CLASS.circle}`)
+			main.selectAll(`.${$CIRCLE.circles}-778-889 .${$CIRCLE.circle}`)
 				.each(checkXY(expectedCx, expectedCy["778.889"]));
 		});
 	});
@@ -366,7 +366,7 @@ describe("DATA", () => {
 		it("check for ascending", () => {
 			const data = [];
 
-			chart.$.arc.selectAll(`g.${CLASS.shapes}`).each(function(d, i) {
+			chart.$.arc.selectAll(`g.${$SHAPE.shapes}`).each(function(d, i) {
 				data.push([d.data.id, d.startAngle]);
 			});
 
@@ -389,7 +389,7 @@ describe("DATA", () => {
 		it("check for descending", () => {
 			const data = [];
 
-			chart.$.arc.selectAll(`g.${CLASS.shapes}`).each(function(d, i) {
+			chart.$.arc.selectAll(`g.${$SHAPE.shapes}`).each(function(d, i) {
 				data.push([d.data.id, d.startAngle]);
 			});
 
@@ -560,7 +560,7 @@ describe("DATA", () => {
 				it("should have milliseconds tick format", () => {
 					const expected = ["2014-05-20 17:25:00.123", "2014-05-20 17:30:00.345"];
 
-					chart.$.main.selectAll(`.${CLASS.axisX} g.tick text`).each(function(d, i) {
+					chart.$.main.selectAll(`.${$AXIS.axisX} g.tick text`).each(function(d, i) {
 						expect(d3Select(this).text()).to.be.equal(expected[i]);
 					});
 				});
@@ -710,7 +710,7 @@ describe("DATA", () => {
 		});
 
 		const checkPathLengths = expected => {
-			const line = chart.$.main.select(`path.${CLASS.line}-data1`);
+			const line = chart.$.main.select(`path.${$LINE.line}-data1`);
 			const path = line.attr("d");
 
 			expect(path.split("M").length).to.be.equal(expected.M);
@@ -780,7 +780,7 @@ describe("DATA", () => {
 		});
 
 		it("check for the normalized y axis tick in percentage", () => {
-			const tick = chart.$.main.selectAll(`.${CLASS.axisY} .tick tspan`);
+			const tick = chart.$.main.selectAll(`.${$AXIS.axisY} .tick tspan`);
 
 			// check for the y axis to be in percentage
 			tick.each(function (v, i) {
@@ -802,7 +802,7 @@ describe("DATA", () => {
 			chart.hide("data1");
 
 			setTimeout(() => {
-				chart.$.main.selectAll(`.${CLASS.target}-data2 path`).each(function() {
+				chart.$.main.selectAll(`.${$COMMON.target}-data2 path`).each(function() {
 					expect(this.getBBox().height).to.be.equal(chartHeight);
 				});
 
@@ -821,8 +821,8 @@ describe("DATA", () => {
 
 		it("check for null data", done => {
 			const main = chart.$.main;
-			const data1Bar = main.select(`.${CLASS.bars}-data1 .${CLASS.bar}-2`).node();
-			const data2Bar = main.select(`.${CLASS.bars}-data2 .${CLASS.bar}-1`).node();
+			const data1Bar = main.select(`.${$BAR.bars}-data1 .${$BAR.bar}-2`).node();
+			const data2Bar = main.select(`.${$BAR.bars}-data2 .${$BAR.bar}-1`).node();
 
 			expect(data1Bar.getBBox().height).to.be.equal(chartHeight);
 			expect(data2Bar.getBBox().height).to.be.equal(chartHeight);
@@ -848,7 +848,7 @@ describe("DATA", () => {
 		it("check for the normalized area's height", () => {
 			let areaHeight = 0;
 
-			chart.$.main.selectAll(`.${CLASS.areas} path`).each(function() {
+			chart.$.main.selectAll(`.${$AREA.areas} path`).each(function() {
 				areaHeight += this.getBBox().height;
 			});
 
@@ -887,13 +887,13 @@ describe("DATA", () => {
 		});
 
 		it("check for empty label text", () => {
-			const emptyLabelText = chart.$.main.select(`.${CLASS.text}.${CLASS.empty}`);
+			const emptyLabelText = chart.$.main.select(`.${$TEXT.text}.${$COMMON.empty}`);
 
 			expect(emptyLabelText.style("display")).to.be.equal("block");
 		});
 
 		it("check the visiblity on data toggles", done => {
-			const emptyLabelText = chart.$.main.select(`.${CLASS.text}.${CLASS.empty}`);
+			const emptyLabelText = chart.$.main.select(`.${$TEXT.text}.${$COMMON.empty}`);
 
 			// display data
 			chart.toggle();
@@ -914,7 +914,7 @@ describe("DATA", () => {
 		});
 
 		it("shouldn't be generating empty label text node", () => {
-			const emptyLabelText = chart.$.main.select(`.${CLASS.text}.${CLASS.empty}`);
+			const emptyLabelText = chart.$.main.select(`.${$TEXT.text}.${$COMMON.empty}`);
 
 			expect(emptyLabelText.empty()).to.be.true;
 		});

--- a/test/internals/grid-spec.ts
+++ b/test/internals/grid-spec.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $COMMON, $EVENT, $FOCUS, $GRID} from "../../src/config/classes";
 import util from "../assets/util";
 
 describe("GRID", function() {
@@ -37,9 +37,9 @@ describe("GRID", function() {
 
 		it("should show 3 grid lines", () => {
 			const checkGridLines = isX => {
-				const grid = chart.$.grid.main.selectAll(`.${isX ? CLASS.xgrids : CLASS.ygrids} line`).nodes();
+				const grid = chart.$.grid.main.selectAll(`.${isX ? $GRID.xgrids : $GRID.ygrids} line`).nodes();
 
-				chart.$.main.selectAll(`.${isX ? CLASS.axisX : CLASS.axisY} .tick`).each(function(d, i) {
+				chart.$.main.selectAll(`.${isX ? $AXIS.axisX : $AXIS.axisY} .tick`).each(function(d, i) {
 					const node = grid[i];
 					const name = isX ? "x" : "y";
 
@@ -58,10 +58,10 @@ describe("GRID", function() {
 		
 		it("check grid lines position for non rotated axis", () => {
 			const checkGridLinesPos = isX => {
-				const axis = chart.$.main.selectAll(`.${isX ? CLASS.axisX : CLASS.axisY} line`).nodes();
+				const axis = chart.$.main.selectAll(`.${isX ? $AXIS.axisX : $AXIS.axisY} line`).nodes();
 				const prop = isX ? "x" : "y";
 	
-				chart.$.grid.main.selectAll(`.${isX ? CLASS.xgrids : CLASS.ygrids} line`)
+				chart.$.grid.main.selectAll(`.${isX ? $GRID.xgrids : $GRID.ygrids} line`)
 					.each(function(d, i) {
 						const pos = this.getBoundingClientRect()[prop];
 						const axisPos = axis[i].getBoundingClientRect()[prop];
@@ -81,10 +81,10 @@ describe("GRID", function() {
 
 		it("check grid lines position for rotated axis", () => {
 			const checkGridLinesPos = isX => {
-				const axis = chart.$.main.selectAll(`.${isX ? CLASS.axisX : CLASS.axisY} line`).nodes();
+				const axis = chart.$.main.selectAll(`.${isX ? $AXIS.axisX : $AXIS.axisY} line`).nodes();
 				const prop = isX ? "y" : "x";
 	
-				chart.$.grid.main.selectAll(`.${isX ? CLASS.xgrids : CLASS.ygrids} line`)
+				chart.$.grid.main.selectAll(`.${isX ? $GRID.xgrids : $GRID.ygrids} line`)
 					.each(function(d, i) {
 						const pos = this.getBoundingClientRect()[prop];
 						const axisPos = axis[i].getBoundingClientRect()[prop];
@@ -124,7 +124,7 @@ describe("GRID", function() {
 		});
 
 		it("should not show y grids", () => {
-			expect(chart.$.main.select(`.${CLASS.ygrids}`).size()).to.be.equal(0);
+			expect(chart.$.main.select(`.${$GRID.ygrids}`).size()).to.be.equal(0);
 		});
 
 		it("set options grid.y.show=true", () => {
@@ -132,10 +132,10 @@ describe("GRID", function() {
 		});
 
 		it("should show y grids", function() {
-			const ygrids = chart.$.main.select(`.${CLASS.ygrids}`);
+			const ygrids = chart.$.main.select(`.${$GRID.ygrids}`);
 
 			expect(ygrids.size()).to.be.equal(1);
-			expect(ygrids.selectAll(`.${CLASS.ygrid}`).size()).to.be.equal(9);
+			expect(ygrids.selectAll(`.${$GRID.ygrid}`).size()).to.be.equal(9);
 		});
 
 		it("set options grid.y.ticks=3", () => {
@@ -143,10 +143,10 @@ describe("GRID", function() {
 		});
 
 		it("should show only 3 y grids", () => {
-			const ygrids = chart.$.main.select(`.${CLASS.ygrids}`);
+			const ygrids = chart.$.main.select(`.${$GRID.ygrids}`);
 
 			expect(ygrids.size()).to.be.equal(1);
-			expect(ygrids.selectAll(`.${CLASS.ygrid}`).size()).to.be.equal(3);
+			expect(ygrids.selectAll(`.${$GRID.ygrid}`).size()).to.be.equal(3);
 		});
 
 		it("set options axis.y.tick.count=5", () => {
@@ -154,17 +154,17 @@ describe("GRID", function() {
 		});
 
 		it("should show grids depending on y axis ticks", () => {
-			const ygrids = chart.$.main.select(`.${CLASS.ygrids}`);
+			const ygrids = chart.$.main.select(`.${$GRID.ygrids}`);
 			const expectedYs = [];
 
-			ygrids.selectAll(`.${CLASS.ygrid}`).each(function(d, i) {
+			ygrids.selectAll(`.${$GRID.ygrid}`).each(function(d, i) {
 				expectedYs[i] = +d3Select(this).attr("y1");
 			});
 
 			expect(ygrids.size()).to.be.equal(1);
-			expect(ygrids.selectAll(`.${CLASS.ygrid}`).size()).to.be.equal(5);
+			expect(ygrids.selectAll(`.${$GRID.ygrid}`).size()).to.be.equal(5);
 
-			chart.$.main.select(`.${CLASS.axisY}`).selectAll(".tick").each(function(d, i) {
+			chart.$.main.select(`.${$AXIS.axisY}`).selectAll(".tick").each(function(d, i) {
 				let y: any = d3Select(this).attr("transform").match(/\d+\)/);
 
 				if (y.length >= 1) {
@@ -178,10 +178,10 @@ describe("GRID", function() {
 
 	describe("front option", () => {
 		it("grid element should positioned before chart element", () => {
-			const grid = chart.$.main.select(`.${CLASS.grid}`).node();
+			const grid = chart.$.main.select(`.${$GRID.grid}`).node();
 			const nextSiblingClassName = grid.nextSibling.getAttribute("class");
 
-			expect(nextSiblingClassName).to.be.equal(CLASS.chart);
+			expect(nextSiblingClassName).to.be.equal($COMMON.chart);
 		});
 
 		it("set options grid.front=true", () => {
@@ -189,10 +189,10 @@ describe("GRID", function() {
 		});
 
 		it("grid element should positioned after gridLines element", () => {
-			const grid = chart.$.main.select(`.${CLASS.xgridFocus}`).node().parentNode;
+			const grid = chart.$.main.select(`.${$FOCUS.xgridFocus}`).node().parentNode;
 			const previousSiblingClassName = grid.previousSibling.getAttribute("class");
 
-			expect(previousSiblingClassName).to.be.equal(`${CLASS.grid} ${CLASS.gridLines}`);
+			expect(previousSiblingClassName).to.be.equal(`${$GRID.grid} ${$GRID.gridLines}`);
 		});
 	});
 
@@ -202,7 +202,7 @@ describe("GRID", function() {
 		});
 
 		it("shouldn't be generating grid elements", () => {
-			expect(chart.$.main.select(`.${CLASS.grid}.${CLASS.gridLines}`).empty()).to.be.true;
+			expect(chart.$.main.select(`.${$GRID.grid}.${$GRID.gridLines}`).empty()).to.be.true;
 		});
 	});
 
@@ -228,12 +228,12 @@ describe("GRID", function() {
 			});
 
 			it("should show 3 grid lines", () => {
-				expect(chart.$.main.selectAll(`.${CLASS.ygrid}-lines .${CLASS.ygrid}-line`).size()).to.be.equal(3);
+				expect(chart.$.main.selectAll(`.${$GRID.ygrid}-lines .${$GRID.ygrid}-line`).size()).to.be.equal(3);
 			});
 
 			it("should locate grid lines properly", done => {
 				setTimeout(() => {
-					const lines = chart.$.main.selectAll(`.${CLASS.ygrid}-lines .${CLASS.ygrid}-line line`);
+					const lines = chart.$.main.selectAll(`.${$GRID.ygrid}-lines .${$GRID.ygrid}-line line`);
 					const expectedY1s = [373, 268, 196];
 
 					lines.each(function (d, i) {
@@ -248,7 +248,7 @@ describe("GRID", function() {
 			});
 
 			it("should locate grid texts properly", () => {
-				const lines = chart.$.main.selectAll(`.${CLASS.ygrid}-lines .${CLASS.ygrid}-line`);
+				const lines = chart.$.main.selectAll(`.${$GRID.ygrid}-lines .${$GRID.ygrid}-line`);
 				const expectedPositions = ["start", "middle", "end"];
 				const expectedDxs = [4, 0, -4];
 
@@ -287,12 +287,12 @@ describe("GRID", function() {
 			});
 
 			it("should show 3 grid lines", () => {
-				expect(chart.$.main.selectAll(`.${CLASS.ygrid}-lines .${CLASS.ygrid}-line`).size()).to.be.equal(3);
+				expect(chart.$.main.selectAll(`.${$GRID.ygrid}-lines .${$GRID.ygrid}-line`).size()).to.be.equal(3);
 			});
 
 			it("should locate grid lines properly", done => {
 				setTimeout(() => {
-					const lines = chart.$.main.selectAll(`.${CLASS.ygrid}-lines .${CLASS.ygrid}-line line`);
+					const lines = chart.$.main.selectAll(`.${$GRID.ygrid}-lines .${$GRID.ygrid}-line line`);
 					const expectedX1s = [75, 220, 321];
 
 					lines.each(function(d, i) {
@@ -307,7 +307,7 @@ describe("GRID", function() {
 			});
 
 			it("should locate grid texts properly", () => {
-				const lines = chart.$.main.selectAll(`.${CLASS.ygrid}-lines .${CLASS.ygrid}-line`);
+				const lines = chart.$.main.selectAll(`.${$GRID.ygrid}-lines .${$GRID.ygrid}-line`);
 				const expectedPositions = ["start", "middle", "end"];
 				const expectedDxs = [4, 0, -4];
 
@@ -324,10 +324,10 @@ describe("GRID", function() {
 
 		describe("lines.front option", () => {
 			it("grid lines should positioned after chart element", () => {
-				const gridLines = chart.$.main.select(`.${CLASS.grid}-lines`).node();
+				const gridLines = chart.$.main.select(`.${$GRID.grid}-lines`).node();
 				const previousSiblingClassName = gridLines.previousSibling.getAttribute("class");
 
-				expect(previousSiblingClassName).to.be.equal(CLASS.chart);
+				expect(previousSiblingClassName).to.be.equal($COMMON.chart);
 			});
 
 			it("set options grid.lines.front=false", () => {
@@ -335,10 +335,10 @@ describe("GRID", function() {
 			});
 
 			it("grid lines should positioned before grid element", () => {
-				const gridLines = chart.$.main.select(`.${CLASS.grid}-lines`).node();
+				const gridLines = chart.$.main.select(`.${$GRID.grid}-lines`).node();
 				const nextSiblingClassName = gridLines.nextSibling.getAttribute("class");
 
-				expect(nextSiblingClassName).to.be.equal(CLASS.grid);
+				expect(nextSiblingClassName).to.be.equal($GRID.grid);
 			});
 		});
 	});
@@ -372,11 +372,11 @@ describe("GRID", function() {
 			})
 
 			it("should show 3 grid lines", () => {
-				expect(chart.$.main.selectAll(`.${CLASS.xgrid}-lines .${CLASS.xgrid}-line`).size()).to.be.equal(3);
+				expect(chart.$.main.selectAll(`.${$GRID.xgrid}-lines .${$GRID.xgrid}-line`).size()).to.be.equal(3);
 			});
 
 			it("should locate grid lines properly", done => {
-				const lines = chart.$.main.selectAll(`.${CLASS.xgrid}-lines .${CLASS.xgrid}-line`);
+				const lines = chart.$.main.selectAll(`.${$GRID.xgrid}-lines .${$GRID.xgrid}-line`);
 				const expectedX1s = [202, 397, 593];
 
 				setTimeout(() => {
@@ -391,7 +391,7 @@ describe("GRID", function() {
 			});
 
 			it("should locate grid texts properly", () => {
-				const lines = chart.$.main.selectAll(`.${CLASS.xgrid}-lines .${CLASS.xgrid}-line`);
+				const lines = chart.$.main.selectAll(`.${$GRID.xgrid}-lines .${$GRID.xgrid}-line`);
 				const expectedPositions = ["start", "middle", "end"];
 				const expectedDxs = [4, 0, -4];
 
@@ -430,11 +430,11 @@ describe("GRID", function() {
 			});
 
 			it("should show 3 grid lines", () => {
-				expect(chart.$.main.selectAll(`.${CLASS.xgrid}-lines .${CLASS.xgrid}-line`).size()).to.be.equal(3);
+				expect(chart.$.main.selectAll(`.${$GRID.xgrid}-lines .${$GRID.xgrid}-line`).size()).to.be.equal(3);
 			});
 
 			it("should locate grid lines properly", done => {
-				const lines = chart.$.main.selectAll(`.${CLASS.xgrid}-lines .${CLASS.xgrid}-line`);
+				const lines = chart.$.main.selectAll(`.${$GRID.xgrid}-lines .${$GRID.xgrid}-line`);
 				const expectedY1s = [144, 283, 421];
 
 				setTimeout(() => {
@@ -448,7 +448,7 @@ describe("GRID", function() {
 			});
 
 			it("should locate grid texts properly", () => {
-				const lines = chart.$.main.selectAll(`.${CLASS.xgrid}-lines .${CLASS.xgrid}-line`);
+				const lines = chart.$.main.selectAll(`.${$GRID.xgrid}-lines .${$GRID.xgrid}-line`);
 				const expectedPositions = ["start", "middle", "end"];
 				const expectedDxs = [4, 0, -4];
 
@@ -486,7 +486,7 @@ describe("GRID", function() {
 			});
 
 			it("should show x grid lines", done => {
-				const lines = chart.$.main.select(`.${CLASS.xgrid}-lines .${CLASS.xgrid}-line`);
+				const lines = chart.$.main.select(`.${$GRID.xgrid}-lines .${$GRID.xgrid}-line`);
 				const expectedX1 = 593;
 				const expectedText = ["Label 3"];
 
@@ -533,7 +533,7 @@ describe("GRID", function() {
 			});
 
 			it("should show x grid lines", done => {
-				const lines = chart.$.main.selectAll(`.${CLASS.xgrid}-lines .${CLASS.xgrid}-line`);
+				const lines = chart.$.main.selectAll(`.${$GRID.xgrid}-lines .${$GRID.xgrid}-line`);
 				const expectedX1 = [524, 75];
 				const expectedText = ["Label 3", "Label a"];
 
@@ -841,7 +841,7 @@ describe("GRID", function() {
 
 		it("Grid text position should be updated", done => {
 			const {main} = chart.$;
-			const eventRect = main.select(`.${CLASS.eventRect}-75`).node();
+			const eventRect = main.select(`.${$EVENT.eventRect}-75`).node();
 
 			new Promise((resolve, reject) => {
 				util.fireEvent(eventRect, "mousedown", {
@@ -868,7 +868,7 @@ describe("GRID", function() {
 						clientY: 150
 					}, chart);
 
-					main.selectAll(`.${CLASS.gridLines} .${CLASS.xgridLine}`).each(function() {
+					main.selectAll(`.${$GRID.gridLines} .${$GRID.xgridLine}`).each(function() {
 						const lineX = +this.querySelector("line").getAttribute("x1");
 						const textY = +this.querySelector("text").getAttribute("y");
 

--- a/test/internals/legend-spec.ts
+++ b/test/internals/legend-spec.ts
@@ -8,7 +8,7 @@ import sinon from "sinon";
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$FOCUS, $LEGEND} from "../../src/config/classes";
 
 describe("LEGEND", () => {
 	let chart;
@@ -344,7 +344,7 @@ describe("LEGEND", () => {
 
 		it("check for legend template setting with template string", () => {
 			const legend = d3Select("#legend");
-			const items = legend.selectAll(`.${CLASS.legendItem}`);
+			const items = legend.selectAll(`.${$LEGEND.legendItem}`);
 
 			expect(legend.html()).not.to.be.null;
 
@@ -365,7 +365,7 @@ describe("LEGEND", () => {
 		});
 
 		it("custom legend should behaves as normal legend", done => {
-			const selector = `.${CLASS.legendItem}-data1`;
+			const selector = `.${$LEGEND.legendItem}-data1`;
 			const legend = chart.$.legend.select(selector).node();
 			const rect = legend.getBoundingClientRect();
 
@@ -374,7 +374,7 @@ describe("LEGEND", () => {
 				clientY: rect.y
 			}, chart);
 
-			expect(legend.classList.contains(CLASS.legendItemFocused)).to.be.true;
+			expect(legend.classList.contains($FOCUS.legendItemFocused)).to.be.true;
 
 			util.fireEvent(legend, "click", {
 				clientX: rect.x,
@@ -382,7 +382,7 @@ describe("LEGEND", () => {
 			}, chart);
 
 			setTimeout(() => {
-				expect(chart.$.legend.select(selector).classed(CLASS.legendItemHidden)).to.be.true;
+				expect(chart.$.legend.select(selector).classed($LEGEND.legendItemHidden)).to.be.true;
 				done();
 			}, 300);
 		});
@@ -415,7 +415,7 @@ describe("LEGEND", () => {
 
 		it("check for legend template setting with template function callback", () => {
 			const legend = d3Select("#legend");
-			const items = legend.selectAll(`.${CLASS.legendItem}`);
+			const items = legend.selectAll(`.${$LEGEND.legendItem}`);
 
 			expect(legend.html()).not.to.be.null;
 
@@ -487,7 +487,7 @@ describe("LEGEND", () => {
 
 		it("should render custom points in legend", () => {
 			const {$el} = chart.internal;
-			const nodes = $el.svg.selectAll(`.${CLASS.legendItem} .${CLASS.legendItemPoint}`);
+			const nodes = $el.svg.selectAll(`.${$LEGEND.legendItem} .${$LEGEND.legendItemPoint}`);
 			const pointTagName = ["circle", "rect", "use", "circle"];
 
 			nodes.each(function(data, idx, selection) {
@@ -534,7 +534,7 @@ describe("LEGEND", () => {
 		it('selects the color from color_pattern if color_treshold is given', function () {
 			const tileColor = [];
 
-			chart.internal.$el.svg.selectAll(`.${CLASS.legendItemTile}`).each(function () {
+			chart.internal.$el.svg.selectAll(`.${$LEGEND.legendItemTile}`).each(function () {
 				tileColor.push(d3Select(this).style('stroke'));
 			});
 
@@ -592,7 +592,7 @@ describe("LEGEND", () => {
 		it("selects the color from data_colors, data_color or default", function() {
 			const tileColor = [];
 
-			chart.internal.$el.svg.selectAll(`.${CLASS.legendItemTile}`)
+			chart.internal.$el.svg.selectAll(`.${$LEGEND.legendItemTile}`)
 				.each(function() {
 					tileColor.push(d3Select(this).style("stroke"));
 				});
@@ -626,7 +626,7 @@ describe("LEGEND", () => {
 		});
 
 		it("check legend item after click", () => {
-			const legend = chart.$.legend.select(`.${CLASS.legendItem}-data2`);
+			const legend = chart.$.legend.select(`.${$LEGEND.legendItem}-data2`);
 			const {x, y} = legend.node().getBoundingClientRect();
 			
 			util.fireEvent(legend.node(), "mouseover", {
@@ -639,7 +639,7 @@ describe("LEGEND", () => {
 				clientY: y
 			}, chart);
 
-			expect(legend.classed(CLASS.legendItemFocused)).to.false;
+			expect(legend.classed($FOCUS.legendItemFocused)).to.false;
 		});
 	});
 

--- a/test/internals/selection-spec.ts
+++ b/test/internals/selection-spec.ts
@@ -11,7 +11,7 @@ import {
 	selectAll as d3SelectAll
 } from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$SHAPE, $SELECT} from "../../src/config/classes";
 
 describe("SELECTION", () => {
 	let chart;
@@ -45,7 +45,7 @@ describe("SELECTION", () => {
 			});
 
 			it("multiple selection & onselected callback", () => {
-				let circle = util.getBBox(d3Select(`.${CLASS.shape}-3`));
+				let circle = util.getBBox(d3Select(`.${$SHAPE.shape}-3`));
 				const rect = chart.internal.$el.eventRect.node();
 
 				util.fireEvent(rect, "click", {
@@ -55,7 +55,7 @@ describe("SELECTION", () => {
 
 				expect(spySelected.calledOnce).to.be.true;
 
-				circle = util.getBBox(d3Select(`.${CLASS.shape}-4`));
+				circle = util.getBBox(d3Select(`.${$SHAPE.shape}-4`));
 
 				util.fireEvent(rect, "click", {
 					clientX: circle.x,
@@ -65,7 +65,7 @@ describe("SELECTION", () => {
 				expect(spySelected.calledTwice).to.be.true;
 
 				// should be selected multiple data points
-				expect(d3SelectAll(`.${CLASS.SELECTED}`).size() > 1).to.be.true;
+				expect(d3SelectAll(`.${$SELECT.SELECTED}`).size() > 1).to.be.true;
 			});
 
 			it("set options data.selection.multiple=false", () => {
@@ -73,7 +73,7 @@ describe("SELECTION", () => {
 			});
 
 			it("one selection & onunselected callback", () => {
-				let circle = util.getBBox(d3Select(`.${CLASS.shape}-3`));
+				let circle = util.getBBox(d3Select(`.${$SHAPE.shape}-3`));
 				const rect = chart.internal.$el.eventRect.node();
 
 				util.fireEvent(rect, "click", {
@@ -83,7 +83,7 @@ describe("SELECTION", () => {
 
 				expect(spySelected.calledOnce).to.be.true;
 
-				circle = util.getBBox(d3Select(`.${CLASS.shape}-4`));
+				circle = util.getBBox(d3Select(`.${$SHAPE.shape}-4`));
 
 				util.fireEvent(rect, "click", {
 					clientX: circle.x,
@@ -94,11 +94,11 @@ describe("SELECTION", () => {
 				expect(spyUnSelected.calledOnce).to.be.true;
 
 				// should be selected one data point only
-				expect(d3SelectAll(`.${CLASS.SELECTED}`).size() === 1).to.be.true;
+				expect(d3SelectAll(`.${$SELECT.SELECTED}`).size() === 1).to.be.true;
 			});
 
 			it("onselected & onunselected callback should be called once", () => {
-				const circle = util.getBBox(d3Select(`.${CLASS.shape}-3`));
+				const circle = util.getBBox(d3Select(`.${$SHAPE.shape}-3`));
 				const rect = chart.internal.$el.eventRect.node();
 
 				util.fireEvent(rect, "click", {
@@ -120,7 +120,7 @@ describe("SELECTION", () => {
 			});
 
 			it("grouped selections & onunselected callback", () => {
-				let circle = util.getBBox(d3Select(`.${CLASS.shape}-3`));
+				let circle = util.getBBox(d3Select(`.${$SHAPE.shape}-3`));
 				const rect = chart.internal.$el.eventRect.node();
 
 				util.fireEvent(rect, "click", {
@@ -130,7 +130,7 @@ describe("SELECTION", () => {
 
 				expect(spySelected.calledTwice).to.be.true;
 
-				circle = util.getBBox(d3Select(`.${CLASS.shape}-4`));
+				circle = util.getBBox(d3Select(`.${$SHAPE.shape}-4`));
 
 				util.fireEvent(rect, "click", {
 					clientX: circle.x,
@@ -141,7 +141,7 @@ describe("SELECTION", () => {
 				expect(spyUnSelected.calledTwice).to.be.true;
 
 				// should be selected 2 data points only
-				expect(d3SelectAll(`.${CLASS.SELECTED}`).size() === 2).to.be.true;
+				expect(d3SelectAll(`.${$SELECT.SELECTED}`).size() === 2).to.be.true;
 			});
 		});
 	});

--- a/test/internals/text-spec.ts
+++ b/test/internals/text-spec.ts
@@ -8,7 +8,7 @@ import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import {format as d3Format} from "d3-format";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $SHAPE, $TEXT} from "../../src/config/classes";
 import {isNumber} from "../../src/module/util";
 
 describe("TEXT", () => {
@@ -68,7 +68,7 @@ describe("TEXT", () => {
 				};
 
 				Object.keys(expectedTextY).forEach(key => {
-					chart.$.main.selectAll(`.${CLASS.texts}-${key} text.${CLASS.text}`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-${key} text.${$TEXT.text}`)
 						.each(checkXY(expectedTextX[key], expectedTextY[key], "", 3));
 				});
 			});
@@ -95,7 +95,7 @@ describe("TEXT", () => {
 				};
 
 				Object.keys(expectedTextY).forEach(key => {
-					chart.$.main.selectAll(`.${CLASS.texts}-${key} text.${CLASS.text}`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-${key} text.${$TEXT.text}`)
 						.each(checkXY(expectedTextX[key], expectedTextY[key], "", 3));
 				});
 			});
@@ -124,7 +124,7 @@ describe("TEXT", () => {
 				};
 
 				Object.keys(expectedTextY).forEach(key => {
-					chart.$.main.selectAll(`.${CLASS.texts}-${key} text.${CLASS.text}`).each(function(d, i) {
+					chart.$.main.selectAll(`.${$TEXT.texts}-${key} text.${$TEXT.text}`).each(function(d, i) {
 						const text = d3Select(this);
 
 						expect(+text.attr("y")).to.be.closeTo(expectedTextY[key][i] - 20, 3);
@@ -213,7 +213,7 @@ describe("TEXT", () => {
 				};
 
 				Object.keys(expectedTextY).forEach(key => {
-					chart.$.main.selectAll(`.${CLASS.texts}-${key} text.${CLASS.text}`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-${key} text.${$TEXT.text}`)
 						.each(checkXY(expectedTextX[key], expectedTextY[key], "", 3));
 				});
 			});
@@ -240,7 +240,7 @@ describe("TEXT", () => {
 				};
 
 				Object.keys(expectedTextY).forEach(key => {
-					chart.$.main.selectAll(`.${CLASS.texts}-${key} text.${CLASS.text}`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-${key} text.${$TEXT.text}`)
 						.each(checkXY(expectedTextX[key], expectedTextY[key], "", 4));
 				});
 			});
@@ -280,7 +280,7 @@ describe("TEXT", () => {
 				};
 
 				Object.keys(expectedTextY).forEach(key => {
-					chart.$.main.selectAll(`.${CLASS.texts}-${key} text.${CLASS.text}`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-${key} text.${$TEXT.text}`)
 						.each(checkXY(expectedTextX[key], expectedTextY[key], "", 3));
 				});
 			});
@@ -307,7 +307,7 @@ describe("TEXT", () => {
 				};
 
 				Object.keys(expectedTextY).forEach(key => {
-					chart.$.main.selectAll(`.${CLASS.texts}-${key} text.${CLASS.text}`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-${key} text.${$TEXT.text}`)
 						.each(checkXY(expectedTextX[key], expectedTextY[key], "", 4));
 				});
 			});
@@ -375,15 +375,15 @@ describe("TEXT", () => {
 			it("should have data labels on all data", () => {
 				const main = chart.$.main;
 
-				main.selectAll(`.${CLASS.texts}-data1 text`).each(function(d, i) {
+				main.selectAll(`.${$TEXT.texts}-data1 text`).each(function(d, i) {
 					expect(d3Select(this).text()).to.equal(`${args.data.columns[0][i + 1]}`);
 				});
 
-				main.selectAll(`.${CLASS.texts}-data2 text`).each(function(d, i) {
+				main.selectAll(`.${$TEXT.texts}-data2 text`).each(function(d, i) {
 					expect(d3Select(this).text()).to.equal(`${args.data.columns[1][i + 1]}`);
 				});
 
-				main.selectAll(`.${CLASS.texts}-data3 text`).each(function(d, i) {
+				main.selectAll(`.${$TEXT.texts}-data3 text`).each(function(d, i) {
 					expect(d3Select(this).text()).to.equal(`${args.data.columns[2][i + 1]}`);
 				});
 			});
@@ -411,15 +411,15 @@ describe("TEXT", () => {
 				it("should have data labels on all data", () => {
 					const main = chart.$.main;
 
-					main.selectAll(`.${CLASS.texts}-data1 text`).each(function(d, i) {
+					main.selectAll(`.${$TEXT.texts}-data1 text`).each(function(d, i) {
 						expect(d3Select(this).text()).to.equal(`${args.data.columns[0][i + 1]}`);
 					});
 
-					main.selectAll(`.${CLASS.texts}-data2 text`).each(function() {
+					main.selectAll(`.${$TEXT.texts}-data2 text`).each(function() {
 						expect(d3Select(this).text()).to.be.equal("");
 					});
 
-					main.selectAll(`.${CLASS.texts}-data3 text`).each(function() {
+					main.selectAll(`.${$TEXT.texts}-data3 text`).each(function() {
 						expect(d3Select(this).text()).to.be.equal("");
 					});
 				});
@@ -446,15 +446,15 @@ describe("TEXT", () => {
 				it("should have data labels on all data", () => {
 					const main = chart.$.main;
 
-					main.selectAll(`.${CLASS.texts}-data1 text`).each(function(d, i) {
+					main.selectAll(`.${$TEXT.texts}-data1 text`).each(function(d, i) {
 						expect(d3Select(this).text()).to.equal(`$${args.data.columns[0][i + 1]}`);
 					});
 
-					main.selectAll(`.${CLASS.texts}-data2 text`).each(function() {
+					main.selectAll(`.${$TEXT.texts}-data2 text`).each(function() {
 						expect(d3Select(this).text()).to.equal("");
 					});
 
-					main.selectAll(`.${CLASS.texts}-data3 text`).each(function() {
+					main.selectAll(`.${$TEXT.texts}-data3 text`).each(function() {
 						expect(d3Select(this).text()).to.equal("");
 					});
 				});
@@ -511,7 +511,7 @@ describe("TEXT", () => {
 					const expectedYs = [68, 50, 68, 423];
 					const expectedXs = [75, 225, 374, 524];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 2));
 				});
 
@@ -530,7 +530,7 @@ describe("TEXT", () => {
 					const expectedYs = [375, 40, 375, 422];
 					const expectedXs = [6, 202, 397, 593];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 2));
 				});
 			});
@@ -556,7 +556,7 @@ describe("TEXT", () => {
 					const expectedYs = [51, 145, 235, 327];
 					const expectedXs = [488.5, 514, 488.5, 4];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 4));
 				});
 
@@ -575,7 +575,7 @@ describe("TEXT", () => {
 					const expectedYs = [9, 130, 249, 370];
 					const expectedXs = [76, 526, 76, 4];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 4));
 				});
 			});
@@ -613,7 +613,7 @@ describe("TEXT", () => {
 					const expectedYs = [385, 11, 385, 12];
 					const expectedXs = [74, 221, 368, 515];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 5));
 				});
 
@@ -632,7 +632,7 @@ describe("TEXT", () => {
 					const expectedYs = [394, 60, 394, 39];
 					const expectedXs = [6, 198, 391, 583];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 4));
 				});
 			});
@@ -659,7 +659,7 @@ describe("TEXT", () => {
 					const expectedYs = [57, 162, 269, 375];
 					const expectedXs = [80, 584, 80, 514];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", {x: 10, y: 5}));
 				});
 
@@ -680,7 +680,7 @@ describe("TEXT", () => {
 					const expectedYs = [9, 147, 286, 424];
 					const expectedXs = [69, 527, 69, 527]; // 72.50132230092231
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", {x: 4, y: 2}));
 				});
 			});
@@ -715,7 +715,7 @@ describe("TEXT", () => {
 					const expectedYs = [392, 43, 52, 215];
 					const expectedXs = [74, 221, 368, 515];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", {x: 10, y: 3}));
 				});
 
@@ -734,7 +734,7 @@ describe("TEXT", () => {
 					const expectedYs = [395, 40, 49, 211];
 					const expectedXs = [6, 198, 391, 583];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", {x: 10, y: 3}));
 				});
 			});
@@ -758,7 +758,7 @@ describe("TEXT", () => {
 					const expectedYs = [57, 163, 269, 375];
 					const expectedXs = [72, 525, 513, 295];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", {x: 4, y: 2}));
 				});
 
@@ -777,7 +777,7 @@ describe("TEXT", () => {
 					const expectedYs = [9, 147, 286, 424];
 					const expectedXs = [70, 527, 515, 297];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", {x: 4, y: 2}));
 				});
 			});
@@ -811,7 +811,7 @@ describe("TEXT", () => {
 					const expectedYs = [385, 317, 370, 164];
 					const expectedXs = [74, 225, 374, 524];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 2));
 				});
 
@@ -830,7 +830,7 @@ describe("TEXT", () => {
 					const expectedYs = [344, 284, 331, 144];
 					const expectedXs = [6, 202, 397, 593];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 2));
 				});
 			});
@@ -854,7 +854,7 @@ describe("TEXT", () => {
 					const expectedYs = [57, 163, 269, 375];
 					const expectedXs = [57, 150, 77, 362];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 2));
 				});
 
@@ -873,7 +873,7 @@ describe("TEXT", () => {
 					const expectedYs = [9, 147, 286, 424];
 					const expectedXs = [107, 192, 125, 386];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 2));
 				});
 			});
@@ -907,7 +907,7 @@ describe("TEXT", () => {
 					const expectedYs = [50, 117, 64, 270];
 					const expectedXs = [74, 221, 368, 515];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 10));
 				});
 
@@ -926,7 +926,7 @@ describe("TEXT", () => {
 					const expectedYs = [90, 151, 103, 290];
 					const expectedXs = [6, 198, 391, 583];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 10));
 				});
 			});
@@ -950,7 +950,7 @@ describe("TEXT", () => {
 					const expectedYs = [57, 163, 269, 375];
 					const expectedXs = [533, 441, 513, 232];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 3));
 				});
 
@@ -969,7 +969,7 @@ describe("TEXT", () => {
 					const expectedYs = [9, 147, 286, 424];
 					const expectedXs = [479, 397, 461, 206];
 
-					chart.$.main.selectAll(`.${CLASS.texts}-data1 text`)
+					chart.$.main.selectAll(`.${$TEXT.texts}-data1 text`)
 						.each(checkXY(expectedXs, expectedYs, "", 5));
 				});
 			});
@@ -990,7 +990,7 @@ describe("TEXT", () => {
 
 			it("data text label should be generated", () => {
 				const data = chart.data.values("data1");
-				const texts = chart.$.main.selectAll(`.${CLASS.chartText} text.${CLASS.text}`);
+				const texts = chart.$.main.selectAll(`.${$TEXT.chartText} text.${$TEXT.text}`);
 
 				expect(texts.size()).to.be.equal(data.length);
 			});
@@ -999,7 +999,7 @@ describe("TEXT", () => {
 				args.scatter = {zerobased: true};
 				chart = util.generate(args);
 
-				const tickNodes = chart.$.svg.select(`.${CLASS.axisY}`).selectAll("g.tick");
+				const tickNodes = chart.$.svg.select(`.${$AXIS.axisY}`).selectAll("g.tick");
 				const translateValues = [426, 389, 352, 314, 277, 240, 202, 165, 127, 90, 53, 15];
 
 				tickNodes.each(function(d, i) {
@@ -1011,7 +1011,7 @@ describe("TEXT", () => {
 				args.scatter = {zerobased: false};
 				chart = util.generate(args);
 
-				const tickNodes = chart.$.svg.select(`.${CLASS.axisY}`).selectAll("g.tick");
+				const tickNodes = chart.$.svg.select(`.${$AXIS.axisY}`).selectAll("g.tick");
 				const translateValues = [402, 367, 331, 296, 260, 225, 189, 154, 118, 83, 47, 12];
 
 				tickNodes.each(function(d, i) {
@@ -1042,14 +1042,14 @@ describe("TEXT", () => {
 			it("should draw points for the scatterplot", () => {
 				const id = "data1";
 				const data = chart.data.values(id);
-				const points = chart.$.main.selectAll(`.${CLASS.shapes}-${id} circle`);
+				const points = chart.$.main.selectAll(`.${$SHAPE.shapes}-${id} circle`);
 
 				expect(points.size()).to.be.equal(data.length);
 			});
 
 			it("should not draw points for the linechart", () => {
 				const id = "data2";
-				const points = chart.$.main.selectAll(`.${CLASS.shapes}-${id} circle`);
+				const points = chart.$.main.selectAll(`.${$SHAPE.shapes}-${id} circle`);
 
 				expect(points.size()).to.be.equal(0);
 			});
@@ -1073,14 +1073,14 @@ describe("TEXT", () => {
 			it("should draw points for the first line", () => {
 				const id = "data1";
 				const data = chart.data.values(id);
-				const points = chart.$.main.selectAll(`.${CLASS.shapes}-${id} circle`);
+				const points = chart.$.main.selectAll(`.${$SHAPE.shapes}-${id} circle`);
 
 				expect(points.size()).to.be.equal(data.length);
 			});
 
 			it("should not draw points for the second line", () => {
 				const id = "data2";
-				const points = chart.$.main.selectAll(`.${CLASS.shapes}-${id} circle`);
+				const points = chart.$.main.selectAll(`.${$SHAPE.shapes}-${id} circle`);
 
 				expect(points.size()).to.be.equal(0);
 			});
@@ -1107,7 +1107,7 @@ describe("TEXT", () => {
 
 				setTimeout(() => {
 					interval = setInterval(() => {
-						text = main.select(`.${CLASS.texts}-data2 .${CLASS.text}-3`);
+						text = main.select(`.${$TEXT.texts}-data2 .${$TEXT.text}-3`);
 						pos.push(+text.attr("x"));
 					}, 20);
 

--- a/test/internals/tooltip-spec.ts
+++ b/test/internals/tooltip-spec.ts
@@ -10,7 +10,7 @@ import {
 	namespaces as d3Namespaces
 } from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$SHAPE, $TOOLTIP} from "../../src/config/classes";
 
 describe("TOOLTIP", function() {
 	let chart;
@@ -72,7 +72,7 @@ describe("TOOLTIP", function() {
 
 		if (expected) {
 			for (let i = 1, el; (el = tooltips[i]); i++) {
-				expect(el.className).to.be.equal(`${CLASS.tooltipName}-${expected[i - 1]}`);
+				expect(el.className).to.be.equal(`${$TOOLTIP.tooltipName}-${expected[i - 1]}`);
 			}
 		}
 	};
@@ -219,7 +219,7 @@ describe("TOOLTIP", function() {
 			it("should show tooltip on proper position", done => {
 				const tooltip = chart.$.tooltip;
 				const circles = chart.$.circles;
-				const getCircleRectX = x => circles.filter(`.${CLASS.shape}-${x}`)
+				const getCircleRectX = x => circles.filter(`.${$SHAPE.shape}-${x}`)
 					.node().getBoundingClientRect().x;
 
 				// when
@@ -660,9 +660,9 @@ describe("TOOLTIP", function() {
 	describe("tooltip order", () => {
 		it("should sort values in data display order", () => {
 			checkTooltip(chart, [
-				`${CLASS.tooltipName}-data1`,
-				`${CLASS.tooltipName}-data2`,
-				`${CLASS.tooltipName}-data3`
+				`${$TOOLTIP.tooltipName}-data1`,
+				`${$TOOLTIP.tooltipName}-data2`,
+				`${$TOOLTIP.tooltipName}-data3`
 			]);
 		});
 
@@ -672,9 +672,9 @@ describe("TOOLTIP", function() {
 
 		it("should sort values in ascending order", () => {
 			checkTooltip(chart, [
-				`${CLASS.tooltipName}-data2`,
-				`${CLASS.tooltipName}-data1`,
-				`${CLASS.tooltipName}-data3`
+				`${$TOOLTIP.tooltipName}-data2`,
+				`${$TOOLTIP.tooltipName}-data1`,
+				`${$TOOLTIP.tooltipName}-data3`
 			]);
 		});
 
@@ -684,9 +684,9 @@ describe("TOOLTIP", function() {
 
 		it("should sort values in descending order", () => {
 			checkTooltip(chart, [
-				`${CLASS.tooltipName}-data3`,
-				`${CLASS.tooltipName}-data1`,
-				`${CLASS.tooltipName}-data2`
+				`${$TOOLTIP.tooltipName}-data3`,
+				`${$TOOLTIP.tooltipName}-data1`,
+				`${$TOOLTIP.tooltipName}-data2`
 			]);
 		});
 
@@ -699,9 +699,9 @@ describe("TOOLTIP", function() {
 
 		it("stacked bar: should sort values in descending order", () => {
 			checkTooltip(chart, [
-				`${CLASS.tooltipName}-data3`,
-				`${CLASS.tooltipName}-data1`,
-				`${CLASS.tooltipName}-data2`
+				`${$TOOLTIP.tooltipName}-data3`,
+				`${$TOOLTIP.tooltipName}-data1`,
+				`${$TOOLTIP.tooltipName}-data2`
 			]);
 		});
 
@@ -711,9 +711,9 @@ describe("TOOLTIP", function() {
 
 		it("stacked bar: should sort values in ascending order", () => {
 			checkTooltip(chart, [
-				`${CLASS.tooltipName}-data2`,
-				`${CLASS.tooltipName}-data1`,
-				`${CLASS.tooltipName}-data3`
+				`${$TOOLTIP.tooltipName}-data2`,
+				`${$TOOLTIP.tooltipName}-data1`,
+				`${$TOOLTIP.tooltipName}-data3`
 			]);
 		});
 
@@ -723,9 +723,9 @@ describe("TOOLTIP", function() {
 
 		it("stacked bar: should be ordered in data input order", () => {
 			checkTooltip(chart, [
-				`${CLASS.tooltipName}-data3`,
-				`${CLASS.tooltipName}-data2`,
-				`${CLASS.tooltipName}-data1`
+				`${$TOOLTIP.tooltipName}-data3`,
+				`${$TOOLTIP.tooltipName}-data2`,
+				`${$TOOLTIP.tooltipName}-data1`
 			]);
 		});
 
@@ -1007,14 +1007,14 @@ describe("TOOLTIP", function() {
 				clientY: 107
 			});
 
-			let value = +chart.$.tooltip.select(`.${CLASS.tooltipName}-data3 .value`).text();
+			let value = +chart.$.tooltip.select(`.${$TOOLTIP.tooltipName}-data3 .value`).text();
 
 			expect(value).to.be.equal(800);
 
 			// check for circle point shape
 			util.hoverChart(chart, undefined, {clientX: 292, clientY: 34});
 
-			value = +chart.$.tooltip.select(`.${CLASS.tooltipName}-data1 .value`).html();
+			value = +chart.$.tooltip.select(`.${$TOOLTIP.tooltipName}-data1 .value`).html();
 
 			expect(value).to.be.equal(1000);
 		});
@@ -1073,11 +1073,11 @@ describe("TOOLTIP", function() {
 			// check for custom point shape
 			util.hoverChart(chart, undefined, {clientX: 185, clientY: 107});
 
-			let value = chart.$.tooltip.select(`.${CLASS.tooltipName}-data1 .value`).text();
+			let value = chart.$.tooltip.select(`.${$TOOLTIP.tooltipName}-data1 .value`).text();
 
 			expect(value).to.be.equal("Mid: 135 High: 160 Low: 120");
 
-			value = +chart.$.tooltip.select(`.${CLASS.tooltipName}-data2 .value`).text();
+			value = +chart.$.tooltip.select(`.${$TOOLTIP.tooltipName}-data2 .value`).text();
 
 			expect(value).to.be.equal(200);
 		});

--- a/test/plugin/sparkline/sparkline-spec.ts
+++ b/test/plugin/sparkline/sparkline-spec.ts
@@ -4,7 +4,7 @@
  */
 /* eslint-disable */
 import {expect} from "chai";
-import CLASS from "../../../src/config/classes";
+import {$CIRCLE, $COMMON} from "../../../src/config/classes";
 import Sparkline from "../../../src/Plugin/sparkline";
 import util from "../../assets/util";
 
@@ -68,10 +68,10 @@ describe("PLUGIN: SPARKLINE", () => {
 		expect(tooltip.select(".name").text()).to.be.equal("data1");
 		expect(tooltip.select(".value").text()).to.be.equal("30");
 
-		const circle = svg.querySelector(`.${CLASS.EXPANDED}`);
+		const circle = svg.querySelector(`.${$COMMON.EXPANDED}`);
 
 		expect(circle).to.be.ok;
-		expect(circle.classList.contains(`${CLASS.circle}-0`)).to.be.true;
+		expect(circle.classList.contains(`${$CIRCLE.circle}-0`)).to.be.true;
 
 		// when
 		util.fireEvent(svg, "mouseout", {

--- a/test/shape/arc-spec.ts
+++ b/test/shape/arc-spec.ts
@@ -7,15 +7,15 @@
 import {expect} from "chai";
 import sinon from "sinon";
 import {selectAll as d3SelectAll} from "d3-selection";
-import CLASS from "../../src/config/classes";
+import {$ARC, $COMMON, $LEGEND, $SHAPE} from "../../src/config/classes";
 import util from "../assets/util";
 
 describe("SHAPE ARC", () => {
 	let chart;
 	const selector = {
-		arc: `.${CLASS.chartArc}.${CLASS.target}.${CLASS.target}`,
-		shapes: `g.${CLASS.shapes}.${CLASS.arcs}.${CLASS.arcs}`,
-		shape: `path.${CLASS.shape}.${CLASS.arc}.${CLASS.arc}`
+		arc: `.${$ARC.chartArc}.${$COMMON.target}.${$COMMON.target}`,
+		shapes: `g.${$SHAPE.shapes}.${$ARC.arcs}.${$ARC.arcs}`,
+		shape: `path.${$SHAPE.shape}.${$ARC.arc}.${$ARC.arc}`
 	};
 
 	after(() => {
@@ -40,11 +40,11 @@ describe("SHAPE ARC", () => {
 		});
 
 		it("should have correct classes", () => {
-			const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
+			const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
 			const selector = {
-				arc: `.${CLASS.chartArc}.${CLASS.target}.${CLASS.target}`,
-				shapes: `g.${CLASS.shapes}.${CLASS.arcs}.${CLASS.arcs}`,
-				shape: `path.${CLASS.shape}.${CLASS.arc}.${CLASS.arc}`
+				arc: `.${$ARC.chartArc}.${$COMMON.target}.${$COMMON.target}`,
+				shapes: `g.${$SHAPE.shapes}.${$ARC.arcs}.${$ARC.arcs}`,
+				shape: `path.${$SHAPE.shape}.${$ARC.arc}.${$ARC.arc}`
 			}
 
 			const arcs = {
@@ -67,13 +67,13 @@ describe("SHAPE ARC", () => {
 		it("should have correct d", () => {
 			const main = chart.$.main;
 
-			expect(main.select(`.${CLASS.arc}-data1`).attr("d"))
+			expect(main.select(`.${$ARC.arc}-data1`).attr("d"))
 				.to.match(/M-124\..+,-171\..+A211\..+,211\..+,0,0,1,-3\..+,-211\..+L0,0Z/);
 
-			expect(main.select(`.${CLASS.arc}-data2`).attr("d"))
+			expect(main.select(`.${$ARC.arc}-data2`).attr("d"))
 				.to.match(/M1\..+,-211\..+A211\..+,211\..+,0,0,1,1\..+,211\..+L0,0Z/);
 
-			expect(main.select(`.${CLASS.arc}-data3`).attr("d"))
+			expect(main.select(`.${$ARC.arc}-data3`).attr("d"))
 				.to.match(/M1\..+,211\..+A211\..+,211\..+,0,0,1,-124\..+,-171\..+L0,0Z/);
 		});
 
@@ -85,7 +85,7 @@ describe("SHAPE ARC", () => {
 			chart.hide("data1");
 
 			chart.data.shown().map(v => v.id)
-				.forEach(id => total += parseFloat(arc.select(`.${CLASS.target}-${id} text`).text()));
+				.forEach(id => total += parseFloat(arc.select(`.${$COMMON.target}-${id} text`).text()));
 
 			expect(total).to.be.equal(100);
 		});
@@ -103,7 +103,7 @@ describe("SHAPE ARC", () => {
 			});
 
 			setTimeout(() => {
-				expect(chart.$.main.select(`.${CLASS.arc}-black`).attr("d"))
+				expect(chart.$.main.select(`.${$ARC.arc}-black`).attr("d"))
 					.to.match(/M-124\..+,-171\..+A211\..+,211\..+,0,0,1,-3\..+,-211\..+L0,0Z/);
 
 				done();
@@ -129,7 +129,7 @@ describe("SHAPE ARC", () => {
 		});
 
 		it("should have correct d attribute", () => {
-			const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
+			const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
 			const arcs = {
 				data1: chartArc.select(`${selector.arc}-data1`)
 					.select(`${selector.shapes}-data1`)
@@ -164,9 +164,9 @@ describe("SHAPE ARC", () => {
 			});
 
 			expect(chart.internal.pie.padAngle()()).to.be.equal(value);
-			expect(chart.$.main.selectAll(`text.${CLASS.chartArcsTitle} tspan`).size()).to.be.equal(3);
+			expect(chart.$.main.selectAll(`text.${$ARC.chartArcsTitle} tspan`).size()).to.be.equal(3);
 
-			d3SelectAll(`.${CLASS.chartArc} text`).each(function(d) {
+			d3SelectAll(`.${$ARC.chartArc} text`).each(function(d) {
 				// @ts-ignore
 				const value = parseInt(this.textContent);
 
@@ -197,7 +197,7 @@ describe("SHAPE ARC", () => {
 			expect(internal.pie.padAngle()()).to.be.equal(padding * 0.01);
 			expect(internal.state.innerRadius).to.be.equal(innerRadius);
 
-			d3SelectAll(`.${CLASS.chartArc} text`).each(function(d) {
+			d3SelectAll(`.${$ARC.chartArc} text`).each(function(d) {
 				// @ts-ignore
 				const value = parseInt(this.textContent);
 
@@ -411,7 +411,7 @@ describe("SHAPE ARC", () => {
 
 		it("should interact properly for mouseover & mouseout", done => {
 			setTimeout(() => {
-				const path = chart.$.main.select(`path.${CLASS.arc}-data2`).node();
+				const path = chart.$.main.select(`path.${$ARC.arc}-data2`).node();
 
 				util.fireEvent(path, "mouseover", {
 					clientX: 500,
@@ -449,7 +449,7 @@ describe("SHAPE ARC", () => {
 
 		it("the dimension should be 0x0", () => {
 			["data2", "data3"].forEach(id => {
-				const rect = chart.$.arc.select(`.${CLASS.arc}-${id}`).node().getBBox();
+				const rect = chart.$.arc.select(`.${$ARC.arc}-${id}`).node().getBBox();
 
 				expect(rect.width === 0).to.be.true;
 				expect(rect.height === 0).to.be.true;
@@ -567,7 +567,7 @@ describe("SHAPE ARC", () => {
 						["data2", 6],
 					],
 					done: () => {
-						const legend = chart.$.legend.select(`.${CLASS.legendItem}-data2`).node();
+						const legend = chart.$.legend.select(`.${$LEGEND.legendItem}-data2`).node();
 
 						util.fireEvent(legend, "mouseover");
 						util.fireEvent(legend, "mouseout");
@@ -689,7 +689,7 @@ describe("SHAPE ARC", () => {
 			new Promise((resolve, reject) => {
 				setTimeout(() => {
 					path = chart.$.arc
-						.select(`.${CLASS.arc}-data1`)
+						.select(`.${$ARC.arc}-data1`)
 						.node();
 
 					length = path.getTotalLength();

--- a/test/shape/area-spec.ts
+++ b/test/shape/area-spec.ts
@@ -6,7 +6,7 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
-import CLASS from "../../src/config/classes";
+import {$AREA, $AXIS, $CIRCLE, $COMMON, $LINE} from "../../src/config/classes";
 import util from "../assets/util";
 
 describe("SHAPE AREA", () => {
@@ -54,7 +54,7 @@ describe("SHAPE AREA", () => {
 		});
 
 		it("check for line path data count", () => {
-			chart.$.main.selectAll(`path.${CLASS.line}`).each(function(d) {
+			chart.$.main.selectAll(`path.${$LINE.line}`).each(function(d) {
 				const line = d3Select(this);
 
 				// it should have 4 lines
@@ -86,7 +86,7 @@ describe("SHAPE AREA", () => {
 		// check non-grouped bar path position
 		const checkBarPathPos = type => {
 			// Get x Axis pos
-			let xAxisYPos = chart.$.main.select(`.${CLASS.axisX} path`).node().getBoundingClientRect();
+			let xAxisYPos = chart.$.main.select(`.${$AXIS.axisX} path`).node().getBoundingClientRect();
 
 			xAxisYPos = type === "y" ? xAxisYPos[type] : xAxisYPos[type] + xAxisYPos.width;
 
@@ -153,8 +153,8 @@ describe("SHAPE AREA", () => {
 		});
 
 		const checkLineLen = dataName => {
-			const target = chart.$.main.select(`.${CLASS.chartLine}.${CLASS.target}-${dataName}`);
-			const commands = target.select(`.${CLASS.line}-${dataName}`).attr("d").split("C");
+			const target = chart.$.main.select(`.${$LINE.chartLine}.${$COMMON.target}-${dataName}`);
+			const commands = target.select(`.${$LINE.line}-${dataName}`).attr("d").split("C");
 			const dataLen = chart.internal.filterRemoveNull(chart.data(dataName)[0].values).length;
 
 			expect(commands.length).to.be.equal(dataLen);
@@ -207,7 +207,7 @@ describe("SHAPE AREA", () => {
 
 		it("check for correct generation", () => {
 			const d = chart.$.line.lines.attr("d");
-			const box = util.getBBox(d3Select(`.${CLASS.chartLine}.${CLASS.target}-data3`));
+			const box = util.getBBox(d3Select(`.${$LINE.chartLine}.${$COMMON.target}-data3`));
 
 			// check for correct path data
 			expect(/NaN/.test(d)).to.be.false;
@@ -242,7 +242,7 @@ describe("SHAPE AREA", () => {
 		});
 
 		function checkPath(pathData) {
-			const path = chart.$.main.selectAll(`.${CLASS.target}-data1 path`);
+			const path = chart.$.main.selectAll(`.${$COMMON.target}-data1 path`);
 
 			path.each(function(v, i) {
 				expect(this.getAttribute("d")).to.be.equal(pathData[i ? "area" : "line"]);
@@ -455,7 +455,7 @@ describe("SHAPE AREA", () => {
 					expect(+stop.attr("stop-opacity")).to.be.equal(expected.opacity[i]);
 				});
 
-				expect(chart.$.line.areas.filter(`.${CLASS.area}${selectorSuffix}`).style("fill")).to.be.equal(`url("${id}")`);
+				expect(chart.$.line.areas.filter(`.${$AREA.area}${selectorSuffix}`).style("fill")).to.be.equal(`url("${id}")`);
 			});
 		});
 
@@ -496,7 +496,7 @@ describe("SHAPE AREA", () => {
 					expect(+stop.attr("stop-opacity")).to.be.equal(stops[i][2]);
 				});
 
-				expect(chart.$.line.areas.filter(`.${CLASS.area}${selectorSuffix}`).style("fill")).to.be.equal(`url("${id}")`);
+				expect(chart.$.line.areas.filter(`.${$AREA.area}${selectorSuffix}`).style("fill")).to.be.equal(`url("${id}")`);
 			});
 		});
 
@@ -543,7 +543,7 @@ describe("SHAPE AREA", () => {
 		});
 
 		it("check stacking order: area.front=false", () => {
-			const stacking = [CLASS.areas, CLASS.lines, CLASS.circles];
+			const stacking = [$AREA.areas, $LINE.lines, $CIRCLE.circles];
 
 			chart.$.main.selectAll(".bb-chart-line > g").each(function(d, i) {
 				expect(this.classList.contains(stacking[i])).to.be.true;
@@ -555,7 +555,7 @@ describe("SHAPE AREA", () => {
 		});
 
 		it("check stacking order: area.front=true", () => {
-			const stacking = [CLASS.lines, CLASS.areas, CLASS.circles];
+			const stacking = [$LINE.lines, $AREA.areas, $CIRCLE.circles];
 
 			chart.$.main.selectAll(".bb-chart-line > g").each(function(d, i) {
 				expect(this.classList.contains(stacking[i])).to.be.true;

--- a/test/shape/bar-spec.ts
+++ b/test/shape/bar-spec.ts
@@ -7,8 +7,7 @@
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
-import State from "../../src/config/Store/State";
+import {$AXIS, $BAR, $COMMON, $EVENT, $SHAPE} from "../../src/config/classes";
 
 describe("SHAPE BAR", () => {
 	let chart;
@@ -38,7 +37,7 @@ describe("SHAPE BAR", () => {
 			it("should be stacked", () => {
 				const expectedBottom = [275, 293, 365, 281, 395, 290];
 
-				chart.$.main.selectAll(`.${CLASS.bars}-data1 .${CLASS.bar}`).each(function(d, i) {
+				chart.$.main.selectAll(`.${$BAR.bars}-data1 .${$BAR.bar}`).each(function(d, i) {
 					const rect = d3Select(this).node()
 						.getBoundingClientRect();
 
@@ -75,7 +74,7 @@ describe("SHAPE BAR", () => {
 			it("should be stacked", () => {
 				const expectedBottom = [275, 293, 365, 281, 395, 290];
 
-				chart.$.main.selectAll(`.${CLASS.bars}-data1 .${CLASS.bar}`).each(function(d, i) {
+				chart.$.main.selectAll(`.${$BAR.bars}-data1 .${$BAR.bar}`).each(function(d, i) {
 					const rect = d3Select(this).node()
 						.getBoundingClientRect();
 
@@ -95,7 +94,7 @@ describe("SHAPE BAR", () => {
 			});
 
 			it("check for bar width regardless tick count limit", () => {
-				const width = chart.$.main.select(`.${CLASS.bars}-data1 .${CLASS.bar}`).node()
+				const width = chart.$.main.select(`.${$BAR.bars}-data1 .${$BAR.bar}`).node()
 					.getBoundingClientRect().width;
 
 				expect(width).to.be.equal(barWidth);
@@ -128,7 +127,7 @@ describe("SHAPE BAR", () => {
 			it("should be stacked", () => {
 				const expectedBottom = [275, 293, 365, 281, 395, 290];
 
-				chart.$.main.selectAll(`.${CLASS.bars}-data1 .${CLASS.bar}`).each(function(d, i) {
+				chart.$.main.selectAll(`.${$BAR.bars}-data1 .${$BAR.bar}`).each(function(d, i) {
 					const rect = d3Select(this).node()
 						.getBoundingClientRect();
 
@@ -338,7 +337,7 @@ describe("SHAPE BAR", () => {
 
 			it("should not be within bar", done => {
 				const internal = chart.internal;
-				const bar = chart.$.main.select(`.${CLASS.target}-data1 .${CLASS.bar}-0`)
+				const bar = chart.$.main.select(`.${$COMMON.target}-data1 .${$BAR.bar}-0`)
 					.on("click", function(event) {
 						internal.state.event = event;
 
@@ -354,7 +353,7 @@ describe("SHAPE BAR", () => {
 
 			it("should be within bar", done => {
 				const internal = chart.internal;
-				const bar = chart.$.main.select(`.${CLASS.target}-data1 .${CLASS.bar}-0`)
+				const bar = chart.$.main.select(`.${$COMMON.target}-data1 .${$BAR.bar}-0`)
 					.on("click", function(event) {
 						internal.state.event = event;
 
@@ -370,7 +369,7 @@ describe("SHAPE BAR", () => {
 
 			it("should not be within bar of negative value", done => {
 				const internal = chart.internal;
-				const bar = chart.$.main.select(`.${CLASS.target}-data3 .${CLASS.bar}-0`)
+				const bar = chart.$.main.select(`.${$COMMON.target}-data3 .${$BAR.bar}-0`)
 					.on("click", function(event) {
 						internal.state.event = event;
 
@@ -386,7 +385,7 @@ describe("SHAPE BAR", () => {
 
 			it("should be within bar of negative value", done => {
 				const internal = chart.internal;
-				const bar = chart.$.main.select(`.${CLASS.target}-data3 .${CLASS.bar}-0`)
+				const bar = chart.$.main.select(`.${$COMMON.target}-data3 .${$BAR.bar}-0`)
 					.on("click", function(event) {
 						internal.state.event = event;
 
@@ -408,7 +407,7 @@ describe("SHAPE BAR", () => {
 
 			it("should not be within bar", done => {
 				const internal = chart.internal;
-				const bar = chart.$.main.select(`.${CLASS.target}-data1 .${CLASS.bar}-0`)
+				const bar = chart.$.main.select(`.${$COMMON.target}-data1 .${$BAR.bar}-0`)
 					.on("click", function(event) {
 						internal.state.event = event;
 
@@ -424,7 +423,7 @@ describe("SHAPE BAR", () => {
 
 			it("should be within bar", done => {
 				const internal = chart.internal;
-				const bar = chart.$.main.select(`.${CLASS.target}-data1 .${CLASS.bar}-0`)
+				const bar = chart.$.main.select(`.${$COMMON.target}-data1 .${$BAR.bar}-0`)
 					.on("click", function(event) {
 						internal.state.event = event;
 
@@ -440,7 +439,7 @@ describe("SHAPE BAR", () => {
 
 			it("should be within bar of negative value", done => {
 				const internal = chart.internal;
-				const bar = chart.$.main.select(`.${CLASS.target}-data3 .${CLASS.bar}-0`)
+				const bar = chart.$.main.select(`.${$COMMON.target}-data3 .${$BAR.bar}-0`)
 					.on("click", function(event) {
 						internal.state.event = event;
 
@@ -482,7 +481,7 @@ describe("SHAPE BAR", () => {
 		});
 
 		it("should not throw error on click", () => {
-			const bar = chart.$.main.select(`.${CLASS.eventRectsMultiple} rect`).node();
+			const bar = chart.$.main.select(`.${$EVENT.eventRectsMultiple} rect`).node();
 
 			expect(() => util.fireEvent(bar, "click")).to.not.throw();
 		});
@@ -583,23 +582,23 @@ describe("SHAPE BAR", () => {
 			const {main} = chart.$;
 
 			// check the path from the third data value
-			main.selectAll(`.${CLASS.shape}.${CLASS.bar}-2`).each(function(d, i) {
+			main.selectAll(`.${$SHAPE.shape}.${$BAR.bar}-2`).each(function(d, i) {
 				expect(removeSpace(this.getAttribute("d"))).to.be.equal(removeSpace(path[i]));
 			})
 		};
 
 		it(`bar width should be ${width}px`, () => {
-			const barWidth = util.getBBox(chart.$.main.select(`.${CLASS.chartBar} path.${CLASS.shape}`)).width;
+			const barWidth = util.getBBox(chart.$.main.select(`.${$BAR.chartBar} path.${$SHAPE.shape}`)).width;
 
 			expect(barWidth).to.be.equal(width);
 		});
 
 		it(`bar padding should be ${padding}px`, () => {
 			const {main} = chart.$;
-			const targetClass = `.${CLASS.chartBar}.${CLASS.target}`;
+			const targetClass = `.${$BAR.chartBar}.${$COMMON.target}`;
 
-			const bar1 = util.getBBox(main.select(`${targetClass}-data1 path.${CLASS.shape}`)).x + width;
-			const bar2 = util.getBBox(main.select(`${targetClass}-data2 path.${CLASS.shape}`)).x;
+			const bar1 = util.getBBox(main.select(`${targetClass}-data1 path.${$SHAPE.shape}`)).x + width;
+			const bar2 = util.getBBox(main.select(`${targetClass}-data2 path.${$SHAPE.shape}`)).x;
 
 			expect(bar2 - bar1).to.be.equal(padding);
 		});
@@ -647,7 +646,7 @@ describe("SHAPE BAR", () => {
 
 		it("each data should be rendered with different width", () => {
 			chart.data().map(v => v.id).forEach(id => {
-				chart.$.main.selectAll(`.${CLASS.bars}-${id} path`).each(function() {
+				chart.$.main.selectAll(`.${$BAR.bars}-${id} path`).each(function() {
 					expect(Math.round(this.getBBox().width)).to.be.equal(args.bar.width[id]);
 				});
 			});
@@ -668,7 +667,7 @@ describe("SHAPE BAR", () => {
 			const expected = [25, 30];
 
 			chart.data().map(v => v.id).forEach((id, i) => {
-				chart.$.main.selectAll(`.${CLASS.bars}-${id} path`).each(function() {
+				chart.$.main.selectAll(`.${$BAR.bars}-${id} path`).each(function() {
 					expect(Math.round(this.getBBox().width)).to.be.equal(expected[i]);
 				});
 			});
@@ -783,7 +782,7 @@ describe("SHAPE BAR", () => {
 		});
 
 		it("clip-path attribute should be added, to avoid wrong rendering for small values", () => {
-			const chartBars = chart.$.main.select(`.${CLASS.chartBars}`).node();
+			const chartBars = chart.$.main.select(`.${$BAR.chartBars}`).node();
 
 			expect(chartBars.getAttribute("clip-path")).to.be.ok;
 		});
@@ -881,7 +880,7 @@ describe("SHAPE BAR", () => {
 		// check non-grouped bar path position
 		const checkBarPathPos = type => {
 			// Get x Axis pos
-			let xAxisYPos = chart.$.main.select(`.${CLASS.axisX} path`).node().getBoundingClientRect();
+			let xAxisYPos = chart.$.main.select(`.${$AXIS.axisX} path`).node().getBoundingClientRect();
 
 			xAxisYPos = type === "y" ? xAxisYPos[type] : xAxisYPos[type] + xAxisYPos.width;
 	

--- a/test/shape/bubble-spec.ts
+++ b/test/shape/bubble-spec.ts
@@ -6,7 +6,7 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $CIRCLE, $TEXT} from "../../src/config/classes";
 import util from "../assets/util";
 import {isArray, isObject} from "../../src/module/util";
 
@@ -40,11 +40,11 @@ describe("SHAPE BUBBLE", () => {
 
 		it("check the radius: default", () => {
 			// check for the maximum
-			let r = +chart.$.main.select(`.${CLASS.circles}-data1 .${CLASS.circle}-3`).attr("r");
+			let r = +chart.$.main.select(`.${$CIRCLE.circles}-data1 .${$CIRCLE.circle}-3`).attr("r");
 			expect(r).to.be.equal(35);
 
 			// check for the minimum
-			r = +chart.$.main.select(`.${CLASS.circles}-data2 .${CLASS.circle}-2`).attr("r");
+			r = +chart.$.main.select(`.${$CIRCLE.circles}-data2 .${$CIRCLE.circle}-2`).attr("r");
 			expect(r).to.be.closeTo(5, 1);
 		});
 
@@ -54,7 +54,7 @@ describe("SHAPE BUBBLE", () => {
 					['data1', 500, 350, 200, 380, 10]
 				],
 				done: function() {
-					chart.$.main.selectAll(`.${CLASS.circles}-data1 circle`)
+					chart.$.main.selectAll(`.${$CIRCLE.circles}-data1 circle`)
 						.each(function(v, i) {
 							const r = +d3Select(this).attr("r");
 
@@ -76,7 +76,7 @@ describe("SHAPE BUBBLE", () => {
 		});
 
 		it("check the radius: customized", () => {
-			const r = +chart.$.main.select(`.${CLASS.circles}-data1 .${CLASS.circle}-3`).attr("r");
+			const r = +chart.$.main.select(`.${$CIRCLE.circles}-data1 .${$CIRCLE.circle}-3`).attr("r");
 
 			expect(r).to.be.equal(50);
 		});
@@ -87,7 +87,7 @@ describe("SHAPE BUBBLE", () => {
 
 		it("check for the label text", () => {
 			args.data.columns.forEach((v, i) => {
-				chart.$.main.selectAll(`.${CLASS.chartTexts}-data${i+1} text`).each(function(w, j) {
+				chart.$.main.selectAll(`.${$TEXT.chartTexts}-data${i+1} text`).each(function(w, j) {
 					expect(+d3Select(this).text()).to.be.equal(v[j+1]);
 				});
 			});
@@ -99,7 +99,7 @@ describe("SHAPE BUBBLE", () => {
 
 		it("check the radius: customized", () => {
 			const value = chart.data.values("data1")[3];
-			const r = +chart.$.main.select(`.${CLASS.circles}-data1 .${CLASS.circle}-3`).attr("r");
+			const r = +chart.$.main.select(`.${$CIRCLE.circles}-data1 .${$CIRCLE.circle}-3`).attr("r");
 
 			expect(r).to.be.equal(maxR({value}));
 		});
@@ -112,7 +112,7 @@ describe("SHAPE BUBBLE", () => {
 
 		it("check the radius: customized", () => {
 			const value = chart.data.values("data1")[3];
-			const r = +chart.$.main.select(`.${CLASS.circles}-data1 .${CLASS.circle}-3`).attr("r");
+			const r = +chart.$.main.select(`.${$CIRCLE.circles}-data1 .${$CIRCLE.circle}-3`).attr("r");
 
 			expect(r).to.be.equal(
 				chart.internal.getBubbleR({value})
@@ -128,7 +128,7 @@ describe("SHAPE BUBBLE", () => {
 		it("should be zerobased", () => {
 			chart = util.generate(args);
 
-			const tickNodes = chart.$.svg.select(`.${CLASS.axisY}`).selectAll("g.tick");
+			const tickNodes = chart.$.svg.select(`.${$AXIS.axisY}`).selectAll("g.tick");
 			const translateValues = [426, 377, 328, 279, 230, 181, 131, 82, 33];
 
 			tickNodes.each(function(d, i) {
@@ -145,7 +145,7 @@ describe("SHAPE BUBBLE", () => {
 		it("should not be zerobased", () => {
 			chart = util.generate(args);
 
-			const tickNodes = chart.$.svg.select(`.${CLASS.axisY}`).selectAll("g.tick");
+			const tickNodes = chart.$.svg.select(`.${$AXIS.axisY}`).selectAll("g.tick");
 			const translateValues = [390, 345, 300, 255, 209, 164, 119, 74, 29];
 
 			tickNodes.each(function(d, i) {

--- a/test/shape/candelstick-spec.ts
+++ b/test/shape/candelstick-spec.ts
@@ -7,7 +7,7 @@
 import {expect} from "chai";
 import util from "../assets/util";
 import {isArray} from "../../src/module/util";
-import CLASS from "../../src/config/classes";
+import {$CANDLESTICK, $COMMON} from "../../src/config/classes";
 
 describe("SHAPE CANDLESTICK", () => {
 	let chart;
@@ -72,7 +72,7 @@ describe("SHAPE CANDLESTICK", () => {
 				const line = this.querySelector("line");
 
 				// check for bearish data
-				if (this.getAttribute("class").indexOf(CLASS.valueDown) > -1) {
+				if (this.getAttribute("class").indexOf($CANDLESTICK.valueDown) > -1) {
 					expect(data._isUp).to.be.false;
 					expect(data.close < data.open).to.be.true;
 
@@ -81,7 +81,7 @@ describe("SHAPE CANDLESTICK", () => {
 				// check for bullrish data
 				} else {
 					expect(data.close > data.open).to.be.true;
-					expect(this.getAttribute("class").indexOf(CLASS.valueUp) > -1).to.be.true;
+					expect(this.getAttribute("class").indexOf($CANDLESTICK.valueUp) > -1).to.be.true;
 				}
 
 				expect(expectedPath[i].test(path.getAttribute("d"))).to.be.true;
@@ -117,7 +117,7 @@ describe("SHAPE CANDLESTICK", () => {
 			chart.tooltip.show({index});
 
 			chart.$.candlestick.each(function(d, i) {
-				const hasExpandedClass = this.getAttribute("class").indexOf(CLASS.EXPANDED) > -1;
+				const hasExpandedClass = this.getAttribute("class").indexOf($COMMON.EXPANDED) > -1;
 
 				expect(hasExpandedClass).to.be[i === index ? "true" : "false"];
 			});
@@ -126,7 +126,7 @@ describe("SHAPE CANDLESTICK", () => {
 			chart.tooltip.hide();
 
 			chart.$.candlestick.each(function() {
-				const hasExpandedClass = this.getAttribute("class").indexOf(CLASS.EXPANDED) > -1;
+				const hasExpandedClass = this.getAttribute("class").indexOf($COMMON.EXPANDED) > -1;
 
 				expect(hasExpandedClass).to.be.false;
 			});
@@ -230,7 +230,7 @@ describe("SHAPE CANDLESTICK", () => {
 				const line = this.querySelector("line");
 
 				// check for bearish data
-				if (this.getAttribute("class").indexOf(CLASS.valueDown) > -1) {
+				if (this.getAttribute("class").indexOf($CANDLESTICK.valueDown) > -1) {
 					expect(data._isUp).to.be.false;
 					expect(data.close < data.open).to.be.true;
 
@@ -239,7 +239,7 @@ describe("SHAPE CANDLESTICK", () => {
 				// check for bullrish data
 				} else {
 					expect(data.close > data.open).to.be.true;
-					expect(this.getAttribute("class").indexOf(CLASS.valueUp) > -1).to.be.true;
+					expect(this.getAttribute("class").indexOf($CANDLESTICK.valueUp) > -1).to.be.true;
 				}
 
 				const compareData = expected[d.id];

--- a/test/shape/gauge-spec.ts
+++ b/test/shape/gauge-spec.ts
@@ -6,15 +6,15 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
-import CLASS from "../../src/config/classes";
+import {$ARC, $COMMON, $GAUGE, $SHAPE} from "../../src/config/classes";
 import util from "../assets/util";
 import {getBoundingRect} from "../../src/module/util";
 
 describe("SHAPE GAUGE", () => {
 	const selector = {
-		arc: `.${CLASS.chartArc}.${CLASS.target}.${CLASS.target}`,
-		shapes: `g.${CLASS.shapes}.${CLASS.arcs}.${CLASS.arcs}`,
-		shape: `path.${CLASS.shape}.${CLASS.arc}.${CLASS.arc}`
+		arc: `.${$ARC.chartArc}.${$COMMON.target}.${$COMMON.target}`,
+		shapes: `g.${$SHAPE.shapes}.${$ARC.arcs}.${$ARC.arcs}`,
+		shape: `path.${$SHAPE.shape}.${$ARC.arc}.${$ARC.arc}`
 	};
 
     describe("show gauge", () => {
@@ -34,21 +34,21 @@ describe("SHAPE GAUGE", () => {
 				}
 			});
 
-			const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
+			const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
 			const data = chartArc.select(`${selector.arc}-data`)
 					.select(`${selector.shapes}-data`)
 					.select(`${selector.shape}-data`);
 
 			// check guage's background color
 			expect(
-				chart.$.arc.select(`path.${CLASS.chartArcsBackground}`).style("fill")
+				chart.$.arc.select(`path.${$ARC.chartArcsBackground}`).style("fill")
 			).to.be.equal(chart.internal.config.gauge_background);
 
 			setTimeout(() => {
 				expect(data.attr("d"))
 					.to.be.equal("M-304,-3.7229262694079536e-14A304,304,0,0,1,245.94116628998404,-178.68671669691184L237.85099634623455,-172.8088641739871A294,294,0,0,0,-294,-3.6004615894932184e-14Z");
 
-				expect(chartArc.select(`.${CLASS.gaugeValue}`).attr("dy")).to.be.equal("-.1em");
+				expect(chartArc.select(`.${$GAUGE.gaugeValue}`).attr("dy")).to.be.equal("-.1em");
 
 				done();
 			}, 500);
@@ -94,7 +94,7 @@ describe("SHAPE GAUGE", () => {
 				}
 			});
 
-			const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
+			const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
 			const data = chartArc.select(`${selector.arc}-data`)
 					.select(`${selector.shapes}-data`)
 					.select(`${selector.shape}-data`);
@@ -157,14 +157,14 @@ describe("SHAPE GAUGE", () => {
 			});
 
 			const chartArc = chart.$.arc;
-			const min = chartArc.select(`.${CLASS.chartArcsGaugeMin}`);
-			const max = chartArc.select(`.${CLASS.chartArcsGaugeMax}`);
+			const min = chartArc.select(`.${$GAUGE.chartArcsGaugeMin}`);
+			const max = chartArc.select(`.${$GAUGE.chartArcsGaugeMax}`);
 
 			expect(min.text()).to.equal("Min: 0%");
 			expect(max.text()).to.equal("Max: 100%");
 
 			// gauge text should be multilined
-			expect(chartArc.selectAll(`.${CLASS.target}-data tspan`).size()).to.be.equal(3);
+			expect(chartArc.selectAll(`.${$COMMON.target}-data tspan`).size()).to.be.equal(3);
 		});
 
 		it("should not show gauge labels", () => {
@@ -182,9 +182,9 @@ describe("SHAPE GAUGE", () => {
 				}
 			});
 
-			const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
-			const min = chartArc.select(`.${CLASS.chartArcsGaugeMin}`);
-			const max = chartArc.select(`.${CLASS.chartArcsGaugeMax}`)
+			const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
+			const min = chartArc.select(`.${$GAUGE.chartArcsGaugeMin}`);
+			const max = chartArc.select(`.${$GAUGE.chartArcsGaugeMax}`)
 
 			expect(min.empty()).to.be.true;
 			expect(max.empty()).to.be.true;
@@ -207,15 +207,15 @@ describe("SHAPE GAUGE", () => {
 			});
 
 			setTimeout(() => {
-				const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
-				const min = chartArc.select(`.${CLASS.chartArcsGaugeMin}`);
-				const max = chartArc.select(`.${CLASS.chartArcsGaugeMax}`);
+				const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
+				const min = chartArc.select(`.${$GAUGE.chartArcsGaugeMin}`);
+				const max = chartArc.select(`.${$GAUGE.chartArcsGaugeMax}`);
 
 				// check if gauge value text is centered
-				expect(+chartArc.select(`.${CLASS.gaugeValue}`).attr("dy")).to.be.above(0);
+				expect(+chartArc.select(`.${$GAUGE.gaugeValue}`).attr("dy")).to.be.above(0);
 
 				// check background height
-				expect(util.getBBox(chartArc.select(`.${CLASS.chartArcsBackground}`)).height).to.be.above(300);
+				expect(util.getBBox(chartArc.select(`.${$ARC.chartArcsBackground}`)).height).to.be.above(300);
 
 				// check for background arcPath length (in this case full circle)
 				const path = 'M-211.85,-2.5944142439936676e-14A211.85,211.85,0,1,1,211.85,2.5944142439936676e-14A211.85,211.85,0,1,1,-211.85,-2.5944142439936676e-14M-201.85,2.4719495640789325e-14A201.85,201.85,0,1,0,201.85,-2.4719495640789325e-14A201.85,201.85,0,1,0,-201.85,2.4719495640789325e-14Z'
@@ -247,10 +247,10 @@ describe("SHAPE GAUGE", () => {
 			});
 
 			setTimeout(() => {
-				const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
+				const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
 
 				// check background height
-				expect(util.getBBox(chartArc.select(`.${CLASS.chartArcsBackground}`)).height).to.be.above(300);
+				expect(util.getBBox(chartArc.select(`.${$ARC.chartArcsBackground}`)).height).to.be.above(300);
 
 				// check for background arcPath length (in this case 3 quarter)
 				const backgroundArcPath = 'M-211.85,-2.5944142439936676e-14A211.85,211.85,0,1,1,1.2972071219968338e-14,211.85L1.2359747820394662e-14,201.85A201.85,201.85,0,1,0,-201.85,-2.4719495640789325e-14Z'
@@ -258,7 +258,7 @@ describe("SHAPE GAUGE", () => {
 
 				// check for arcPath length (in this case 3 quarter)
 				const arcPath = 'M-211.85,-2.5944142439936676e-14A211.85,211.85,0,1,1,1.2972071219968338e-14,211.85L1.2359747820394662e-14,201.85A201.85,201.85,0,1,0,-201.85,-2.4719495640789325e-14Z'
-				expect(chartArc.select(`path.${CLASS.arc + '-' + chart.internal.data.targets[0].id}`).attr('d')).to.be.equal(arcPath);
+				expect(chartArc.select(`path.${$ARC.arc + '-' + chart.internal.data.targets[0].id}`).attr('d')).to.be.equal(arcPath);
 
 				done();
 			}, 100);
@@ -295,7 +295,7 @@ describe("SHAPE GAUGE", () => {
 		  	];
 
 			setTimeout(() => {
-				chart.$.arc.selectAll(`.${CLASS.target} path`).each(function(d, i) {
+				chart.$.arc.selectAll(`.${$COMMON.target} path`).each(function(d, i) {
 					expect(this.getAttribute("d")).to.be.equal(expected[i]);
 				});
 
@@ -333,9 +333,9 @@ describe("SHAPE GAUGE", () => {
 			setTimeout(() => {
 				const data = chart.data();
 
-				expect(chart.$.arc.select(`.${CLASS.chartArcsGaugeTitle}`).text()).to.be.equal(args.gauge.title);
+				expect(chart.$.arc.select(`.${$GAUGE.chartArcsGaugeTitle}`).text()).to.be.equal(args.gauge.title);
 
-				chart.$.arc.selectAll(`.${CLASS.target} path`).each(function(d, i) {
+				chart.$.arc.selectAll(`.${$COMMON.target} path`).each(function(d, i) {
 					expect(d.value).to.be.equal(data[i].values[0].value);
 					expect(this.getAttribute("d")).to.be.equal(expected[i]);
 				});
@@ -368,7 +368,7 @@ describe("SHAPE GAUGE", () => {
 			];
 
 			setTimeout(() => {
-				chart.$.arc.selectAll(`.${CLASS.target} path`).each(function(d, i) {
+				chart.$.arc.selectAll(`.${$COMMON.target} path`).each(function(d, i) {
 					expect(this.getAttribute("d")).to.be.equal(expected[i]);
 				});
 				
@@ -393,11 +393,11 @@ describe("SHAPE GAUGE", () => {
 
 			// gauge backgound should be aligned with the 'startingAngle' option
 			expect(
-				getBoundingRect(arc.select(`.${CLASS.chartArcsBackground}`).node()).width
+				getBoundingRect(arc.select(`.${$ARC.chartArcsBackground}`).node()).width
 			).to.be.equal(0);
 
 			expect(
-				arc.select(`.${CLASS.arc}-data`).datum().startAngle
+				arc.select(`.${$ARC.arc}-data`).datum().startAngle
 			).to.be.equal(
 				chart.config("gauge.startingAngle")
 			);
@@ -484,17 +484,17 @@ describe("SHAPE GAUGE", () => {
 
 		it("each data_column should have one arc", () => {
 			const arc = chart.$.arc;
-			const chartArcs = arc.selectAll(`.${CLASS.chartArc} .${CLASS.arc}`);
+			const chartArcs = arc.selectAll(`.${$ARC.chartArc} .${$ARC.arc}`);
 
 			chartArcs.each(function(d, i) {
-				expect(d3Select(this).classed(`${CLASS.shape} ${CLASS.arc} ${CLASS.arc}-${args.data.columns[i][0]}`)).to.be.true;
+				expect(d3Select(this).classed(`${$SHAPE.shape} ${$ARC.arc} ${$ARC.arc}-${args.data.columns[i][0]}`)).to.be.true;
 			});
 		});
 
 		it("each arc should have the color from color_pattern if color_treshold is given ", done => {
 			setTimeout(() => {
 				const arc = chart.$.arc;
-				const chartArcs = arc.selectAll(`.${CLASS.chartArc} .${CLASS.arc}`);
+				const chartArcs = arc.selectAll(`.${$ARC.chartArc} .${$ARC.arc}`);
 
 				chartArcs.each(function(d, i) {
 					expect(d3Select(this).style("fill")).to.be.equal(arcColor[i]);
@@ -506,16 +506,16 @@ describe("SHAPE GAUGE", () => {
 
 		it("each data_column should have one background", () => {
 			const arc = chart.$.arc;
-			const chartArcBackgrounds = arc.selectAll(`.${CLASS.chartArcs} path.${CLASS.chartArcsBackground}`);
+			const chartArcBackgrounds = arc.selectAll(`.${$ARC.chartArcs} path.${$ARC.chartArcsBackground}`);
 
 			chartArcBackgrounds.each(function(d, i) {
-				expect(d3Select(this).classed(`${CLASS.chartArcsBackground}-${i}`)).to.be.true;
+				expect(d3Select(this).classed(`${$ARC.chartArcsBackground}-${i}`)).to.be.true;
 			});
 		});
 
 		it("each background should have the same color", () => {
 			const arc = chart.$.arc;
-			const chartArcBackgrounds = arc.selectAll(`.${CLASS.chartArcs} path.${CLASS.chartArcsBackground}`);
+			const chartArcBackgrounds = arc.selectAll(`.${$ARC.chartArcs} path.${$ARC.chartArcsBackground}`);
 
 			chartArcBackgrounds.each(function(d, i) {
 				expect(d3Select(this).style("fill")).to.be.equal("rgb(224, 224, 224)");
@@ -525,7 +525,7 @@ describe("SHAPE GAUGE", () => {
 		it("each data_column should have a label", done => {
 			setTimeout(() => {
 				const arc = chart.$.arc;
-				const gaugeValues = arc.selectAll(`${selector.arc} text.${CLASS.gaugeValue}`);
+				const gaugeValues = arc.selectAll(`${selector.arc} text.${$GAUGE.gaugeValue}`);
 
 				gaugeValues.each(function(d, i) {
 					expect(d3Select(this).text()).to.be.equal(`${args.data.columns[i][1]}%`);
@@ -537,7 +537,7 @@ describe("SHAPE GAUGE", () => {
 
 		it("each label should have the same color", () => {
 			const arc = chart.$.arc;
-			const gaugeValues = arc.selectAll(`${selector.arc} text.${CLASS.gaugeValue}`);
+			const gaugeValues = arc.selectAll(`${selector.arc} text.${$GAUGE.gaugeValue}`);
 
 			gaugeValues.each(function(d, i) {
 				expect(d3Select(this).style("fill")).to.be.equal("rgb(0, 0, 0)");
@@ -546,16 +546,16 @@ describe("SHAPE GAUGE", () => {
 
 		it("each data_column should have a labelline", () => {
 			const arc = chart.$.arc;
-			const arcLabelLines = arc.selectAll(`.${CLASS.chartArc} .${CLASS.arcLabelLine}`);
+			const arcLabelLines = arc.selectAll(`.${$ARC.chartArc} .${$ARC.arcLabelLine}`);
 
 			arcLabelLines.each(function(d, i) {
-				expect(d3Select(this).classed(`${CLASS.arcLabelLine} ${CLASS.target} ${CLASS.target}-${args.data.columns[i][0]}`)).to.be.true;
+				expect(d3Select(this).classed(`${$ARC.arcLabelLine} ${$COMMON.target} ${$COMMON.target}-${args.data.columns[i][0]}`)).to.be.true;
 			});
 		});
 
 		it("each labelline should have the color from color_pattern if color_treshold is given", () => {
 			const arc = chart.$.arc;
-			const arcLabelLines = arc.selectAll(`.${CLASS.chartArc} .${CLASS.arcLabelLine}`);
+			const arcLabelLines = arc.selectAll(`.${$ARC.chartArc} .${$ARC.arcLabelLine}`);
 
 			arcLabelLines.each(function(d, i) {
 				expect(d3Select(this).style("fill")).to.be.equal(arcColor[i]);
@@ -578,7 +578,7 @@ describe("SHAPE GAUGE", () => {
 
 			chart.focus("padded3");
 
-			const gaugeValues = arc.selectAll(`${selector.arc} text.${CLASS.gaugeValue}`);
+			const gaugeValues = arc.selectAll(`${selector.arc} text.${$GAUGE.gaugeValue}`);
 			const gaugeValuesNodes = gaugeValues.nodes();
 
 			expect(gaugeValuesNodes[0].className.baseVal).to.be.equal("bb-gauge-value");
@@ -628,7 +628,7 @@ describe("SHAPE GAUGE", () => {
 		it("check gauge's background color", () => {
 			const arc = chart.$.arc;
 			const backgroundColor = chart.internal.config.gauge_background;
-			const gaugeBackground = arc.selectAll(`path.${CLASS.chartArcsBackground}`);
+			const gaugeBackground = arc.selectAll(`path.${$ARC.chartArcsBackground}`);
 
 			gaugeBackground.each(function(d, i) {
 				expect(this.style.fill).to.be.equal(backgroundColor);
@@ -649,7 +649,7 @@ describe("SHAPE GAUGE", () => {
 
 		it("should mirror the starting angle", done => {
 			setTimeout(() => {
-				const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
+				const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
 
 				// check for background arcPath length (in this case 3 quarter)
 				const expectedBackgroundArcPaths = [
@@ -658,7 +658,7 @@ describe("SHAPE GAUGE", () => {
 					'M-173.94888197948833,-111.69129266906184A206.71999999999997,206.71999999999997,0,0,1,173.94888197948833,-111.69129266906181L152.20527173205232,-97.7298810854291A180.88,180.88,0,0,0,-152.20527173205232,-97.72988108542911Z',
 					'M-152.20527173205232,-97.72988108542911A180.88,180.88,0,0,1,152.20527173205232,-97.7298810854291L130.46166148461626,-83.76846950179637A155.04,155.04,0,0,0,-130.46166148461626,-83.76846950179639Z',
 					]
-				const backgroundArcPaths = chartArc.selectAll(`path.${CLASS.chartArcsBackground}`);
+				const backgroundArcPaths = chartArc.selectAll(`path.${$ARC.chartArcsBackground}`);
 				backgroundArcPaths.each((data, index, elements)=> {
 					expect(elements[index].getAttribute('d')).to.be.equal(expectedBackgroundArcPaths[index])
 				})
@@ -670,7 +670,7 @@ describe("SHAPE GAUGE", () => {
 					'M-173.94888197948833,-111.69129266906184A206.71999999999997,206.71999999999997,0,0,1,1.265794931598704e-14,-206.71999999999997L1.1075705651488663e-14,-180.88A180.88,180.88,0,0,0,-152.20527173205232,-97.72988108542911Z',
 					'M-152.20527173205232,-97.72988108542911A180.88,180.88,0,0,1,-102.13253058769399,-149.2867060248626L-87.54216907516629,-127.96003373559653A155.04,155.04,0,0,0,-130.46166148461626,-83.76846950179639Z',
 				]
-				const arcPaths = chartArc.selectAll(`path.${CLASS.arc}`);
+				const arcPaths = chartArc.selectAll(`path.${$ARC.arc}`);
 				arcPaths.each((data, index, elements)=> {
 					expect(elements[index].getAttribute('d')).to.be.equal(expectedArcPaths[index])
 				})
@@ -688,9 +688,9 @@ describe("SHAPE GAUGE", () => {
 
 		it("check for fullCircle option", done => {
 			setTimeout(() => {
-				const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
-				const min = chartArc.select(`.${CLASS.chartArcsGaugeMin}`);
-				const max = chartArc.select(`.${CLASS.chartArcsGaugeMax}`);
+				const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
+				const min = chartArc.select(`.${$GAUGE.chartArcsGaugeMin}`);
+				const max = chartArc.select(`.${$GAUGE.chartArcsGaugeMax}`);
 
 				// check for background arcPath length (in this case full circle)
 				const expectedBackgroundArcPaths = [
@@ -699,7 +699,7 @@ describe("SHAPE GAUGE", () => {
 					'M-144.05799999999996,-1.7642016859156936e-14A144.05799999999996,144.05799999999996,0,1,1,144.05799999999996,1.7642016859156936e-14A144.05799999999996,144.05799999999996,0,1,1,-144.05799999999996,-1.7642016859156936e-14M-126.05074999999998,1.543676475176232e-14A126.05074999999998,126.05074999999998,0,1,0,126.05074999999998,-1.543676475176232e-14A126.05074999999998,126.05074999999998,0,1,0,-126.05074999999998,1.543676475176232e-14Z',
 					'M-126.05074999999998,-1.543676475176232e-14A126.05074999999998,126.05074999999998,0,1,1,126.05074999999998,1.543676475176232e-14A126.05074999999998,126.05074999999998,0,1,1,-126.05074999999998,-1.543676475176232e-14M-108.04349999999998,1.3231512644367703e-14A108.04349999999998,108.04349999999998,0,1,0,108.04349999999998,-1.3231512644367703e-14A108.04349999999998,108.04349999999998,0,1,0,-108.04349999999998,1.3231512644367703e-14Z'
 				]
-				const backgroundArcPaths = chartArc.selectAll(`path.${CLASS.chartArcsBackground}`);
+				const backgroundArcPaths = chartArc.selectAll(`path.${$ARC.chartArcsBackground}`);
 				backgroundArcPaths.each((data, index, elements)=> {
 					expect(elements[index].getAttribute('d')).to.be.equal(expectedBackgroundArcPaths[index])
 				})
@@ -711,7 +711,7 @@ describe("SHAPE GAUGE", () => {
 					'M-144.05799999999996,-1.7642016859156936e-14A144.05799999999996,144.05799999999996,0,1,1,144.05799999999996,6.39746033925803e-14L126.05074999999998,5.597777796850777e-14A126.05074999999998,126.05074999999998,0,1,0,-126.05074999999998,-1.543676475176232e-14Z',
 					'M-126.05074999999998,-1.543676475176232e-14A126.05074999999998,126.05074999999998,0,0,1,-38.95182390370789,-119.88138717139132L-33.38727763174962,-102.75547471833542A108.04349999999998,108.04349999999998,0,0,0,-108.04349999999998,-1.3231512644367703e-14Z'
 				]
-				const arcPaths = chartArc.selectAll(`path.${CLASS.arc}`);
+				const arcPaths = chartArc.selectAll(`path.${$ARC.arc}`);
 				arcPaths.each((data, index, elements)=> {
 					expect(elements[index].getAttribute('d')).to.be.equal(expectedArcPaths[index])
 				})
@@ -731,7 +731,7 @@ describe("SHAPE GAUGE", () => {
 
 		it("check for arcLength option", done => {
 			setTimeout(() => {
-				const chartArc = chart.$.main.select(`.${CLASS.chartArcs}`);
+				const chartArc = chart.$.main.select(`.${$ARC.chartArcs}`);
 
 				// check for background arcPath length (in this case 3 quarter)
 				const expectedBackgroundArcPaths = [
@@ -740,7 +740,7 @@ describe("SHAPE GAUGE", () => {
 					'M-144.05799999999996,-1.7642016859156936e-14A144.05799999999996,144.05799999999996,0,1,1,8.821008429578468e-15,144.05799999999996L7.71838237588116e-15,126.05074999999998A126.05074999999998,126.05074999999998,0,1,0,-126.05074999999998,-1.543676475176232e-14Z',
 					'M-126.05074999999998,-1.543676475176232e-14A126.05074999999998,126.05074999999998,0,1,1,7.71838237588116e-15,126.05074999999998L6.615756322183852e-15,108.04349999999998A108.04349999999998,108.04349999999998,0,1,0,-108.04349999999998,-1.3231512644367703e-14Z'
 				]
-				const backgroundArcPaths = chartArc.selectAll(`path.${CLASS.chartArcsBackground}`);
+				const backgroundArcPaths = chartArc.selectAll(`path.${$ARC.chartArcsBackground}`);
 				backgroundArcPaths.each((data, index, elements)=> {
 					expect(elements[index].getAttribute('d')).to.be.equal(expectedBackgroundArcPaths[index])
 				})
@@ -752,7 +752,7 @@ describe("SHAPE GAUGE", () => {
 					'M-144.05799999999996,-1.7642016859156936e-14A144.05799999999996,144.05799999999996,0,0,1,101.86438868417164,-101.86438868417163L89.1313400986502,-89.13134009865018A126.05074999999998,126.05074999999998,0,0,0,-126.05074999999998,-1.543676475176232e-14Z',
 					'M-126.05074999999998,-1.543676475176232e-14A126.05074999999998,126.05074999999998,0,0,1,-74.09077189040543,-101.97719890370789L-63.5063759060618,-87.40902763174962A108.04349999999998,108.04349999999998,0,0,0,-108.04349999999998,-1.3231512644367703e-14Z'
 				]
-				const arcPaths = chartArc.selectAll(`path.${CLASS.arc}`);
+				const arcPaths = chartArc.selectAll(`path.${$ARC.arc}`);
 				arcPaths.each((data, index, elements)=> {
 					expect(elements[index].getAttribute('d')).to.be.equal(expectedArcPaths[index])
 				})
@@ -799,7 +799,7 @@ describe("SHAPE GAUGE", () => {
 				}
             };
             const chart = util.generate(args);
-			const maxValue = +chart.$.main.select(`.${CLASS.chartArcsGaugeMax}`).text();
+			const maxValue = +chart.$.main.select(`.${$GAUGE.chartArcsGaugeMax}`).text();
             
 			expect(args.gauge.max).to.be.below(maxValue);
 			expect(maxValue).to.be.equal(args.data.columns[0][1]);
@@ -822,7 +822,7 @@ describe("SHAPE GAUGE", () => {
 			const chart = util.generate(args);
 			
 			const valueRect = chart.$.text.texts.node().getBoundingClientRect();
-			const unitRect = chart.$.main.select(`.${CLASS.chartArcsGaugeUnit}`).node().getBoundingClientRect();
+			const unitRect = chart.$.main.select(`.${$GAUGE.chartArcsGaugeUnit}`).node().getBoundingClientRect();
 
 			expect(unitRect.y).to.be.greaterThan(valueRect.y + valueRect.height);
 		});

--- a/test/shape/line-spec.ts
+++ b/test/shape/line-spec.ts
@@ -10,7 +10,7 @@ import {
 	curveStepAfter as d3CurveStepAfter,
 	curveStepBefore as d3CurveStepBefore
 } from "d3-shape";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $COMMON, $LINE, $SELECT} from "../../src/config/classes";
 import util from "../assets/util";
 
 describe("SHAPE LINE", () => {
@@ -46,14 +46,14 @@ describe("SHAPE LINE", () => {
 		});
 
 		it("Should render the lines correctly", () => {
-			const target = chart.$.main.select(`.${CLASS.chartLine}.${CLASS.target}-data1`);
-			const commands = parseSvgPath(target.select(`.${CLASS.line}-data1`).attr("d"));
+			const target = chart.$.main.select(`.${$LINE.chartLine}.${$COMMON.target}-data1`);
+			const commands = parseSvgPath(target.select(`.${$LINE.line}-data1`).attr("d"));
 
 			expect(commands.length).to.be.equal(6);
 		});
 
 		it("should not have shape-rendering when it's line chart", () => {
-			chart.$.main.selectAll(`.${CLASS.line}`).each(function() {
+			chart.$.main.selectAll(`.${$LINE.line}`).each(function() {
 				const style = d3Select(this).style("shape-rendering");
 
 				expect(style).to.be.equal("auto");
@@ -66,7 +66,7 @@ describe("SHAPE LINE", () => {
 		});
 
 		it("should have shape-rendering = crispedges when it's step chart", () => {
-			chart.$.main.selectAll(`.${CLASS.line}`).each(function() {
+			chart.$.main.selectAll(`.${$LINE.line}`).each(function() {
 				const style = d3Select(this).style("shape-rendering").toLowerCase();
 
 				expect(style).to.be.equal("crispedges");
@@ -111,8 +111,8 @@ describe("SHAPE LINE", () => {
 
 		it("should not draw a line segment for null data", done => {
 			setTimeout(() => {
-				const target = chart.$.main.select(`.${CLASS.chartLine}.${CLASS.target}-data1`);
-				const commands = parseSvgPath(target.select(`.${CLASS.line}-data1`).attr("d"));
+				const target = chart.$.main.select(`.${$LINE.chartLine}.${$COMMON.target}-data1`);
+				const commands = parseSvgPath(target.select(`.${$LINE.line}-data1`).attr("d"));
 				let segments = 0;
 
 				for (let i = 0; i < commands.length; i++) {
@@ -181,7 +181,7 @@ describe("SHAPE LINE", () => {
 		});
 
 		it("<g> selected node shouldn't be generated when point.show=false", () => {
-			const selectedCircle = chart.$.main.selectAll(`.${CLASS.selectedCircles}`);
+			const selectedCircle = chart.$.main.selectAll(`.${$SELECT.selectedCircles}`);
 
 			expect(selectedCircle.empty()).to.be.true;
 		});
@@ -198,7 +198,7 @@ describe("SHAPE LINE", () => {
 		});
 
 		it("<g> selected node shouldn't be generated when data.selection.enabled=false", () => {
-			const selectedCircle = chart.$.main.selectAll(`.${CLASS.selectedCircles}`);
+			const selectedCircle = chart.$.main.selectAll(`.${$SELECT.selectedCircles}`);
 
 			expect(selectedCircle.empty()).to.be.true;
 		});
@@ -337,7 +337,7 @@ describe("SHAPE LINE", () => {
 			args.line.zerobased = false;
 			chart = util.generate(args);
 
-			const tickNodes = chart.$.svg.select(`.${CLASS.axisY}`).selectAll("g.tick");
+			const tickNodes = chart.$.svg.select(`.${$AXIS.axisY}`).selectAll("g.tick");
 			const tickElements = tickNodes.nodes();
 
 			const translateValues = [
@@ -361,7 +361,7 @@ describe("SHAPE LINE", () => {
 			args.line.zerobased = true;
 			chart = util.generate(args);
 
-			const tickNodes = chart.$.svg.select(`.${CLASS.axisY}`).selectAll("g.tick");
+			const tickNodes = chart.$.svg.select(`.${$AXIS.axisY}`).selectAll("g.tick");
 			const tickElements = tickNodes.nodes();
 
 			const translateValues = [

--- a/test/shape/point-spec.ts
+++ b/test/shape/point-spec.ts
@@ -6,7 +6,7 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$CIRCLE} from "../../src/config/classes";
 
 describe("SHAPE POINT", () => {
 	let chart;
@@ -164,7 +164,7 @@ describe("SHAPE POINT", () => {
 
 			setTimeout(() => {
 				interval = setInterval(() => {
-					point = main.select(`.${CLASS.circles}-data2 .${CLASS.circle}-3`);
+					point = main.select(`.${$CIRCLE.circles}-data2 .${$CIRCLE.circle}-3`);
 					pos.push(+point.attr("cx"));
 				}, 20);
 

--- a/test/shape/radar-spec.ts
+++ b/test/shape/radar-spec.ts
@@ -6,7 +6,7 @@
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import util from "../assets/util";
-import CLASS from "../../src/config/classes";
+import {$AXIS, $COMMON, $RADAR} from "../../src/config/classes";
 
 describe("SHAPE RADAR", () => {
 	let chart;
@@ -34,18 +34,18 @@ describe("SHAPE RADAR", () => {
 		});
 
 		it("radar should be positioned at center", () => {
-			const rect = chart.$.main.select(`.${CLASS.chartRadars}`).node().getBoundingClientRect();
+			const rect = chart.$.main.select(`.${$RADAR.chartRadars}`).node().getBoundingClientRect();
 			const left = (chart.$.chart.node().getBoundingClientRect().width - rect.width) / 2;
 
 			expect(left).to.be.closeTo(rect.x, 5);
 		});
 
 		it("data points should positioned next to radar polygon element", () => {
-			expect(chart.internal.$el.radar.select(`.${CLASS.target}-data1 polygon`).node().nextSibling.querySelectorAll("circle").length).to.equal(3);
+			expect(chart.internal.$el.radar.select(`.${$COMMON.target}-data1 polygon`).node().nextSibling.querySelectorAll("circle").length).to.equal(3);
 		});
 
 		it("check for shape rendering", done => {
-			const radar = chart.$.main.select(`.${CLASS.chartRadars}`);
+			const radar = chart.$.main.select(`.${$RADAR.chartRadars}`);
 			const expectedPoints = "233,30.290000000000003 233,233 309.32696069614934,277.06739130434784";
 
 			setTimeout(() => {
@@ -56,12 +56,12 @@ describe("SHAPE RADAR", () => {
 		});
 
 		it("Should render level, axes and data edges", () => {
-			const radar = chart.$.main.select(`.${CLASS.chartRadars}`);
+			const radar = chart.$.main.select(`.${$RADAR.chartRadars}`);
 			const data = chart.data();
 			const dataLen = data[0].values.length;
 
-			const axes = radar.selectAll(`.${CLASS.axis} g`);
-			const levels = radar.selectAll(`.${CLASS.levels} g`);
+			const axes = radar.selectAll(`.${$AXIS.axis} g`);
+			const levels = radar.selectAll(`.${$RADAR.levels} g`);
 
 			expect(axes.size()).to.be.equal(dataLen);
 			expect(levels.size()).to.be.equal(dataLen);
@@ -86,8 +86,8 @@ describe("SHAPE RADAR", () => {
 		});
 
 		it("check for axis options", () => {
-			const radar = chart.$.main.select(`.${CLASS.chartRadars}`);
-			const axis = radar.selectAll(`.${CLASS.axis}`);
+			const radar = chart.$.main.select(`.${$RADAR.chartRadars}`);
+			const axis = radar.selectAll(`.${$AXIS.axis}`);
 
 			expect(axis.selectAll("line").empty()).to.be.true;
 			expect(axis.selectAll("text").empty()).to.be.true;
@@ -101,8 +101,8 @@ describe("SHAPE RADAR", () => {
 		});
 
 		it("check for level options", () => {
-			const radar = chart.$.main.select(`.${CLASS.chartRadars}`);
-			const levels = radar.select(`.${CLASS.levels}`);
+			const radar = chart.$.main.select(`.${$RADAR.chartRadars}`);
+			const levels = radar.select(`.${$RADAR.levels}`);
 			const level = levels.selectAll("polygon");
 
 			// check for level element depth size
@@ -121,9 +121,9 @@ describe("SHAPE RADAR", () => {
 		});
 
 		it("check for resize", () => {
-			const radars = chart.$.main.select(`.${CLASS.chartRadars}`);
-			const level = radars.select(`.${CLASS.levels}`);
-			const axis = radars.select(`.${CLASS.axis}`);
+			const radars = chart.$.main.select(`.${$RADAR.chartRadars}`);
+			const level = radars.select(`.${$RADAR.levels}`);
+			const axis = radars.select(`.${$AXIS.axis}`);
 
 			const old = [radars, level, axis].map(v => util.getBBox(v));
 
@@ -142,7 +142,7 @@ describe("SHAPE RADAR", () => {
 			// retrieve point data for next the next test
 			points = [];
 
-			chart.$.main.selectAll(`.${CLASS.chartRadars} .${CLASS.axis} text`)
+			chart.$.main.selectAll(`.${$RADAR.chartRadars} .${$AXIS.axis} text`)
 				.each(function() {
 					points.push([+this.getAttribute("x"), +this.getAttribute("y")]);
 				});
@@ -153,7 +153,7 @@ describe("SHAPE RADAR", () => {
 		});
 
 		it("check for direction", () => {
-			const texts = chart.$.main.selectAll(`.${CLASS.chartRadars} .${CLASS.axis} text`);
+			const texts = chart.$.main.selectAll(`.${$RADAR.chartRadars} .${$AXIS.axis} text`);
 
 			texts.each(function(d, i) {
 				const newPoints = [+this.getAttribute("x"), +this.getAttribute("y")];
@@ -186,7 +186,7 @@ describe("SHAPE RADAR", () => {
 		});
 
 		it("check for multiline axis text", () => {
-			chart.$.main.selectAll(`.${CLASS.chartRadars} .${CLASS.axis} text`)
+			chart.$.main.selectAll(`.${$RADAR.chartRadars} .${$AXIS.axis} text`)
 				.each(function(d, i) {
 					expect(this.childNodes.length).to.be.equal(i === 2 ? 1 : 2);
 				});
@@ -215,7 +215,7 @@ describe("SHAPE RADAR", () => {
 		});
 
 		it("check if default indexed axis text are showing", () => {
-			chart.$.main.selectAll(`.${CLASS.chartRadars} .${CLASS.axis} text`)
+			chart.$.main.selectAll(`.${$RADAR.chartRadars} .${$AXIS.axis} text`)
 				.each(function(d, i) {
 					expect(+this.textContent).to.be.equal(i);
 				});
@@ -240,7 +240,7 @@ describe("SHAPE RADAR", () => {
 		});
 
 		it("check for the default text position", () => {
-			chart.$.main.selectAll(`.${CLASS.chartRadars} .${CLASS.axis} g`)
+			chart.$.main.selectAll(`.${$RADAR.chartRadars} .${$AXIS.axis} g`)
 				.each(function(d, i) {
 					const line = this.firstChild.getBoundingClientRect();
 					const text = this.lastChild.getBoundingClientRect();
@@ -268,7 +268,7 @@ describe("SHAPE RADAR", () => {
 				}
 			};
 
-			chart.$.main.selectAll(`.${CLASS.chartRadars} .${CLASS.axis} text`)
+			chart.$.main.selectAll(`.${$RADAR.chartRadars} .${$AXIS.axis} text`)
 				.each(function() {
 					textPos.push(this.getBoundingClientRect());
 				});
@@ -277,7 +277,7 @@ describe("SHAPE RADAR", () => {
 		it("check for axis text position", () => {
 			const {x, y} = args.radar.axis.text.position;
 
-			chart.$.main.selectAll(`.${CLASS.chartRadars} .${CLASS.axis} text`)
+			chart.$.main.selectAll(`.${$RADAR.chartRadars} .${$AXIS.axis} text`)
 				.each(function(d, i) {
 					const rect = this.getBoundingClientRect();
 					let distance = 0;


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2513

## Details
<!-- Detailed description of the change/feature -->
Split class name objects by its types.
Add [`treeshake`](https://rollupjs.org/guide/en/#treeshake) option on rollup plugin build config.