### PR TITLE
refactor(grid): update threshold for grid interval

### DIFF
--- a/src/ChartInternal/Axis/AxisRenderer.ts
+++ b/src/ChartInternal/Axis/AxisRenderer.ts
@@ -243,7 +243,7 @@ export default class AxisRenderer {
 		let res = this.generatedTicks;
 
 		if (len > count) {
-			const interval = Math.round((len / count) - 0.1);
+			const interval = Math.round((len / count) + 0.1);
 
 			res = this.generatedTicks
 				.map((v, i) => (i % interval === 0 ? v : null))

--- a/test/internals/grid-spec.ts
+++ b/test/internals/grid-spec.ts
@@ -178,6 +178,36 @@ describe("GRID", function() {
 		});
 
 		it("set options", () => {
+				args = {
+					data: {
+						columns: [
+							["data1", 130, 340, 200, 500, 250, 350]
+						],
+						type: "line"
+					},
+					axis: {
+						y: {
+							min: 0
+						}
+					},
+					grid: {
+						y: {
+							show: true,
+							ticks: 5
+						}
+					}
+				};
+		});
+		
+		it("y grid showed with nice intervals?", () => {
+			const yPos = [426, 320, 214, 108, 1];
+
+			chart.$.grid.y.each(function(d, i) {
+				expect(+this.getAttribute("y1")).to.be.equal(yPos[i]);
+			});
+		});
+
+		it("set options", () => {
 			args = {
 				data: {
 					columns: [


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
Adjust interval for grid lines display when grid.y.ticks is given

ex.
When `axis.y.grid.ticks=5` is given,
- As-is: left
- To-be: right

<img width="975" alt="image" src="https://user-images.githubusercontent.com/2178435/182774464-f4efcf9d-43fc-48ad-830e-ade4fde209dc.png">

