### PR TITLE
fix(plugin): fix sparkline dimension & tooltip

### DIFF
--- a/src/Plugin/sparkline/index.ts
+++ b/src/Plugin/sparkline/index.ts
@@ -119,16 +119,26 @@ export default class Sparkline extends Plugin {
 
 		config.legend_show = false;
 		config.resize_auto = false;
-
 		config.axis_x_show = false;
-		config.axis_x_padding = {
-			left: 15,
-			right: 15,
-			unit: "px"
-		};
+
+		// set default axes padding
+		if (config.padding !== false) {
+			const hasOption = o => Object.keys(o || {}).length > 0;
+
+			if (hasOption(config.axis_x_padding)) {
+				config.axis_x_padding = {
+					left: 15,
+					right: 15,
+					unit: "px"
+				};
+			}
+
+			if (hasOption(config.axis_y_padding)) {
+				config.axis_y_padding = 5;
+			}
+		}
 
 		config.axis_y_show = false;
-		config.axis_y_padding = 5;
 
 		if (!config.tooltip_position) {
 			config.tooltip_position = function(data, width, height) {
@@ -150,8 +160,7 @@ export default class Sparkline extends Plugin {
 	}
 
 	$init(): void {
-		const {$$} = this;
-		const {$el} = $$;
+		const {$$: {$el}} = this;
 
 		// make disable-ish main chart element
 		$el.chart
@@ -159,7 +168,7 @@ export default class Sparkline extends Plugin {
 			.style("height", "0")
 			.style("pointer-events", "none");
 
-		document.body.appendChild($el.tooltip.node());
+		$el.tooltip?.node() && document.body.appendChild($el.tooltip.node());
 	}
 
 	$afterInit(): void {
@@ -178,7 +187,9 @@ export default class Sparkline extends Plugin {
 	 * @private
 	 */
 	bindEvents(bind = true): void {
-		if (this.$$.config.interaction_enabled) {
+		const {$$: {config}} = this;
+
+		if (config.interaction_enabled && config.tooltip_show) {
 			const method = `${bind ? "add" : "remove"}EventListener`;
 
 			this.element

--- a/test/plugin/sparkline/sparkline-spec.ts
+++ b/test/plugin/sparkline/sparkline-spec.ts
@@ -4,7 +4,7 @@
  */
 /* eslint-disable */
 import {expect} from "chai";
-import {$CIRCLE, $COMMON} from "../../../src/config/classes";
+import {$AREA, $CIRCLE, $COMMON} from "../../../src/config/classes";
 import Sparkline from "../../../src/Plugin/sparkline";
 import util from "../../assets/util";
 
@@ -22,6 +22,13 @@ describe("PLUGIN: SPARKLINE", () => {
 				["data2", 200, 130, 90],
 				["data3", 300, 200, 160]
 			],
+			types: {
+				data3: "area"
+			}
+		},
+		padding: {},
+		tooltip: {
+			show: true
 		},
 		plugins: [
 			new Sparkline({
@@ -80,7 +87,21 @@ describe("PLUGIN: SPARKLINE", () => {
 		}, chart);
 
 		expect(tooltip.style("display")).to.be.equal("none");
+	});
+	
+	it("set options", () => {
+		args.padding = false;
+		args.tooltip.show = false;
+	});
 
-		console.log(1);
-	})
+	it("check for the dimension & tooltip", () => {
+		const last = document.querySelectorAll(selector)[2];
+		const {width, height} = last.querySelector(`.${$AREA.areas} path`).getBoundingClientRect();
+
+		// chart element should occupy the whole dimension of given size
+		expect({width, height}).to.be.deep.equal(args.size);
+
+		// tooltip element shouldn't be added to the DOM
+		expect(chart.$.tooltip).to.be.null;
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2682

## Details
<!-- Detailed description of the change/feature -->
- Make to override padding values when there's no option given and when padding != false.
- Append tooltip node when tooltip is enabled and bind events when is necessary only.