### PR TITLE
fix(plugin): fix stanford tooltip formatting

### DIFF
--- a/src/Plugin/stanford/index.ts
+++ b/src/Plugin/stanford/index.ts
@@ -228,20 +228,23 @@ export default class Stanford extends Plugin {
 
 		if (isEmpty(config.tooltip_contents)) {
 			config.tooltip_contents = function(d, defaultTitleFormat, defaultValueFormat, color) {
+				const {data_x} = config;
 				let html = `<table class="${$TOOLTIP.tooltip}"><tbody>`;
 
 				d.forEach(v => {
+					const {id = "", value = 0, epochs = 0, x = ""} = v;
+
 					html += `<tr>
-							<th>${defaultTitleFormat(config.data_x)}</th>
-							<th class="value">${defaultValueFormat(v.x)}</th>
+							<th>${data_x || ""}</th>
+							<th class="value">${defaultTitleFormat(x)}</th>
 						</tr>
 						<tr>
-							<th>${defaultTitleFormat(v.id)}</th>
-							<th class="value">${defaultValueFormat(v.value)}</th>
+							<th>${v.id}</th>
+							<th class="value">${defaultValueFormat(value)}</th>
 						</tr>
-						<tr class="${$TOOLTIP.tooltipName}-${v.id}">
-							<td class="name"><span style="background-color:${color(v)}"></span>${defaultTitleFormat("Epochs")}</td>
-							<td class="value">${defaultValueFormat(v.epochs)}</td>
+						<tr class="${$TOOLTIP.tooltipName}-${id}">
+							<td class="name"><span style="background-color:${color(v)}"></span>Epochs</td>
+							<td class="value">${defaultValueFormat(epochs)}</td>
 						</tr>`;
 				});
 

--- a/test/plugin/stanford/stanford-spec.ts
+++ b/test/plugin/stanford/stanford-spec.ts
@@ -12,7 +12,7 @@ import {compareEpochs, getCentroid, getRegionArea, pointInRegion} from "../../..
 describe("PLUGIN: STANFORD", () => {
 	let chart;
 	let stanford = new Stanford({ epochs: [30, 35] });
-	let args = {
+	let args: any = {
 		data: {
 			x: "x",
 			columns: [
@@ -175,6 +175,76 @@ describe("PLUGIN: STANFORD", () => {
 			chart.plugins[0].options.regions[0].text.args.forEach(v => {
 				expect(v.every(t => typeof t === "number")).to.be.true;
 			});
+		});
+	});
+
+	describe("tooltip", () => {
+		before(() => {
+			args = {
+				data: {
+					x: "Datetime",
+					columns: [
+					  [
+						"Datetime",
+						1650965572,
+						1650965572,
+						1650965572
+					  ],
+					  [
+						"Pressure",
+						1,
+						2.04,
+						2.96
+					  ],
+					],
+					type: "scatter"
+				},
+				axis: {
+					x: {
+						label: "Datetime",
+						tick: {
+							fit: true,
+							count: 30,
+							format: '%d/%m/%y',
+							culling: {
+								max: 6
+							}
+						},
+						type: 'timeseries'
+					}
+				},
+				plugins: [
+					new Stanford({
+						epochs: [
+							34.794, 34.787, 34.791
+						],
+						scale: {
+							min: 34.79,
+							max: 35.139,
+							width: 10
+						}
+					})
+				]
+			};
+		});
+
+		it("sholud tooltip name and value display correctly for timeseries.", () => {
+			const {tooltip} = chart.$;
+
+			chart.tooltip.show({
+				data: {
+					x: new Date(1650965572),  // x Axis value
+					id: "Pressure",
+					value: 1
+				}
+			});
+
+			tooltip.selectAll("th:first-child").each(function(d, i) {
+				expect(this.textContent).to.be.equal(args.data.columns[i][0]);
+			});
+
+			expect(tooltip.select(".value").text()).to.be.equal("20/01/70");
+			expect(tooltip.select(".name").text()).to.be.equal("Epochs");
 		});
 	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2657

## Details
<!-- Detailed description of the change/feature -->
Fix formatting tooltip for timeseries type chart

<img width="506" alt="image" src="https://user-images.githubusercontent.com/2178435/166956773-1bb7a9fe-32aa-4025-8573-30bc18e67352.png">



