### PR TITLE
chore(gh-actions): Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,12 @@ jobs:
         node-version: [14.x, 16.x, 17.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-        
-    - name: Cache Node.js modules
-      uses: actions/cache@v2
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
+        cache: npm
 
     - name: Install dependencies
       run: |
@@ -67,15 +58,16 @@ jobs:
     if: contains('refs/heads/next refs/heads/latest', github.ref)
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14
+          cache: npm
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -9,17 +9,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Setup Git
         shell: bash
         run: bash ./config/deploy-nightly.sh setup ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14
+          cache: npm
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Details

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yml
- uses: actions/checkout@v2
- name: Use Node.js ${{ matrix.node-version }}
  uses: actions/setup-node@v1
  with:
    node-version: ${{ matrix.node-version }}

- name: Cache Node.js modules
  uses: actions/cache@v2
  with:
   # npm cache files are stored in `~/.npm` on Linux/macOS
    path: ~/.npm
    key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
    restore-keys: |
      ${{ runner.OS }}-node-
      ${{ runner.OS }}-
```

### TO-BE

```yml
- uses: actions/checkout@v3
- name: Use Node.js ${{ matrix.node-version }}
  uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node-version }}
    cache: npm
```

> It’s literally a one line change to pass the `cache: npm` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)
