### PR TITLE
feat(api): Implement axis range reset

### DIFF
--- a/test/api/axis-spec.ts
+++ b/test/api/axis-spec.ts
@@ -37,6 +37,9 @@ describe("API axis", function() {
 						label: "Y2 Axis Label"
 					}
 				},
+				transition: {
+					duration: 0
+				},
 				onrendered: function() {
 					main = this.internal.$el.main;
 					resolve(true);
@@ -103,6 +106,7 @@ describe("API axis", function() {
 			const y = 0;
 			const y2 = 5;
 
+			// when
 			chart.axis.min({
 				x,
 				y,
@@ -141,6 +145,7 @@ describe("API axis", function() {
 			const y = 300;
 			const y2 = 100;
 
+			// when
 			chart.axis.max({
 				x,
 				y,
@@ -163,6 +168,80 @@ describe("API axis", function() {
 
 				done();
 			}, 500);
+		});
+
+		it("axis.min(): check unset & shorthand", () => {
+			const current = chart.axis.min();
+
+			after(() => {
+				chart.axis.min(current);
+			})
+
+			// when
+			chart.axis.min({
+				y: false
+			});
+
+			const min = chart.axis.min();
+
+			Object.keys(min).forEach(key => {
+				if (key === "y") {
+					expect(min[key]).to.be.undefined;
+				} else {
+					expect(typeof min[key] === "number").to.be.true;
+				}
+			});
+
+			// when - shorthand
+			chart.axis.min(-100);
+
+			expect(chart.axis.min()).to.be.deep.equal({
+				x: -1, y: -100, y2: -100
+			});
+
+			// when - shorthand
+			chart.axis.min(false);
+
+			expect(chart.axis.min()).to.be.deep.equal({
+				x: -1, y: undefined, y2: undefined
+			});
+		});
+
+		it("axis.max(): check unset & shorthand", () => {
+			const current = chart.axis.max();
+
+			after(() => {
+				chart.axis.max(current);
+			})
+
+			// when
+			chart.axis.max({
+				y2: false
+			});
+
+			const max = chart.axis.max();
+
+			Object.keys(max).forEach(key => {
+				if (key === "y2") {
+					expect(max[key]).to.be.undefined;
+				} else {
+					expect(typeof max[key] === "number").to.be.true;
+				}
+			});
+
+			// when - shorthand
+			chart.axis.max(1000);
+
+			expect(chart.axis.max()).to.be.deep.equal({
+				x: 10, y: 1000, y2: 1000
+			});
+
+			// when - shorthand
+			chart.axis.max(false);
+
+			expect(chart.axis.max()).to.be.deep.equal({
+				x: 10, y: undefined, y2: undefined
+			});
 		});
 	});
 
@@ -223,6 +302,51 @@ describe("API axis", function() {
 
 				done();
 			}, 500);
+		});
+
+		it("axis.range(): check unset & shorthand", () => {
+			const current = chart.axis.range();
+
+			after(() => {
+				chart.axis.range(current);
+			});
+
+			// when
+			chart.axis.range({
+				min: {
+					y: false
+				},
+				max: {
+					y2: false
+				}
+			});
+
+			const range = chart.axis.range();
+
+			expect(range.min.y).to.be.undefined;
+			expect(range.max.y2).to.be.undefined;
+
+			// when - shorthand
+			chart.axis.range({
+				min: -100,
+				max: 15000
+			});
+
+			expect(chart.axis.range()).to.deep.equal({
+				min: {x: -10, y: -100, y2: -100},
+				max: {x: 100, y: 15000, y2: 15000}
+			});
+
+			// when - shorthand
+			chart.axis.range({
+				min: false,
+				max: false
+			});
+
+			expect(chart.axis.range()).to.deep.equal({
+				min: {x: -10, y: undefined, y2: undefined},
+				max: {x: 100, y: undefined, y2: undefined}
+			});
 		});
 	});
 });

--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -177,16 +177,16 @@ export interface Chart {
 		 * Get and set axis min value.
 		 * @param min If min is given, specified axis' min value will be updated. If no argument is given, the current min values for each axis will be returned.
 		 */
-		min(min?: number | { [key: string]: number }): number | {
-			[key: string]: number | { fit?: boolean; value?: number; }
+		min(min?: number | false | { [key: string]: number }): number | {
+			[key: string]: number | undefined
 		};
 
 		/**
 		 * Get and set axis max value.
 		 * @param max If max is given, specified axis' max value will be updated. If no argument is given, the current max values for each axis will be returned.
 		 */
-		max(max?: number | { [key: string]: number }): number | {
-			[key: string]: number | { fit?: boolean; value?: number; }
+		max(max?: number | false | { [key: string]: number }): number | {
+			[key: string]: number | undefined
 		};
 
 		/**
@@ -194,11 +194,11 @@ export interface Chart {
 		 * @param range If range is given, specified axis' min and max value will be updated. If no argument is given, the current min and max values for each axis will be returned.
 		 */
 		range(range?: {
-			min?: number | { [key: string]: number };
-			max?: number | { [key: string]: number };
+			min?: number | false | { [key: string]: number | false };
+			max?: number | false | { [key: string]: number | false };
 		}): {
-			min: number | { [key: string]: number };
-			max: number | { [key: string]: number };
+			min: number | { [key: string]: number | undefined };
+			max: number | { [key: string]: number | undefined };
 		};
 	};
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2398

## Details
<!-- Detailed description of the change/feature -->
Add capability to reset specified axis range min/max value

```js
chart.axis.min({
    x: false,
    y: false,
    y2: false
});

// shorthand
chart.axis.min(-100);  // will set min of y/y2 as -100
chart.axis.min(false);  // will unset min of y/y2

chart.axis.max({
    x: false,
    y: false,
    y2: false
});

// shorthand
chart.axis.max(1000);  // will set max of y/y2 as 1000
chart.axis.max(false);  // will unset max of y/y2

chart.axis.range({
    min: {
        x: false,
        y: false,
        y2: false
    },
    max: {
        x: false,
        y: false,
        y2: false
    },
});

// shorthand
chart.axis.range({
  // shorthand, which sets min of y/y2 as -100, max of y/y2 as 10000
  min: -100,
  max: 10000,
  
  // shorthand, which unset min & max of y/y2
  min: false,
  max: false
});

```