### PR TITLE
refactor(internal): Reinforce clip-path unique id definition

### DIFF
--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -18,7 +18,7 @@ import Options from "../config/Options/Options";
 import {document, window} from "../module/browser";
 import Cache from "../module/Cache";
 import {generateResize} from "../module/generator";
-import {capitalize, extend, notEmpty, convertInputType, getOption, isFunction, isObject, isString, callFn, sortValue} from "../module/util";
+import {capitalize, extend, notEmpty, convertInputType, getOption, getRandom, isFunction, isObject, isString, callFn, sortValue} from "../module/util";
 
 // data
 import dataConvert from "./data/convert";
@@ -255,7 +255,7 @@ export default class ChartInternal {
 		const isRotated = config.axis_rotated;
 
 		// datetime to be used for uniqueness
-		state.datetimeId = `bb-${+new Date()}`;
+		state.datetimeId = `bb-${+new Date() * (getRandom() as number)}`;
 
 		$$.color = $$.generateColor();
 		$$.levelColor = $$.generateLevelColor();

--- a/src/module/util.ts
+++ b/src/module/util.ts
@@ -312,11 +312,13 @@ function getBoundingRect(node): {
 /**
  * Retrun random number
  * @param {boolean} asStr Convert returned value as string
+ * @param {number} min Minimum value
+ * @param {number} max Maximum value
  * @returns {number|string}
  * @private
  */
-function getRandom(asStr: boolean = true): number | string {
-	const rand = Math.random();
+function getRandom(asStr: boolean = true, min = 0, max = 10000): number | string {
+	const rand = Math.floor(Math.random() * (max - min) + min);
 
 	return asStr ? String(rand) : rand;
 }

--- a/test/internals/core-spec.ts
+++ b/test/internals/core-spec.ts
@@ -285,6 +285,42 @@ describe("CORE", function() {
 		});
 	});
 
+	describe("miscellaneous", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 500, 60]
+					]
+				}
+			};
+		});
+
+		it("datetimeId should be an unique value", () => {
+			const inst = [
+				util.generate({
+					...args,
+					bindto: "#chart1"
+				}),
+				util.generate({
+					...args,
+					bindto: "#chart2"
+				}),
+				util.generate({
+					...args,
+					bindto: "#chart3"
+				})
+			];
+
+			expect(
+				inst.map(v => v.internal.state.datetimeId)
+					.every((v, i, array) => {
+						return array.filter(v2 => v2 === v).length === 1;
+				})
+			).to.be.true;
+		});
+	});	
+
 	describe("options", () => {
 		before(() => {
 			args = {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2551

## Details
<!-- Detailed description of the change/feature -->
Remove changes to be duplicate clip-pah id value, coming from timestamp value.
Make to be defined from random and timestamp computation.