### PR TITLE
fix(types): Fix types for the tooltip contents callback

### DIFF
--- a/src/config/Options/common/tooltip.ts
+++ b/src/config/Options/common/tooltip.ts
@@ -39,7 +39,7 @@ export default {
 	 *  - **Note:**
 	 *    - defaultTitleFormat:
 	 *      - if `axis.x.tick.format` option will be used if set.
-	 *      - otherwise, will return funciton based on tick format type(category, timeseries).
+	 *      - otherwise, will return function based on tick format type(category, timeseries).
 	 *    - defaultValueFormat:
 	 *	    - for Arc type (except gauge, radar), the function will return value from `(ratio * 100).toFixed(1)`.
 	 *	    - for Axis based types, will be used `axis.[y|y2].tick.format` option value if is set.

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1083,9 +1083,9 @@ export interface TooltipOptions {
 	contents?: ((
 		this: Chart,
 		data: any,
-		defaultTitleFormat: string,
-		defaultValueFormat: string,
-		color: any
+		defaultTitleFormat: (x: any) => string,
+		defaultValueFormat: (value: any, ratio: number|undefined, id: string) => number|string,
+		color: (d: any) => string
 	) => string) | {
 		/**
 		 * Set CSS selector or element reference to bind tooltip.


### PR DESCRIPTION
## Issue

## Details

The arguments were not typed properly as functions (but the doc was showing them as being functions)
