### PR TITLE
feat(options): Intent to ship bar.overlap

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3924,6 +3924,50 @@ d3.select(".chart_area")
 				}
 			},
 		],
+		BarOverlap: [
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 80, 150, 100, 100, 100],
+							["data2", 100, 120, 130, 50, 150],
+							["data3", 150, 80, 120, 30, 80]
+						],
+						type: "bar"
+					},
+					bar: {
+						width: {
+							data1: {
+								ratio: 1.2
+							},
+							data2: 40,
+							data3: 20
+						},
+						overlap: true
+					}
+				}
+			},
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 130, 150, 130, 100, 130],
+							["data2", 70, 120, 125, 50, 125],
+							["data3", 50, 80, 110, 30, 20]
+						],
+						type: "bar"
+					},
+					bar: {
+						width: {
+							data1: 20,
+							data2: 40,
+							data3: 60
+						},
+						overlap: true
+					}
+				}
+			}
+		],
 		BarPadding: {
 			options: {
 				data: {

--- a/src/ChartInternal/shape/bar.ts
+++ b/src/ChartInternal/shape/bar.ts
@@ -6,6 +6,7 @@ import type {DataRow} from "../../../types/types";
 import {$BAR, $COMMON} from "../../config/classes";
 import {getRandom, isNumber} from "../../module/util";
 import type {IDataRow} from "../data/IData";
+import type {IOffset} from "./shape";
 
 type BarTypeDataRow = DataRow<number | number[]>;
 
@@ -234,7 +235,7 @@ export default {
 		const {config} = $$;
 		const axis = isSub ? $$.axis.subX : $$.axis.x;
 		const barTargetsNum = $$.getIndicesMax(barIndices) + 1;
-		const barW = $$.getBarW("bar", axis, barTargetsNum);
+		const barW: IOffset = $$.getBarW("bar", axis, barTargetsNum);
 		const barX = $$.getShapeX(barW, barIndices, !!isSub);
 		const barY = $$.getShapeY(!!isSub);
 		const barOffset = $$.getShapeOffset($$.isBarType, barIndices, !!isSub);

--- a/src/ChartInternal/shape/candlestick.ts
+++ b/src/ChartInternal/shape/candlestick.ts
@@ -5,8 +5,9 @@
 import {select as d3Select} from "d3-selection";
 import {$CANDLESTICK, $COMMON} from "../../config/classes";
 import {getRandom, isArray, isNumber, isObject} from "../../module/util";
+import type {IOffset} from "./shape";
 
-type CandlestickData = {
+interface ICandlestickData {
 	open: number;
 	high: number;
 	low: number;
@@ -160,7 +161,7 @@ export default {
 
 		const axis = isSub ? $$.axis.subX : $$.axis.x;
 		const targetsNum = $$.getIndicesMax(indices) + 1;
-		const barW = $$.getBarW("candlestick", axis, targetsNum);
+		const barW: IOffset = $$.getBarW("candlestick", axis, targetsNum);
 		const x = $$.getShapeX(barW, indices, !!isSub);
 		const y = $$.getShapeY(!!isSub);
 		const shapeOffset = $$.getShapeOffset($$.isBarType, indices, !!isSub);
@@ -244,7 +245,7 @@ export default {
 	 * @returns {object|null} Converted data object
 	 * @private
 	 */
-	getCandlestickData({value}): CandlestickData | null {
+	getCandlestickData({value}): ICandlestickData | null {
 		let d;
 
 		if (isArray(value)) {

--- a/src/config/Options/shape/bar.ts
+++ b/src/config/Options/shape/bar.ts
@@ -14,6 +14,7 @@ export default {
 	 * @property {object} bar Bar object
 	 * @property {number} [bar.indices.removeNull=false] Remove nullish data on bar indices positions.
 	 * @property {number} [bar.label.threshold=0] Set threshold ratio to show/hide labels.
+	 * @property {boolean} [bar.overlap=false] Bars will be rendered at same position, which will be overlapped each other. (for non-grouped bars only)
 	 * @property {number} [bar.padding=0] The padding pixel value between each bar.
 	 * @property {number} [bar.radius] Set the radius of bar edge in pixel.
 	 * @property {number} [bar.radius.ratio] Set the radius ratio of bar edge in relative the bar's width.
@@ -29,6 +30,7 @@ export default {
 	 * @property {number} [bar.width.dataname.max] The maximum width value for ratio.
 	 * @property {boolean} [bar.zerobased=true] Set if min or max value will be 0 on bar chart.
 	 * @see [Demo: bar indices](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarIndices)
+	 * @see [Demo: bar overlap](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarOverlap)
 	 * @see [Demo: bar padding](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarPadding)
 	 * @see [Demo: bar radius](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarRadius)
 	 * @see [Demo: bar width](https://naver.github.io/billboard.js/demo/#BarChartOptions.BarWidth)
@@ -39,6 +41,9 @@ export default {
 	 *      indices: {
 	 *          removeNull: true
 	 *      },
+	 *
+	 *      // remove nullish da
+	 *      overlap: true,
 	 *
 	 *      padding: 1,
 	 *
@@ -80,6 +85,7 @@ export default {
 	 */
 	bar_label_threshold: 0,
 	bar_indices_removeNull: false,
+	bar_overlap: false,
 	bar_padding: 0,
 	bar_radius: <number|{ratio: number}|undefined> undefined,
 	bar_radius_ratio: <number|undefined> undefined,

--- a/test/shape/bar-spec.ts
+++ b/test/shape/bar-spec.ts
@@ -876,6 +876,49 @@ describe("SHAPE BAR", () => {
 		})
 	});
 
+	describe("bar overlap", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 80, 150, 100],
+						["data2", 100, 120, 130],
+						["data3", 150, 80, 120]
+					],
+					type: "bar"
+				},
+				bar: {
+					width: {
+						data1: 60,
+						data2: 40,
+						data3: 20
+					},
+					overlap: true
+				}
+			};
+		});
+
+		it("bars should positioned at the center of each x Axis ticks.", () => {
+			const {x} = chart.internal.scale;
+			const {bars} = chart.$.bar;
+			const dataNames = chart.data().map(v => v.id);
+			const {width} = args.bar;
+			const ticks = dataNames.map((v, i) => x(i));
+			const re = /^M(\d+)/;
+
+			dataNames.forEach(id => {
+				const bar = bars.filter(d => d.id === id).nodes();
+
+				ticks.forEach((t, i) => {
+					const xPos = +bar[i].getAttribute("d").match(re)?.[1] ?? 0;
+					const expectedX = t - width[id] / 2;
+
+					expect(xPos).to.be.closeTo(expectedX, 1);
+				});
+			});
+		});
+	});
+
 	describe("bar position", () => {
 		before(() => {
 			args = {

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -322,6 +322,11 @@ export interface ChartOptions {
 		}
 
 		/**
+		 * Bars will be rendered at same position, which will be overlapped each other. (for non-grouped bars only)
+		 */
+		orverlap?: boolean;
+
+		/**
 		 * The padding pixel value between each bar.
 		 */
 		padding?: number;


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2839

## Details
<!-- Detailed description of the change/feature -->
Implement overlapped bar option

```js
bb.generate({
	data: {
		columns: [
			["data1", 80, 150, 100],
			["data2", 100, 120, 130],
			["data3", 150, 80, 120]
		],
		type: "bar"
	},
	bar: {
		width: {
			data1: 60,
			data2: 40,
			data3: 20
		},
		overlap: true
	}
});
```

<img width="500" alt="image" src="https://user-images.githubusercontent.com/2178435/190943829-2a756d51-7412-44f5-99b9-9ff050812e52.png">
