### PR TITLE
fix(point,util): fix syntax to work on legacy browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,15 @@ If you want to use 'billboard.js' without installation, load files directly from
 
 ## Supported Browsers
 
-> Basically will work on all SVG supported browsers.
+> - Basically will work on all SVG supported browsers.
+> - <sup>*</sup>Notes for legacy browsers:
+>   - Recommended to use `packaged` build or construct your own build following [`How to bundle for legacy browsers?`](https://github.com/naver/billboard.js/wiki/How-to-bundle-for-legacy-browsers%3F) instruction.
+>   - D3.js dropped the support of legacy browsers since [v6](https://observablehq.com/@d3/d3v6-migration-guide).
+>   - The support isn't fully guaranteed.
 
 |Internet Explorer|Chrome|Firefox|Safari|iOS|Android|
 |---|---|---|---|---|---|
-|9+|Latest|Latest|Latest|8+|4+|
+|9+<sup>*</sup>|Latest|Latest|Latest|8+|4+|
 
 
 ## Dependency by version

--- a/src/ChartInternal/shape/point.ts
+++ b/src/ChartInternal/shape/point.ts
@@ -103,8 +103,10 @@ export default {
 			.attr("class", classCircles)
 			.style("cursor", d => (isFunction(isSelectable) && isSelectable(d) ? "pointer" : null))
 			.style("opacity", function() {
+				const parent = d3Select(this.parentNode);
+
 				// if the parent node is .bb-chart-circles (bubble, scatter), initialize <g bb-circles> with opacity "0"
-				return this.parentNode?.classList.contains("bb-chart-circles") ? "0" : null;
+				return parent.attr("class").indexOf($CIRCLE.chartCircles) > -1 ? "0" : null;
 			});
 
 		// Update date for selected circles

--- a/src/module/util.ts
+++ b/src/module/util.ts
@@ -768,5 +768,6 @@ function convertInputType(mouse: boolean, touch: boolean): "mouse" | "touch" | n
 	const hasMouse = mouse && ["any-hover:hover", "any-pointer:fine"]
 		.some(v => matchMedia?.(`(${v})`).matches);
 
-	return (hasMouse && "mouse") || (hasTouch && "touch") || null;
+	// fallback to 'mouse' if no input type is detected.
+	return (hasMouse && "mouse") || (hasTouch && "touch") || "mouse";
 }


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2637

## Details
<!-- Detailed description of the change/feature -->
- Make .inputType() to return 'mouse' if haven't detected any.
- Degrade the use of DOM APIs which isn't supported for legacy browser.