### PR TITLE
fix(tooltip): revert tooltip.contents' defaultValueFormat

### DIFF
--- a/src/ChartInternal/internals/format.ts
+++ b/src/ChartInternal/internals/format.ts
@@ -38,11 +38,16 @@ export default {
 	 */
 	getDefaultValueFormat(): Function {
 		const $$ = this;
-		const hasArc = $$.hasArcType();
+		const {defaultArcValueFormat, yFormat, y2Format} = $$;
+		const hasArc = $$.hasArcType(null, ["gauge", "radar"]);
 
-		return hasArc && !$$.hasType("gauge") ?
-			$$.defaultArcValueFormat :
-			$$.defaultValueFormat;
+		return function(v, ratio, id) {
+			const format = hasArc ? defaultArcValueFormat : (
+				$$.axis && $$.axis.getId(id) === "y2" ? y2Format : yFormat
+			);
+
+			return format.call($$, v, ratio);
+		};
 	},
 
 	defaultValueFormat(v): number|string {

--- a/src/config/Options/common/tooltip.ts
+++ b/src/config/Options/common/tooltip.ts
@@ -34,7 +34,16 @@ export default {
 	 *   - `element {SVGElement}`: Tooltip event bound element
 	 *   - `pos {object}`: Current position of the tooltip.
 	 * @property {Function|object} [tooltip.contents] Set custom HTML for the tooltip.<br>
-	 *  Specified function receives data, defaultTitleFormat, defaultValueFormat and color of the data point to show. If tooltip.grouped is true, data includes multiple data points.
+	 *  If tooltip.grouped is true, data includes multiple data points.<br><br>
+	 *  Specified function receives `data` array and `defaultTitleFormat`, `defaultValueFormat` and `color` functions of the data point to show.
+	 *  - **Note:**
+	 *    - defaultTitleFormat:
+	 *      - if `axis.x.tick.format` option will be used if set.
+	 *      - otherwise, will return funciton based on tick format type(category, timeseries).
+	 *    - defaultValueFormat:
+	 *	    - for Arc type (except gauge, radar), the function will return value from `(ratio * 100).toFixed(1)`.
+	 *	    - for Axis based types, will be used `axis.[y|y2].tick.format` option value if is set.
+	 *	    - otherwise, will parse value and return as number.
 	 * @property {string|HTMLElement} [tooltip.contents.bindto=undefined] Set CSS selector or element reference to bind tooltip.
 	 *  - **NOTE:** When is specified, will not be updating tooltip's position.
 	 * @property {string} [tooltip.contents.template=undefined] Set tooltip's template.<br><br>

--- a/test/internals/tooltip-spec.ts
+++ b/test/internals/tooltip-spec.ts
@@ -1265,6 +1265,40 @@ describe("TOOLTIP", function() {
 			};
 		});
 
+		it("set options tooltip.contents", () => {
+			args.tooltip.contents = function(data, defaultTitleFormat, defaultValueFormat, color) {
+				const d = data[0];
+				const value = defaultValueFormat(d.value, d?.ratio, d.id);
+				const hasYTickFormat = !!args.axis?.y?.tick?.format;
+
+				expect(typeof value === (hasYTickFormat ? "string" : "number")).to.be.ok;
+
+				return value;
+			};
+		});
+
+		it("tooltip.contents' defaultValueFormat should return number type.", () => {
+			// when
+			chart.tooltip.show({x:1});
+		});
+
+		it("set options tooltip.contents", () => {
+			args.axis = {
+				y: {
+					tick: {
+						format: function(x) {
+							return `${x}`;
+						}
+					}
+				}
+			}
+		});
+
+		it("tooltip.contents' defaultValueFormat should return string type.", () => {
+			// when
+			chart.tooltip.show({x:1});
+		});
+
 		it("tooltip shouldn't be hiding", () => {
 			util.hoverChart(chart, "mousemove", {clientX: 185, clientY: 107});
 			util.hoverChart(chart, "mouseout", {clientX: -100, clientY: -100});


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2542

## Details
<!-- Detailed description of the change/feature -->
- Revert defaultValueFormat function changes done from d2be8c0
- Add descriptive info on how defaultValueFormat behave on API doc