### PR TITLE
fix(option): Fix data.hide not working for bubble/scatter type

### DIFF
--- a/src/ChartInternal/shape/point.ts
+++ b/src/ChartInternal/shape/point.ts
@@ -89,8 +89,7 @@ export default {
 			const mainCircle = $el.main.select(`.${$CIRCLE.chartCircles}`)
 				.style("pointer-events", "none")
 				.selectAll(`.${$CIRCLE.circles}`)
-				.data(targets)
-				.attr("class", classCircles);
+				.data(targets);
 
 			mainCircle.exit().remove();
 			enterNode = mainCircle.enter();
@@ -102,7 +101,11 @@ export default {
 
 		enterNode.append("g")
 			.attr("class", classCircles)
-			.style("cursor", d => (isFunction(isSelectable) && isSelectable(d) ? "pointer" : null));
+			.style("cursor", d => (isFunction(isSelectable) && isSelectable(d) ? "pointer" : null))
+			.style("opacity", function() {
+				// if the parent node is .bb-chart-circles (bubble, scatter), initialize <g bb-circles> with opacity "0"
+				return this.parentNode?.classList.contains("bb-chart-circles") ? "0" : null;
+			});
 
 		// Update date for selected circles
 		selectionEnabled && targets.forEach(t => {

--- a/test/internals/data-spec.ts
+++ b/test/internals/data-spec.ts
@@ -684,6 +684,47 @@ describe("DATA", () => {
 		});
 	});
 
+	describe("data.hide", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 50, 20, 10, 40, 15, 25],
+						["data3", 170, 250, 210, 190, 175, 225],
+						["data4", 283, 170, 275, 143, 220, 255]
+					],
+					hide: true,
+					type: "line",
+					types: {
+						data1: "bubble",
+						data2: "scatter"
+					}
+				}
+			};
+		});
+
+		it("All types should be hidden", () => {
+			const selector = `.${$COMMON.target}, .${$CIRCLE.chartCircles} > .${$CIRCLE.circles}`;
+
+			chart.$.svg.selectAll(selector).each(function() {
+				expect(this.style.opacity).to.be.equal("0");
+			});
+		});
+
+		it("set options: data.hide=['data1', 'data2']", () => {
+			args.data.hide = ["data1", "data2"];
+		});
+
+		it("only given dataseries should be hidden", () => {
+			const selector = `.${$COMMON.target}, .${$CIRCLE.chartCircles} > .${$CIRCLE.circles}`;
+
+			chart.$.svg.selectAll(selector).each(function(d) {
+				expect(this.style.opacity).to.be.equal(args.data.hide.indexOf(d.id) > -1 ? "0" : "");
+			});
+		});
+	});
+
 	describe("data.regions", () => {
 		before(() => {
 			args = {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2609

## Details
<!-- Detailed description of the change/feature -->
Make bubble/scatter type circle to be initialized with opacity=0,
and then handle the opacity at the initialization according dataset's visibility option.