### PR TITLE
feat(resize): Intent to ship resize.timer

### DIFF
--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -715,7 +715,7 @@ export default class ChartInternal {
 	bindResize(): void {
 		const $$ = <any> this;
 		const {config, state} = $$;
-		const resizeFunction = generateResize();
+		const resizeFunction = generateResize(config.resize_timer);
 		const list: Function[] = [];
 
 		list.push(() => callFn(config.onresize, $$, $$.api));

--- a/src/config/Options/common/main.ts
+++ b/src/config/Options/common/main.ts
@@ -144,12 +144,24 @@ export default {
 	 * @type {object}
 	 * @property {object} [resize] resize object
 	 * @property {boolean} [resize.auto=true] Set chart resize automatically on viewport changes.
+	 * @property {boolean|number} [resize.timer=true] Set resize timer option.
+	 * - **NOTE:** The resize function will be called using: true - `setTimeout()`, false - `requestIdleCallback()`.
 	 * @example
 	 *  resize: {
-	 *      auto: false
+	 *      auto: false,
+	 *
+	 *      // set resize function will be triggered using `setTimer()`
+	 *      timer: true,
+	 *
+	 *      // set resize function will be triggered using `requestIdleCallback()`
+	 *      timer: false,
+	 *
+	 *      // set resize function will be triggered using `setTimer()` with a delay of `100ms`.
+	 *      timer: 100
 	 *  }
 	 */
 	resize_auto: true,
+	resize_timer: true,
 
 	/**
 	 * Set a callback to execute when the chart is clicked.

--- a/src/module/generator.ts
+++ b/src/module/generator.ts
@@ -4,16 +4,17 @@
  */
 import {d3Transition} from "../../types/types";
 import {window} from "./browser";
-import {isArray, isTabVisible} from "./util";
+import {isArray, isNumber, isTabVisible} from "./util";
 
 const {setTimeout, clearTimeout} = window;
 
 /**
  * Generate resize queue function
+ * @param {boolean|number} option Resize option
  * @returns {Fucntion}
  * @private
  */
-export function generateResize() {
+export function generateResize(option: boolean|number) {
 	const fn: any[] = [];
 	let timeout;
 
@@ -21,9 +22,15 @@ export function generateResize() {
 		// Delay all resize functions call, to prevent unintended excessive call from resize event
 		callResizeFn.clear();
 
-		timeout = setTimeout(() => {
-			fn.forEach((f: Function) => f());
-		}, 200);
+		if (option === false && window.requestIdleCallback) {
+			requestIdleCallback(() => {
+				fn.forEach((f: Function) => f());
+			}, {timeout: 200});
+		} else {
+			timeout = setTimeout(() => {
+				fn.forEach((f: Function) => f());
+			}, isNumber(option) ? option : 200);
+		}
 	};
 
 	callResizeFn.clear = () => {

--- a/test/internals/bb-spec.ts
+++ b/test/internals/bb-spec.ts
@@ -299,7 +299,7 @@ describe("Interface & initialization", () => {
 					]
 				},
 				resize: {
-					timer: 1000
+					timer: 500
 				}
 			});
 
@@ -313,7 +313,7 @@ describe("Interface & initialization", () => {
 			let count = 0;
 			const interval = setInterval(function() {
 				const w = +chart.$.svg.attr("width");
-console.log("-->", w)
+
 				if (w === width) {
 					clearInterval(interval);
 

--- a/test/internals/bb-spec.ts
+++ b/test/internals/bb-spec.ts
@@ -666,43 +666,5 @@ describe("Interface & initialization", () => {
 			start = Date.now();
 			window.dispatchEvent(new Event("resize"));
 		});
-
-		it("check for the resize timer delay call", done => {
-			const timer = 1000;
-			let start = 0;
-			const resized = function() {
-				const diff = Date.now() - start;
-
-				if (diff > 1000 && diff < 1100) {
-					expect(true).to.be.ok;
-				}
-
-				done();
-			};
-
-			container.innerHTML = `<div id="chartTimerResize2" style="width:640px"></div>`;
-
-			const chart = util.generate({
-				bindto: "#chartTimerResize2",
-				data: {
-					columns: [
-						["data1", 30, 200, 100, 400],
-						["data2", 500, 800, 500, 2000]
-					]
-				},
-				resize: {
-					timer
-				},
-				onresized: resized,
-				onreisze: resized
-			});
-
-			// resize chart holder
-			chart.$.chart.style("width", "300px");
-
-			// trigger resize eventize 
-			start = Date.now();
-			window.dispatchEvent(new Event("resize"));
-		});
 	});
 });

--- a/test/internals/bb-spec.ts
+++ b/test/internals/bb-spec.ts
@@ -140,14 +140,15 @@ describe("Interface & initialization", () => {
 	});
 
 	describe("auto resize", () => {
+		const containerName = "container";
 		let container;
 
 		beforeEach(() => {
-			container = document.getElementById("container");
+			container = document.getElementById(containerName);
 
 			if (!container) {
 				container = document.createElement("div");
-				container.id = "container";
+				container.id = containerName;
 				document.body.appendChild(container);
 			}
 		});
@@ -284,76 +285,6 @@ describe("Interface & initialization", () => {
 			});
 
 			expect(chart.$.chart.node().getBoundingClientRect().height).to.be.equal(height);
-		});
-
-		it("check for the resize timer delay call", done => {
-			const width = 300;
-			container.innerHTML = `<div id="chartTimerResize" style="width:640px"></div>`;
-
-			chart = util.generate({
-				bindto: "#chartTimerResize",
-				data: {
-					columns: [
-						["data1", 30, 200, 100, 400],
-						["data2", 500, 800, 500, 2000]
-					]
-				},
-				resize: {
-					timer: 500
-				}
-			});
-
-			// resize chart holder
-			chart.$.chart.style("width", `${width}px`);
-
-			// trigger resize eventize 
-			window.dispatchEvent(new Event("resize"));
-
-			// wait for the timer
-			let count = 0;
-			const interval = setInterval(function() {
-				const w = +chart.$.svg.attr("width");
-
-				if (w === width) {
-					clearInterval(interval);
-
-					expect(count > 0).to.be.true;
-					done();
-				}
-
-				count++;
-			}, 50);
-
-		});
-
-		it("check for the resize timer using requestIdleCallback()", done => {
-			chart.$.chart.style("width", "640px");
-
-			chart = util.generate({
-				bindto: "#chartTimerResize",
-				data: {
-					columns: [
-						["data1", 30, 200, 100, 400],
-						["data2", 500, 800, 500, 2000]
-					]
-				},
-				resize: {
-					timer: false
-				}
-			});
-
-			const width = 300;
-
-			// resize chart holder
-			chart.$.chart.style("width", `${width}px`);
-
-			// trigger resize eventize 
-			window.dispatchEvent(new Event("resize"));
-
-			setTimeout(() => {
-				expect(+chart.$.svg.attr("width")).to.be.equal(width);
-				done();
-			}, 50);
 		});
 	});
 
@@ -688,6 +619,89 @@ describe("Interface & initialization", () => {
 			const element = chart.$.main.select(".myBgClass");
 
 			expect(element.node().nextSibling.getAttribute("class")).to.be.equal($COMMON.chart);
+		});
+	});
+
+	describe("resize options", () => {
+		const containerName = "container2";
+		let container;
+
+		beforeEach(() => {
+			container = document.getElementById(containerName);
+
+			if (!container) {
+				container = document.createElement("div");
+				container.id = containerName;
+				document.body.appendChild(container);
+			}
+		});
+
+		it("check for the resize timer using requestIdleCallback()", done => {			
+			container.innerHTML = `<div id="chartTimerResize1" style="width:640px"></div>`;
+
+			let start = 0;
+			const chart = util.generate({
+				bindto: "#chartTimerResize1",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				},
+				resize: {
+					timer: false
+				},
+				onresized: function() {
+					expect(Date.now() - start).to.be.below(100);
+					done();
+				}
+			});
+
+			const width = 300;
+
+			// resize chart holder
+			chart.$.chart.style("width", `${width}px`);
+
+			// trigger resize eventize 
+			start = Date.now();
+			window.dispatchEvent(new Event("resize"));
+		});
+
+		it("check for the resize timer delay call", done => {
+			const width = 300;
+			const timer = 1000;
+			let start = 0;
+
+			container.innerHTML = `<div id="chartTimerResize2" style="width:640px"></div>`;
+
+			const chart = util.generate({
+				bindto: "#chartTimerResize2",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				},
+				resize: {
+					timer
+				},
+				onresized: function() {
+					const diff = Date.now() - start;
+
+					if (diff > 1000 && diff < 1100) {
+						expect(true).to.be.ok;
+					}
+
+					done();
+				}
+			});
+
+			// resize chart holder
+			chart.$.chart.style("width", `${width}px`);
+
+			// trigger resize eventize 
+			start = Date.now();
+			window.dispatchEvent(new Event("resize"));
 		});
 	});
 });

