### PR TITLE
fix(types): Fix the signature of the tick format callback for timeseries

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1193,7 +1193,7 @@ export interface SubchartOptions {
 				 * Use custom format for x axis ticks - see 'axis.x.tick.format' option for details.
 				 */
 				format?: string
-					| ((this: Chart, x: number | Date) => string | number)
+					| ((this: Chart, x: Date) => string | number)
 					| ((this: Chart, index: number, categoryName: string) => string);
 				/**
 				 * Show or hide x axis tick line.


### PR DESCRIPTION
## Issue

## Details

When running typescript in strict modes, it checks the compatibility of callback signatures.
When using a timeseries axis and passing a date formatting callback for the ticks, it currently returns that error:

```
assets/js/widget/program-evolution-chart.js:76:15 - error TS2322: Type '(arg0: Date) => string' is not assignable to type 'string | ((this: Chart, x: number | Date) => string | number) | ((this: Chart, index: number, categoryName: string) => string) | undefined'.
  Type '(arg0: Date) => string' is not assignable to type '(this: Chart, x: number | Date) => string | number'.
    Types of parameters 'arg0' and 'x' are incompatible.
      Type 'number | Date' is not assignable to type 'Date'.
        Type 'number' is not assignable to type 'Date'.

76       format: formatDate,
                 ~~~~~~~~~~
```

The documentation explicitly says that timeseries axis are always passing a Date there, so there is no need to require a callback support both dates and numbers:
![image](https://user-images.githubusercontent.com/439401/167250179-6a2d7285-b066-41fc-8241-1759770222d3.png)

