### PR TITLE
fix(subchart): Fix axis position on subchart.hide() call

### DIFF
--- a/src/Chart/api/chart.ts
+++ b/src/Chart/api/chart.ts
@@ -31,7 +31,7 @@ export default {
 
 			state.resizing = true;
 
-			this.flush(false, true);
+			this.flush(false);
 			$$.resizeFunction();
 		}
 	},

--- a/src/Chart/api/subchart.ts
+++ b/src/Chart/api/subchart.ts
@@ -48,13 +48,13 @@ export default {
 					$$.updateSizes();
 					$$.updateTargetsForSubchart($$.data.targets);
 
-					$target = subchart.main.selectAll(`.${$COMMON.target}`);
+					$target = subchart.main?.selectAll(`.${$COMMON.target}`);
 				}
 
-				$target.style("opacity", null);
-				subchart.main.style("display", null);
+				$target?.style("opacity", null);
+				subchart.main?.style("display", null);
 
-				this.flush();
+				this.resize();
 			}
 		},
 
@@ -69,13 +69,13 @@ export default {
 		 */
 		hide(): void {
 			const $$ = this.internal;
-			const {$el: {subchart}, config} = $$;
+			const {$el: {subchart: {main}}, config} = $$;
 
-			if (config.subchart_show && subchart.main.style("display") !== "none") {
+			if (config.subchart_show && main?.style("display") !== "none") {
 				config.subchart_show = false;
-				subchart.main.style("display", "none");
+				main.style("display", "none");
 
-				this.flush();
+				this.resize();
 			}
 		},
 

--- a/test/api/subchart-spec.ts
+++ b/test/api/subchart-spec.ts
@@ -32,7 +32,7 @@ describe("API subchart", () => {
 		});
 
 		it("check subchart interactions", () => {
-			const {subchart} = chart.internal.$el;
+			const {$el: {axis, subchart}} = chart.internal;
 
 			expect(subchart.main).to.be.null;
 
@@ -50,11 +50,14 @@ describe("API subchart", () => {
 			chart.subchart.toggle();
 
 			expect(subchart.main.style("display")).to.be.not.equal("none");
+			const xAxisYPos = util.parseNum(axis.x.attr("transform"));
+
 
 			// when
 			chart.subchart.toggle();
 
 			expect(subchart.main.style("display")).to.be.equal("none");
+			expect(util.parseNum(axis.x.attr("transform"))).to.be.above(xAxisYPos);
 		});
 
 		it("dynamic data load", done => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2536 #2534

## Details
<!-- Detailed description of the change/feature -->
- Replace calling .reszize() instead of .flush() when show & hide is called.
- Add prevention code on handling subchart's node