### PR TITLE
fix(size.axis): fix truncated axis when has no data

### DIFF
--- a/src/ChartInternal/internals/size.axis.ts
+++ b/src/ChartInternal/internals/size.axis.ts
@@ -25,9 +25,12 @@ export default {
 
 		if ($$.axis) {
 			const position = $$.axis?.getLabelPositionById(id);
+			const width = $$.axis.getMaxTickWidth(id, withoutRecompute);
+			const gap = width === 0 ? 0.5 : 0;
 
-			return $$.axis.getMaxTickWidth(id, withoutRecompute) +
-				(position.isInner ? 20 : 40);
+			return width + (
+				position.isInner ? (20 + gap) : 40
+			);
 		} else {
 			return 40;
 		}

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -2537,6 +2537,33 @@ describe("AXIS", function() {
 				axisY.select(".tick:nth-child(12)").node().getBoundingClientRect().width
 			);
 		});
+
+		it("set option", () => {
+			args = {
+				data: {
+					columns: [
+						["data1"]
+					],
+					empty: {
+						label: {
+							text: "No data..."
+						}
+					},
+					type: "line"
+				},
+				axis: {
+					y: {
+						label: "Your Y Axis"
+					}
+				}
+			};
+		});
+
+		it("<clipPath> width shouldn't truncate y axis tick when has no data", () => {
+			const rect = chart.internal.$el.defs.selectAll("clipPath[id$='yaxis'] rect");
+
+			expect(+rect.attr("width")).to.be.equal(50);
+		});
 	});
 
 	describe("Axes tick culling", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2675

## Details
<!-- Detailed description of the change/feature -->
Add gap pixels when tickWidth is zero.

<img width="522" alt="image" src="https://user-images.githubusercontent.com/2178435/169452723-12d04e0e-2a27-4413-8978-1552a3281dd0.png">
