### PR TITLE
feat(options): Intent to ship data.groupsZeroAs

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2583,6 +2583,80 @@ var demos = {
 				}
 			}
 		],
+		Groups: [
+			{
+				options: {
+					title: {
+						text: "Groups zero treated as 'positive' value"
+					},
+					data: {
+						columns: [
+							["series1", -11, -11, -11, -11],
+							["series2", 4, 4, 4, 4],
+							["series3", 0, 1, 0, -1]
+						],
+						type: "area",
+						order: null,
+						groups: [
+						  [
+							"series1",
+							"series2",
+							"series3",
+						  ]
+						],
+						groupsZeroAs: "positive"
+					}
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "Groups zero treated as 'negative' value"
+					},
+					data: {
+						columns: [
+							["series1", -11, -11, -11, -11],
+							["series2", 4, 4, 4, 4],
+							["series3", 0, 1, 0, -1]
+						],
+						type: "area",
+						order: null,
+						groups: [
+						  [
+							"series1",
+							"series2",
+							"series3",
+						  ]
+						],
+						groupsZeroAs: "negative"
+					}
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "Groups zero treated as absolute 'zero' value"
+					},
+					data: {
+						columns: [
+							["series1", -11, -11, -11, -11],
+							["series2", 4, 4, 4, 4],
+							["series3", 0, 1, 0, -1]
+						],
+						type: "area",
+						order: null,
+						groups: [
+						  [
+							"series1",
+							"series2",
+							"series3",
+						  ]
+						],
+						groupsZeroAs: "zero"
+					}
+				}
+			}
+		],
 		OnMinMaxCallback: {
 			options: {
 				data: {

--- a/src/Chart/api/group.ts
+++ b/src/Chart/api/group.ts
@@ -18,7 +18,7 @@ export default {
 	 *     ["data1", "data2"]
 	 *  ]);
 	 */
-	groups(groups: string[][]): string[][] {
+	groups<T = string[][]>(groups: T): T {
 		const $$ = this.internal;
 		const {config} = $$;
 

--- a/src/config/Options/data/data.ts
+++ b/src/config/Options/data/data.ts
@@ -258,6 +258,24 @@ export default {
 	data_groups: <string[][]> [],
 
 	/**
+	 * Set how zero value will be treated on groups.<br>
+	 * Possible values:
+	 * - `zero`: 0 will be positioned at absolute axis zero point.
+	 * - `positive`: 0 will be positioned at the top of a stack.
+	 * - `negative`: 0 will be positioned at the bottom of a stack.
+	 * @name data․groupsZeroAs
+	 * @memberof Options
+	 * @type {string}
+	 * @default "positive"
+	 * @see [Demo](https://naver.github.io/billboard.js/demo/#Data.Groups)
+	 * @example
+	 * data: {
+	 *   groupsZeroAs: "zero" // "positive" or "negative"
+	 * }
+	 */
+	data_groupsZeroAs: <"zero" | "positive" | "negative"> "positive",
+
+	/**
 	 * Set color converter function.<br><br>
 	 * This option should a function and the specified function receives color (e.g. '#ff0000') and d that has data parameters like id, value, index, etc. And it must return a string that represents color (e.g. '#00ff00').
 	 * @name data․color

--- a/test/interactions/interaction-spec.ts
+++ b/test/interactions/interaction-spec.ts
@@ -302,7 +302,7 @@ describe("INTERACTION", () => {
 				});
 
 				it("rect elements should be positioned without gaps", () => {
-					const rect = [];
+					const rect: number[] = [];
 
 					chart.$.main.selectAll(`.${$EVENT.eventRect}`).each(function(d, i) {
 						const x = +this.getAttribute("x");

--- a/test/internals/data-spec.ts
+++ b/test/internals/data-spec.ts
@@ -1136,7 +1136,7 @@ describe("DATA", () => {
 					}
 				}
 			};
-		})
+		});
 
 		it("should generate chart without error.", () => {
 			expect(
@@ -1152,6 +1152,62 @@ describe("DATA", () => {
 				const node = svg.select(`[class$=data2] > ${type}`);
 
 				expect(node.style(prop)).to.be.equal("blue");
+			});
+		});
+	});
+
+	describe("data.groups", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", -11, -11, -11, -11],
+						["data2", 4, 4, 4, 4],
+						["data3", 0, 1, 0, -1]
+					],
+					type: "area",
+					order: null,
+					groups: [
+					  [
+						"data1",
+						"data2",
+						"data3",
+					  ]
+					],
+					groupsZeroAs: "positive"
+				}
+			};
+		});
+
+		it("when data.groupsZeroAs='positivie'", () => {
+			const expectedY = [57, 36, 57, 390];
+
+			chart.$.circles.filter(d => d.id === "data3").each(function(d, i) {
+				expect(+this.getAttribute("cy")).to.be.closeTo(expectedY[i], 1);
+			});
+		});
+
+		it("set options: data.groupsZeroAs='negative'", () => {
+			args.data.groupsZeroAs = "negative";
+		});
+
+		it("when data.groupsZeroAs='negative'", () => {
+			const expectedY = [369, 36, 369, 390];
+
+			chart.$.circles.filter(d => d.id === "data3").each(function(d, i) {
+				expect(+this.getAttribute("cy")).to.be.closeTo(expectedY[i], 1);
+			});
+		});
+
+		it("set options: data.groupsZeroAs='zero'", () => {
+			args.data.groupsZeroAs = "zero";
+		});
+
+		it("when data.groupsZeroAs='zero'", () => {
+			const expectedY = [140, 36, 140, 390];
+
+			chart.$.circles.filter(d => d.id === "data3").each(function(d, i) {
+				expect(+this.getAttribute("cy")).to.be.closeTo(expectedY[i], 1);
 			});
 		});
 	});

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1565,6 +1565,15 @@ export interface Data {
 	groups?: string[][];
 
 	/**
+	 * Set how zero value will be treated on groups.<br>
+	 * Possible values:
+	 * - `zero`: 0 will be positioned at absolute axis zero point.
+	 * - `positive`: 0 will be positioned at the top of a stack.
+	 * - `negative`: 0 will be positioned at the bottom of a stack.
+	 */
+	groupsZeroAs?: "positive" | "negative" | "zero";
+
+	/**
 	 * Set y axis the data related to. y and y2 can be used.
 	 * - **NOTE:** If all data is related to one of the axes, the domain of axis without related data will be replaced by the domain from the axis with related data
 	 */


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2813

## Details
<!-- Detailed description of the change/feature -->
Implement the way to specify how zero value is treated on groups

Possible values:
- `zero`: 0 will be positioned at absolute axis zero point.
- `positive`: 0 will be positioned at the top of a stack.
- `negative`: 0 will be positioned at the bottom of a stack.

```js
data: {
  columns: [
    ["data1", -11, -11, -11, -11],
    ["data2", 4, 4, 4, 4],
    ["data3", 0, 1, 0, -1]
  ],
  type: "area",
  order: null,
  groups: [
    ["data1", "data2", "data3"]
  ],
  groupsZeroAs: "positive"
}
```

<img width="447" alt="image" src="https://user-images.githubusercontent.com/2178435/184081701-db5818fa-ded9-4db9-847a-a6fe0dca2531.png">
