### PR TITLE
feat(options): Intent to ship legend.item.tile.type

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2877,6 +2877,51 @@ var demos = {
 	},
 
 	Legend: {
+		CustomLegend: {
+			options: {
+				data: {
+					columns: [
+						["data1", 100],
+						["data2", 300],
+						["data3", 200]
+					],
+					type: "pie"
+				},
+				legend: {
+					show: false
+				}
+			},
+			func: function(chart) {
+				function toggle(id) { chart.toggle(id); }
+
+d3.select(".chart_area")
+	.insert("div", ".chart")
+	.attr("class", "legend")
+	.selectAll("span")
+	.data(["data1", "data2", "data3"])
+	.enter()
+	.append("span")
+	.attr('data-id', function(id) {
+		return id;
+	})
+	.html(function(id) {
+		return id;
+	})
+	.each(function(id) {
+		d3.select(this)
+			.style('background-color', chart.color(id));
+	})
+	.on("mouseover", function(event, id) {
+		chart.focus(id);
+	})
+	.on("mouseout", function(event, id) {
+		chart.revert();
+	})
+	.on("click", function(event, id) {
+		chart.toggle(id);
+	});
+			}
+		},
 		HideLegend: {
 			options: {
 				data: {
@@ -2890,6 +2935,49 @@ var demos = {
 				}
 			}
 		},
+		LegendItemTileType: [
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 100],
+							["data2", 300],
+							["data3", 200]
+						],
+						type: "pie"
+					},
+					legend: {
+						item: {
+							tile: {							
+								type: "circle",
+								r: 7
+							},
+						}
+					}
+				},
+			},
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 100],
+							["data2", 300],
+							["data3", 200]
+						],
+						type: "pie"
+					},
+					legend: {
+						item: {
+							tile: {							
+								type: "rectangle",
+								width: 15,
+								height: 15
+							},
+						}
+					}
+				}
+			}
+		],
 		LegendPosition: {
 			options: {
 				data: {
@@ -2959,51 +3047,6 @@ var demos = {
 						}
 					}
 				}
-			}
-		},
-		CustomLegend: {
-			options: {
-				data: {
-					columns: [
-						["data1", 100],
-						["data2", 300],
-						["data3", 200]
-					],
-					type: "pie"
-				},
-				legend: {
-					show: false
-				}
-			},
-			func: function(chart) {
-				function toggle(id) { chart.toggle(id); }
-
-d3.select(".chart_area")
-	.insert("div", ".chart")
-	.attr("class", "legend")
-	.selectAll("span")
-	.data(["data1", "data2", "data3"])
-	.enter()
-	.append("span")
-	.attr('data-id', function(id) {
-		return id;
-	})
-	.html(function(id) {
-		return id;
-	})
-	.each(function(id) {
-		d3.select(this)
-			.style('background-color', chart.color(id));
-	})
-	.on("mouseover", function(event, id) {
-		chart.focus(id);
-	})
-	.on("mouseout", function(event, id) {
-		chart.revert();
-	})
-	.on("click", function(event, id) {
-		chart.toggle(id);
-	});
 			}
 		},
 		usePoint: {

--- a/src/config/Options/common/legend.ts
+++ b/src/config/Options/common/legend.ts
@@ -43,9 +43,15 @@ export default {
 	 * @property {Function} [legend.item.onclick=undefined] Set click event handler to the legend item.
 	 * @property {Function} [legend.item.onover=undefined] Set mouse/touch over event handler to the legend item.
 	 * @property {Function} [legend.item.onout=undefined] Set mouse/touch out event handler to the legend item.
-	 * @property {number} [legend.item.tile.width=10] Set width of item tile element
-	 * @property {number} [legend.item.tile.height=10] Set height of item tile element
+	 * @property {number} [legend.item.tile.width=10] Set width for 'rectangle' legend item tile element.
+	 * @property {number} [legend.item.tile.height=10] ㄹ
+	 * @property {number} [legend.item.tile.r=5] Set the radius for 'circle' legend item tile type.
+	 * @property {string} [legend.item.tile.type="rectangle"] Set legend item shape type.<br>
+	 * - **Available Values:**
+	 *   - circle
+	 *   - rectangle
 	 * @property {boolean} [legend.usePoint=false] Whether to use custom points in legend.
+	 * @see [Demo: item.tile.type](https://naver.github.io/billboard.js/demo/#Legend.LegendItemTileType)
 	 * @see [Demo: position](https://naver.github.io/billboard.js/demo/#Legend.LegendPosition)
 	 * @see [Demo: contents.template](https://naver.github.io/billboard.js/demo/#Legend.LegendTemplate1)
 	 * @see [Demo: usePoint](https://naver.github.io/billboard.js/demo/#Legend.usePoint)
@@ -85,8 +91,15 @@ export default {
 	 *
 	 *          // set tile's size
 	 *          tile: {
-	 *              width: 20,
+	 *              // set tile type
+	 *              type: "circle"  // or "rectangle" (default)
+	 *
+	 *              // width & height, are only applicable for 'rectangle' legend type
+	 *              width: 15,
 	 *              height: 15
+	 *
+	 *              // radis is only applicable for 'circle' legend type
+	 *              r: 10
 	 *          }
 	 *      },
 	 *      usePoint: true
@@ -108,5 +121,7 @@ export default {
 	legend_padding: 0,
 	legend_item_tile_width: 10,
 	legend_item_tile_height: 10,
+	legend_item_tile_r: 5,
+	legend_item_tile_type: <"rectangle"|"circle"> "rectangle",
 	legend_usePoint: false
 };

--- a/test/internals/legend-spec.ts
+++ b/test/internals/legend-spec.ts
@@ -708,4 +708,62 @@ describe("LEGEND", () => {
 			}, 50);
 		});
 	});
+
+	describe("item.tile.type option", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 100],
+						["data2", 300],
+						["data3", 200]
+					],
+					type: "pie", // for ESM specify as: pie()
+				},
+				legend: {
+					item: {
+						tile: {
+							type: "circle"
+						},
+					}
+				}
+			};
+		});
+
+		it("should item tile's shapes are 'circle'?", () => {
+			const legendItems = chart.$.legend.selectAll("circle");
+
+			expect(legendItems.size()).to.be.equal(chart.data().length);
+			
+			legendItems.each(function() {
+				expect(+this.getAttribute("r")).to.be.equal(5);
+			});
+		});
+
+		it("set options: legend.item.tile.r=7", () => {
+			args.legend.item.tile.r = 7;
+		});
+
+		it("check 'circle' item's radius", () => {
+			const legendItems = chart.$.legend.selectAll("circle");
+
+			expect(legendItems.size()).to.be.equal(chart.data().length);
+			
+			legendItems.each(function() {
+				expect(+this.getAttribute("r")).to.be.equal(args.legend.item.tile.r);
+			});
+		});
+
+		it("set options: legend.item.tile='rectangle'", () => {
+			args.legend.item.tile = {
+				type: "rectangle"
+			};
+		});
+
+		it("should item tile's shapes are 'rectangle'?", () => {
+			const legendItems = chart.$.legend.selectAll("line");
+
+			expect(legendItems.size()).to.be.equal(chart.data().length);
+		});
+	});
 });

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1000,14 +1000,24 @@ export interface LegendOptions {
 		 */
 		tile?: {
 			/**
-			 * Tile width.
+			 * Set width for 'rectangle' legend item tile element.
 			 */
 			width?: number;
 
 			/**
-			 * Tile height
+			 * Set height for 'rectangle' legend item tile element.
 			 */
 			height?: number;
+
+			/**
+			 * Set legend item shape type.
+			 */
+			type?: "circle" | "recntangle";
+
+			/**
+			 * Set the radius for 'circle' legend item tile type.
+			 */
+			r?: number;
 		};
 		/**
 		 * Set click event handler to the legend item.


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2874

## Details
<!-- Detailed description of the change/feature -->
Implement 'circle' shape for legend item tile.

```js
legend: {
    item: {
        tile: {
            type: "circle",  // default 'rectangle'
            r: 10,  // setup radius of circle item type
        }
    }
}
```

<img width="574" alt="image" src="https://user-images.githubusercontent.com/2178435/192176302-d5835968-659e-4333-9d7a-8d852e3c2d5a.png">
