### PR TITLE
fix(zoom): Fix unzoom after appeding regions

### DIFF
--- a/src/ChartInternal/internals/redraw.ts
+++ b/src/ChartInternal/internals/redraw.ts
@@ -246,10 +246,11 @@ export default {
 	redrawWithoutRescale() {
 		this.redraw({
 			withY: false,
-			withLegend: true,
+			withDimension: false,
+			withLegend: false,
 			withSubchart: false,
 			withEventRect: false,
-			withTransitionForAxis: false
+			withTransitionForAxis: false,
 		});
 	}
 };

--- a/test/api/zoom-spec.ts
+++ b/test/api/zoom-spec.ts
@@ -561,4 +561,71 @@ describe("API zoom", function() {
 			chkZoomEvents();
 		});
 	});
+
+	describe("zoom for timeseries axis type", () => {
+		before(() => {
+			chart = util.generate({
+				data: {
+					columns: [
+						["sample", 30, 200, 100, 400, 150, 250, 150, 200, 170, 240, 350, 150, 100, 400, 150, 250, 150, 200, 170, 240, 100, 150, 250, 150, 200, 170, 240, 30, 200, 100, 400, 150, 250, 150, 200, 170, 240, 350, 150, 100, 400, 350, 220, 250, 300, 270, 140, 150, 90, 150, 50, 120, 70, 40]
+					],
+					type: "line"
+				},
+				legend: {
+					show: true
+				},
+				zoom: {
+					enabled: true, 
+					type: "drag",
+				},
+				transition: {
+					duration: 0
+				}
+			});
+		});
+
+		it("unzoom after adding xgrid dynamically.", () => {
+			const {internal: $$} = chart;
+
+			// zoom
+			chart.zoom([30, 40]);
+
+			const {$el: {eventRect}, scale: {x, zoom}} = $$;
+			const xDomain = x.domain().reduce((prev, curr) => prev + curr);
+			const zoomDomain = zoom.domain().reduce((prev, curr) => prev + curr);
+
+			// when
+			chart.xgrids([{value: 33, text: "123"}]);
+
+			expect(zoomDomain).to.be.above(xDomain);
+
+			// unzoom
+			chart.unzoom();
+
+			expect($$.scale.x.domain()).to.be.deep.equal(x.domain());
+			expect($$.scale.zoom).to.be.null;
+		});
+
+		it("unzoom after adding regions dynamically.", () => {
+			const {internal: $$} = chart;
+
+			// zoom
+			chart.zoom([30, 40]);
+
+			const {$el: {eventRect}, scale: {x, zoom}} = $$;
+			const xDomain = x.domain().reduce((prev, curr) => prev + curr);
+			const zoomDomain = zoom.domain().reduce((prev, curr) => prev + curr);
+
+			// when
+			chart.regions([{axis: "x", start: 30, end: 35}]);
+
+			expect(zoomDomain).to.be.above(xDomain);
+
+			// unzoom
+			chart.unzoom();
+
+			expect($$.scale.x.domain()).to.be.deep.equal(x.domain());
+			expect($$.scale.zoom).to.be.null;		  	
+		});
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2531

## Details
<!-- Detailed description of the change/feature -->
When grids/regions APIs called, do not update legend,
where makes x's scale update.

<img src=https://user-images.githubusercontent.com/2178435/152485444-b309f53f-019f-44fe-a13d-9f1b8aa10368.gif width=380>

