### PR TITLE
fix(types): Fix the signature of the tick format callback for timeseries

### DIFF
--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -192,7 +192,7 @@ export interface XTickConfiguration {
 	 * A function to format tick value. Format string is also available for timeseries data.
 	 */
 	format?: string
-		| ((this: Chart, x: number | Date) => string | number)
+		| ((this: Chart, x: Date) => string | number)
 		| ((this: Chart, index: number, categoryName: string) => string);
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
this is the one actually fixing what https://github.com/naver/billboard.js/pull/2676 tried to fix (I missed the fact that my first PR was fixing it only for subcharts and not for the x axis of all charts.