--- a/test/internals/bb-spec.ts
+++ b/test/internals/bb-spec.ts
@@ -313,7 +313,7 @@ describe("Interface & initialization", () => {
 			let count = 0;
 			const interval = setInterval(function() {
 				const w = +chart.$.svg.attr("width");
-
+console.log("-->", w)
 				if (w === width) {
 					clearInterval(interval);
 

--- a/test/internals/bb-spec.ts
+++ b/test/internals/bb-spec.ts
@@ -285,6 +285,76 @@ describe("Interface & initialization", () => {
 
 			expect(chart.$.chart.node().getBoundingClientRect().height).to.be.equal(height);
 		});
+
+		it("check for the resize timer delay call", done => {
+			const width = 300;
+			container.innerHTML = `<div id="chartTimerResize" style="width:640px"></div>`;
+
+			chart = util.generate({
+				bindto: "#chartTimerResize",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				},
+				resize: {
+					timer: 1000
+				}
+			});
+
+			// resize chart holder
+			chart.$.chart.style("width", `${width}px`);
+
+			// trigger resize eventize 
+			window.dispatchEvent(new Event("resize"));
+
+			// wait for the timer
+			let count = 0;
+			const interval = setInterval(function() {
+				const w = +chart.$.svg.attr("width");
+
+				if (w === width) {
+					clearInterval(interval);
+
+					expect(count > 0).to.be.true;
+					done();
+				}
+
+				count++;
+			}, 50);
+
+		});
+
+		it("check for the resize timer using requestIdleCallback()", done => {
+			chart.$.chart.style("width", "640px");
+
+			chart = util.generate({
+				bindto: "#chartTimerResize",
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 500, 800, 500, 2000]
+					]
+				},
+				resize: {
+					timer: false
+				}
+			});
+
+			const width = 300;
+
+			// resize chart holder
+			chart.$.chart.style("width", `${width}px`);
+
+			// trigger resize eventize 
+			window.dispatchEvent(new Event("resize"));
+
+			setTimeout(() => {
+				expect(+chart.$.svg.attr("width")).to.be.equal(width);
+				done();
+			}, 50);
+		});
 	});
 
 	describe("set defaults options", () => {

--- a/test/internals/bb-spec.ts
+++ b/test/internals/bb-spec.ts
@@ -668,9 +668,17 @@ describe("Interface & initialization", () => {
 		});
 
 		it("check for the resize timer delay call", done => {
-			const width = 300;
 			const timer = 1000;
 			let start = 0;
+			const resized = function() {
+				const diff = Date.now() - start;
+
+				if (diff > 1000 && diff < 1100) {
+					expect(true).to.be.ok;
+				}
+
+				done();
+			};
 
 			container.innerHTML = `<div id="chartTimerResize2" style="width:640px"></div>`;
 
@@ -685,19 +693,12 @@ describe("Interface & initialization", () => {
 				resize: {
 					timer
 				},
-				onresized: function() {
-					const diff = Date.now() - start;
-
-					if (diff > 1000 && diff < 1100) {
-						expect(true).to.be.ok;
-					}
-
-					done();
-				}
+				onresized: resized,
+				onreisze: resized
 			});
 
 			// resize chart holder
-			chart.$.chart.style("width", `${width}px`);
+			chart.$.chart.style("width", "300px");
 
 			// trigger resize eventize 
 			start = Date.now();


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2650

## Details
<!-- Detailed description of the change/feature -->
Implement resize.timer option, where to give alternative option
for controlling timer trigger delay and use requestIdleCallback()
instead.

```js
resize: {
    timer: false,  // make to use 'requestIdleCallback()'
    timer: 1000 // trigger resize function on delay of 1000ms (default delay is 200ms)
}
```

- default resize(w/200ms delay)
![Jun-02-2022 15-53-33](https://user-images.githubusercontent.com/2178435/171571325-65c7dd40-6eb3-4ad3-9098-dc2c9c8edf20.gif)

- using 'requestCallbackIdle()
![Jun-02-2022 15-54-14](https://user-images.githubusercontent.com/2178435/171571340-53580cef-0eca-49f0-bde2-6c24593706b5.gif)

