### PR TITLE
refactor(color): Refactor getColorFromCss()

### DIFF
--- a/demo/benchmark/benchmark.js
+++ b/demo/benchmark/benchmark.js
@@ -11,6 +11,10 @@ window.bench = {
         transition: document.getElementById("transition")
     },
     init() {
+        if (/^(127\.|localhost)/.test(location.host)) {
+            this.target.push("local");
+        }
+
        // append targeted version list
        this.target.forEach(v => {
          this.$el.version.add(new Option(v, v));
@@ -36,7 +40,7 @@ window.bench = {
     
             data.push(d);
         }
-    
+    console.log(JSON.stringify(data));
         return data;
     },
     loadBillboard: function() {
@@ -44,7 +48,8 @@ window.bench = {
 
         this.billboard && document.head.removeChild(this.billboard);
         this.billboard = document.createElement("script");
-        this.billboard.src = `https://cdn.jsdelivr.net/npm/billboard.js${version === "latest" ? "" : `@${version}`}/dist/billboard.pkgd.min.js`;
+        this.billboard.src = version === "local" ? "../../dist/billboard.pkgd.min.js" :
+            `https://cdn.jsdelivr.net/npm/billboard.js${version === "latest" ? "" : `@${version}`}/dist/billboard.pkgd.min.js`;
 
         this.billboard.onload = () => {
             const {options} = this.$el.version;

--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -202,16 +202,6 @@ export default class ChartInternal {
 			$el.style = styleEl;
 		}
 
-		// when 'padding=false' is set, disable axes and subchart. Because they are useless.
-		if (config.padding === false) {
-			config.axis_x_show = false;
-			config.axis_y_show = false;
-			config.axis_y2_show = false;
-			config.subchart_show = false;
-		}
-
-		$$.initParams();
-
 		const bindto = {
 			element: config.bindto,
 			classname: "bb"
@@ -235,6 +225,7 @@ export default class ChartInternal {
 			.classed(state.datetimeId, useCssRule)
 			.style("position", "relative");
 
+		$$.initParams();
 		$$.initToRender();
 	}
 
@@ -289,6 +280,14 @@ export default class ChartInternal {
 			// to not apply inline color setting
 			$$.colorByRule = null;
 			$$.colorTextByRule = null;
+		}
+
+		// when 'padding=false' is set, disable axes and subchart. Because they are useless.
+		if (config.padding === false) {
+			config.axis_x_show = false;
+			config.axis_y_show = false;
+			config.axis_y2_show = false;
+			config.subchart_show = false;
 		}
 
 		if ($$.hasPointType()) {

--- a/src/ChartInternal/internals/color.ts
+++ b/src/ChartInternal/internals/color.ts
@@ -21,17 +21,18 @@ import {d3Selection} from "../../../types";
  * @private
  */
 const colorizePattern = (pattern, color, id: string) => {
-	const n = d3Select(pattern.cloneNode(true));
-	const node = n
+	const node = d3Select(pattern.cloneNode(true));
+
+	node
 		.attr("id", id)
 		.insert("rect", ":first-child")
-		.attr("width", n.attr("width"))
-		.attr("height", n.attr("height"))
-		.style("fill", color)
-		.node();
+		.attr("width", node.attr("width"))
+		.attr("height", node.attr("height"))
+		.style("fill", color);
 
 	return {
-		id, node
+		id,
+		node: node.node()
 	};
 };
 

--- a/test/internals/color-spec.ts
+++ b/test/internals/color-spec.ts
@@ -51,16 +51,21 @@ describe("COLOR", () => {
 		});
 
 		after(() => {
-			styleSheet.parentNode.removeChild(styleSheet);
+			styleSheet.parentNode?.removeChild(styleSheet);
 			document.body[CACHE_KEY.colorPattern] = null;
 		});
 
 		it("should get and parse from the stylesheet", () => {			
-			const pttrn = chart.internal.getColorFromCss();
+			const color = chart.internal.generateColor();
+			const pttrn: string[] = [];
+			
+			chart.data().forEach(v => {
+				pttrn.push(color(v.id));
+			});
 
 			expect(pttrn).to.deep.equal(pattern);
 
-			// check if pattern value are cached
+			// // check if pattern value are cached
 			expect(document.body["__colorPattern__"]).to.deep.equal(pattern);
 		});
 
@@ -270,7 +275,7 @@ describe("COLOR", () => {
 			const {$: {main}, internal: {$el}} = chart;
 			const eventRect = $el.eventRect.node();
 			const shape = main.selectAll(`.${$SHAPE.shape}-1`);
-			const originalColor = [];
+			const originalColor: any = [];
 
 			shape.each(function() {
 				originalColor.push({


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
- Refactor not appending new element to parse colors from CSS to improve initial render
- Detach extending to ChartInternal
- Add option to load local build on benchmark