### PR TITLE
fix(types): Fix the type for options.data.names

### DIFF
--- a/src/Chart/api/data.ts
+++ b/src/Chart/api/data.ts
@@ -97,7 +97,7 @@ extend(data, {
 	 * @function data․names
 	 * @instance
 	 * @memberof Chart
-	 * @param {object} names If this argument is given, the names of data will be updated. If not given, the current names will be returned. The format of this argument is the same as
+	 * @param {object} names If this argument is given, the names of data will be updated. If not given, the current names will be returned. The format of this argument is the same as [data.names](./Options.html#.data%25E2%2580%25A4names).
 	 * @returns {object} Corresponding names according its key value, if specified names values.
 	 * @example
 	 * // Get current names
@@ -110,7 +110,7 @@ extend(data, {
 	 *  data2: "New Name 2"
 	 *});
 	 */
-	names: function(names?: Array<{ [key: string]: string; }>): {[key: string]: string} {
+	names: function(names?: Array<{ [key: string]: string|null; }>): {[key: string]: string|null} {
 		const $$ = this.internal;
 
 		return $$.updateDataAttributes("names", names);

--- a/src/config/Options/data/data.ts
+++ b/src/config/Options/data/data.ts
@@ -45,6 +45,7 @@ export default {
 
 	/**
 	 * Set custom data name.
+	 * If a name is set to `null`, the series is omitted from the legend.
 	 * @name data․names
 	 * @memberof Options
 	 * @type {object}
@@ -58,7 +59,7 @@ export default {
 	 *   }
 	 * }
 	 */
-	data_names: <{[key: string]: string}> {},
+	data_names: <{[key: string]: string|null}> {},
 
 	/**
 	 * Set custom data class.<br><br>

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1520,7 +1520,7 @@ export interface Data {
 	/**
 	 * Set custom data name.
 	 */
-	names?: { [key: string]: string };
+	names?: { [key: string]: string|null };
 	/**
 	 * Set custom data class.
 	 * If this option is specified, the element g for the data has an additional class that has the prefix billboard-target- (e.g. billboard-target-additional-data1-class).


### PR DESCRIPTION
## Issue

## Details
The code supports setting a name to null to hide it from the legend. But type declarations were not allowing it:
https://github.com/naver/billboard.js/blob/9a87464c5212e8d29c0a7b3d3d07729524aa911a/src/ChartInternal/internals/legend.ts#L460-L462
