### PR TITLE
fix(types): Fix the type declarations for the y tick format

### DIFF
--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -337,7 +337,7 @@ export interface YTickConfiguration {
 	 * Set formatter for y axis tick text.
 	 * This option accepts d3.format object as well as a function you define.
 	 */
-	format?(this: Chart, x: number | Date): string | number;
+	format?: ((this: Chart, x: number) => string | number) | ((this: Chart, x: Date) => string | number);
 
 	/**
 	 * Setting for culling ticks.


### PR DESCRIPTION
## Issue
This fixes the issue I reported in https://github.com/naver/billboard.js/commit/fb246bc92d328450b185314d5267dfc0862e55d3#r77903654 when those types were changed compared to [my submitted PR](https://github.com/naver/billboard.js/pull/2769)

## Details
<!-- Detailed description of the change/feature -->
