### PR TITLE
feat(api): Enhance .config() to return generation options

### DIFF
--- a/src/Chart/api/chart.ts
+++ b/src/Chart/api/chart.ts
@@ -142,7 +142,9 @@ export default {
 	},
 
 	/**
-	 * Get or set single config option value.
+	 * Get or set config option value.
+	 * - **NOTE:** for without parameter occasion
+	 * 	- will return all specified generation options object only. (will exclude any other options not specified at the initialization)
 	 * @function config
 	 * @instance
 	 * @memberof Chart
@@ -152,8 +154,12 @@ export default {
 	 * - **NOTE:** Doesn't guarantee work in all circumstances. It can be applied for limited options only.
 	 * @returns {*}
 	 * @example
+	 *
 	 * // Getter
 	 * chart.config("gauge.max");
+	 *
+	 * // without any arguments, it returns generation config object
+	 * chart.config();  // {data: { ... }, axis: { ... }, ...}
 	 *
 	 * // Setter
 	 * chart.config("gauge.max", 100);
@@ -163,11 +169,11 @@ export default {
 	 */
 	config(name: string, value?: any, redraw?: boolean): any {
 		const $$ = this.internal;
-		const {config} = $$;
+		const {config, state} = $$;
 		const key = name?.replace(/\./g, "_");
 		let res;
 
-		if (key in config) {
+		if (name && key in config) {
 			if (isDefined(value)) {
 				config[key] = value;
 				res = value;
@@ -176,6 +182,8 @@ export default {
 			} else {
 				res = config[key];
 			}
+		} else {
+			res = state.orgConfig;
 		}
 
 		return res;

--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -468,8 +468,9 @@ export default class ChartInternal {
 		}
 
 		// Define g for chart area
-		main.append("g").attr("class", $COMMON.chart)
-			.attr("clip-path", state.clip.path);
+		main.append("g")
+			.classed($COMMON.chart, true)
+			.attr("clip-path", hasAxis ? state.clip.path : null);
 
 		$$.callPluginHook("$init");
 

--- a/src/config/Store/State.ts
+++ b/src/config/Store/State.ts
@@ -127,6 +127,7 @@ export default class State {
 			hasPositiveValue: true,
 
 			orgAreaOpacity: "0.2",
+			orgConfig: {}, // user original genration config
 
 			// ID strings
 			hiddenTargetIds: <string[]> [],

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,13 +4,14 @@
  */
 import {isDefined, isObjectType} from "../module/util";
 import Options from "./Options/Options";
+import type {ChartOptions} from "../../types/options";
 
 /**
  * Load configuration option
  * @param {object} config User's generation config value
  * @private
  */
-export function loadConfig(config: Options): void {
+export function loadConfig(config: ChartOptions): void {
 	const thisConfig: Options = this.config;
 	let target;
 	let keys;
@@ -38,4 +39,9 @@ export function loadConfig(config: Options): void {
 			thisConfig[key] = read;
 		}
 	});
+
+	// only should run in the ChartInternal context
+	if (this.api) {
+		this.state.orgConfig = config;
+	}
 }

--- a/test/api/chart-spec.ts
+++ b/test/api/chart-spec.ts
@@ -116,7 +116,7 @@ describe("API chart", () => {
 
 			expect(bb.instance.indexOf(chart) === -1).to.be.true;
 
-			const el = document.getElementById("chart");
+			const el = <HTMLDivElement>document.getElementById("chart");
 
 			// should revert removing className and styles
 			expect(el.classList.contains("bb")).to.be.false;
@@ -221,7 +221,7 @@ describe("API chart", () => {
 
 		it("check for the axis config update", () => {
 			const axisYTick = chart.$.main.selectAll(`.${$AXIS.axisY} .tick`);
-			const expected = [];
+			const expected: {[key: string]: number}[] = [];
 
 			// axis y tick is outer
 			axisYTick.each(function() {
@@ -252,6 +252,10 @@ describe("API chart", () => {
 				expect(text.style.textAnchor).to.be.equal("start");
 				expect(+tspan.getAttribute("x")).to.be.equal(Math.abs(expected[i].tspan));
 			});
+		});
+
+		it("should return generation options object.", () => {
+			expect(args).to.be.deep.equal(chart.config());
 		});
 	});
 });

--- a/test/plugin/sparkline/sparkline-spec.ts
+++ b/test/plugin/sparkline/sparkline-spec.ts
@@ -96,7 +96,7 @@ describe("PLUGIN: SPARKLINE", () => {
 
 	it("check for the dimension & tooltip", () => {
 		const last = document.querySelectorAll(selector)[2];
-		const {width, height} = last.querySelector(`.${$AREA.areas} path`).getBoundingClientRect();
+		const {width, height} = last.querySelector(`.${$AREA.areas} path`)?.getBoundingClientRect() ?? {width:0, height: 0};
 
 		// chart element should occupy the whole dimension of given size
 		expect({width, height}).to.be.deep.equal(args.size);

--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -515,11 +515,13 @@ export interface Chart {
 
 	/**
 	 * Get or set single config option value.
+	 * - **NOTE:**
+	 *   - without parameter, will return all specified generation options object only. (will exclude any other options not specified at the initialization)
 	 * @param optionName The option key name.
 	 * @param value The value accepted for indicated option.
 	 * @param redraw Set to redraw with the new option changes. (NOTE: Doesn't guarantee work in all circumstances. It can be applied for limited options only)
 	 */
-	config(optionName: string, value?: any, redraw?: boolean): any;
+	config(optionName?: string, value?: any, redraw?: boolean): any;
 }
 
 export interface GridOperations {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2864

## Details
<!-- Detailed description of the change/feature -->
Get generation options object from the API call

```js
const chart = bb.generate({
	data: {
		columns: [
			["data1", 80, 150, 100],
			["data2", 100, 120, 130],
			["data3", 150, 80, 120]
		],
		type: "bar"
	},
	bindto: "#chart"
});

// get the options object specified at the initialization
chart.config();
// --> {data: {…}, bindto: '#chart'}
```