### PR TITLE
fix(types): Fix the type declarations for the y tick format

### DIFF
--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -352,7 +352,7 @@ export interface YTickConfiguration {
 	 * Set formatter for y axis tick text.
 	 * This option accepts d3.format object as well as a function you define.
 	 */
-	format?: (this: Chart, x: number | Date) => string | number;
+	format?: ((this: Chart, x: number) => string | number) | ((this: Chart, x: Date) => string | number);
 
 	/**
 	 * Setting for culling ticks.


### PR DESCRIPTION
## Issue
this fixes the issue reported in https://github.com/naver/billboard.js/commit/fb246bc92d328450b185314d5267dfc0862e55d3#r77903654

## Details

This is resubmitting #2790 because you modified the patch when "merging" it in https://github.com/naver/billboard.js/commit/1d378e05af25e33d6d50d92dea51db7fd6b411d7, which totally defeats the goal of the patch.

See https://github.com/naver/billboard.js/pull/2676 for the original type checking error that this fixes (if the patch gets merged without reverting the most important part of it, the issue will finally be fixed)
