### PR TITLE
Fix `Chart.load({ json })` typing

### DIFF
--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -347,7 +347,7 @@ export interface Chart {
 	load(this: Chart, args: {
 		append?: boolean;
 		url?: string;
-		json?: [{ [key: string]: string | number }] | {[key: string]: Array<string|number>};
+		json?: { [key: string]: string | number }[] | {[key: string]: Array<string|number>};
 		rows?: PrimitiveArray[];
 		columns?: PrimitiveArray[];
 		data?: Array<{ [key: string]: number }>;


### PR DESCRIPTION
The existing type specified a tuple with a single element, instead of an array of elements.

## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
<!-- Detailed description of the change/feature -->
