### PR TITLE
fix(tooltip): fix redundant onxxx callback calls

### DIFF
--- a/src/ChartInternal/interactions/interaction.ts
+++ b/src/ChartInternal/interactions/interaction.ts
@@ -28,24 +28,26 @@ export default {
 			}
 		}
 
-		main.selectAll(`.${$SHAPE.shape}-${index}`)
+		const shapeAtIndex = main.selectAll(`.${$SHAPE.shape}-${index}`)
 			.each(function() {
 				d3Select(this).classed($COMMON.EXPANDED, true);
 
 				if (isSelectionEnabled) {
 					eventRect.style("cursor", isSelectionGrouped ? "pointer" : null);
 				}
-
-				if (!isTooltipGrouped) {
-					$$.hideGridFocus?.();
-					$$.hideTooltip();
-
-					!isSelectionGrouped && $$.setExpand(index);
-				}
 			})
 			.filter(function(d) {
 				return $$.isWithinShape(this, d);
-			})
+			});
+
+		if (shapeAtIndex.empty() && !isTooltipGrouped) {
+			$$.hideGridFocus?.();
+			$$.hideTooltip();
+
+			!isSelectionGrouped && $$.setExpand(index);
+		}
+
+		shapeAtIndex
 			.call(selected => {
 				const d = selected.data();
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2901

## Details
<!-- Detailed description of the change/feature -->
Make the call only when there's no selected shape.

![tooltip-onevents](https://user-images.githubusercontent.com/2178435/197137264-51672e77-0161-4217-a849-a3749da00aa0.gif)
