### PR TITLE
Feat/area below

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3736,6 +3736,34 @@ d3.select(".chart_area")
 				}
 			}
 		},
+		Below: [{
+			options: {
+				title: {
+				 text: "Area with negative values"
+				},
+				data: {
+					columns: [
+						["data", 230, -280, 251, -400, 150, 546, 158]
+					],
+					type: "area",
+				},
+			}
+		}, {
+			options: {
+				title: {
+				 text: "Area with negative values and area below set to true"
+				},
+			 data: {
+				 columns: [
+					 ["data", 230, -280, 251, -400, 150, 546, 158]
+					],
+					type: "area",
+				},
+				area: {
+					below: true
+				}
+			}
+		}],
 		LinearGradient: [
 			{
 				options: {
@@ -4030,7 +4058,7 @@ d3.select(".chart_area")
 				}
 			}
 		],
-		Padding: [			
+		Padding: [
 			{
 				options: {
 					data: {

--- a/src/ChartInternal/shape/area.ts
+++ b/src/ChartInternal/shape/area.ts
@@ -157,7 +157,7 @@ export default {
 						.x1(value1) :
 					area.x(xValue)
 						// @ts-ignore
-						.y0(config.area_above ? 0 : value0)
+						.y0(config.area_above ? 0 : config.area_below ? $$.state.height : value0)
 						.y1(value1);
 
 				if (!lineConnectNull) {

--- a/src/config/Options/shape/area.ts
+++ b/src/config/Options/shape/area.ts
@@ -13,6 +13,7 @@ export default {
 	 * @type {object}
 	 * @property {object} area Area object
 	 * @property {boolean} [area.above=false] Set background area above the data chart line.
+	 * @property {boolean} [area.below=false] Set background area below the data chart line.
 	 * @property {boolean} [area.front=true] Set area node to be positioned over line node.
 	 * @property {boolean|object} [area.linearGradient=false] Set the linear gradient on area.<br><br>
 	 * Or customize by giving below object value:
@@ -23,6 +24,7 @@ export default {
 	 * @see [MDN's &lt;linearGradient>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient), [&lt;stop>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/stop)
 	 * @see [Demo](https://naver.github.io/billboard.js/demo/#Chart.AreaChart)
 	 * @see [Demo: above](https://naver.github.io/billboard.js/demo/#AreaChartOptions.Above)
+	 * @see [Demo: above](https://naver.github.io/billboard.js/demo/#AreaChartOptions.Below)
 	 * @see [Demo: linearGradient](https://naver.github.io/billboard.js/demo/#AreaChartOptions.LinearGradient)
 	 * @example
 	 *  area: {
@@ -58,6 +60,7 @@ export default {
 	 *  }
 	 */
 	area_above: false,
+	area_below: false,
 	area_front: true,
 	area_linearGradient: <
 	boolean|{x?: number[]; y?: number[]; stops?: [number, string|Function|null, number]}


### PR DESCRIPTION
## Issue
#2740 

## Details
Added option for rendering area below line based on area height. Since it's not possible to use above and below at the same time perhaps it would be more correct to have an option like:

```
area: {
   fill?: 'above' | 'below' | null
}
```

Where omitting it or null would be the default (same as not specifying it right now).
