### PR TITLE
feat(arc): Intent to ship arc.cornerRadius

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4597,6 +4597,23 @@ d3.select(".chart_area")
 		}
 	},
 	DonutChartOptions: {
+		DonutCornerRadius: {
+			options: {
+				data: {
+					columns: [
+						["data1", 30],
+						["data2", 45],
+						["data3", 25]
+					],
+					type: "donut"
+				},
+				arc: {
+					cornerRadius: {
+						ratio: 0.2
+					}
+				}
+			}
+		},
 		LabelRatio: {
 			options: {
 				data: {
@@ -4655,6 +4672,21 @@ d3.select(".chart_area")
 				}
 			}
 		},
+		StartingAngle: {
+			options: {
+				data: {
+					columns: [
+						["data1", 30],
+						["data2", 45],
+						["data3", 25]
+					],
+					type: "donut"
+				},
+				donut: {
+					startingAngle: 0.7
+				}
+			}
+		},
 		padAngle: {
 			options: {
 				data: {
@@ -4670,24 +4702,61 @@ d3.select(".chart_area")
 					padAngle: 0.1
 				}
 			}
-		},
-		StartingAngle: {
-			options: {
-				data: {
-					columns: [
-						["data1", 30],
-						["data2", 45],
-						["data3", 25]
-					],
-					type: "donut"
-				},
-				donut: {
-					startingAngle: 0.7
-				}
-			}
 		}
 	},
 	GaugeChartOptions: {
+		GaugeCornerRadius: [
+			{
+				options: {
+					data: {
+						columns: [
+							["data", 77]
+						],
+						type: "gauge"
+					},
+					arc: {
+						cornerRadius: 15
+					},
+					gauge: {
+						arcLength: 70,
+						fullCircle: true,
+						label: {
+							extents: function() { return ""; }
+						},
+						startingAngle: -2.2,
+						width: 25
+					}
+				}
+			},
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 77],
+							["data2", 50],
+							["data3", 20],
+
+						],
+						type: "gauge"
+					},
+					arc: {
+						cornerRadius: {
+							ratio: 0.5
+						}
+					},
+					gauge: {
+						type: "multi",
+						arcLength: 95,
+						fullCircle: true,
+						label: {
+							extents: function() { return ""; }
+						},
+						startingAngle: -3,
+						width: 50
+					}
+				}
+			}
+		],
 		GaugeFullCircle: {
 			options: {
 				data: {
@@ -4956,7 +5025,48 @@ d3.select(".chart_area")
 		}
 	},
 	PieChartOptions: {
-		LabelRatio: {
+		CornerRadius: [
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 30],
+							["data2", 45],
+							["data3", 25],
+							["data4", 35],
+							["data5", 15],
+							["data6", 35]
+						],
+						type: "pie"
+					},
+					arc: {
+						cornerRadius: 70
+					}
+				}
+			},
+			{
+				options: {
+					data: {
+						columns: [
+							["data1", 30],
+							["data2", 45],
+							["data3", 25]
+						],
+						type: "pie"
+					},
+					arc: {
+						cornerRadius: function(id, value, outerRadius) {
+						return ({
+						    data1: outerRadius * 0.3,
+						    data2: value > 45 ? 50 : 0,
+						    data3: 60
+						})[id];
+						}
+					}
+				}
+			},
+		],
+		ExpandRate: {
 			options: {
 				data: {
 					columns: [
@@ -4967,51 +5077,8 @@ d3.select(".chart_area")
 					type: "pie"
 				},
 				pie: {
-					label: {
-						ratio: 2.4
-					}
-				},
-				legend: {
-					show: false
-				}
-			},
-			style: [
-				"#labelRatio .bb-chart-arc text {fill: #f00;font-size: 15px;font-weight: bold;}"
-			]
-		},
-		LabelFormat: {
-			options: {
-				data: {
-					columns: [
-						["data1", 30],
-						["data2", 50]
-					],
-					type: "pie"
-				},
-				pie: {
-					label: {
-						format: function(value, ratio, id) {
-							return d3.format('$')(value);
-								}
-					}
-				}
-			}
-		},
-		MultilineLabel: {
-			options: {
-				data: {
-					columns: [
-						["data1", 30],
-						["data2", 50],
-						["data3", 45]
-					],
-					type: "pie"
-				},
-				pie: {
-					label: {
-						format: function(value, ratio, id) {
-							return value +"\nHours";
-								}
+					expand: {
+						rate: 1.007
 					}
 				}
 			}
@@ -5052,6 +5119,66 @@ d3.select(".chart_area")
 				}
 			},
 		],
+		LabelFormat: {
+			options: {
+				data: {
+					columns: [
+						["data1", 30],
+						["data2", 50]
+					],
+					type: "pie"
+				},
+				pie: {
+					label: {
+						format: function(value, ratio, id) {
+							return d3.format('$')(value);
+								}
+					}
+				}
+			}
+		},
+		LabelRatio: {
+			options: {
+				data: {
+					columns: [
+						["data1", 30],
+						["data2", 45],
+						["data3", 25]
+					],
+					type: "pie"
+				},
+				pie: {
+					label: {
+						ratio: 2.4
+					}
+				},
+				legend: {
+					show: false
+				}
+			},
+			style: [
+				"#labelRatio .bb-chart-arc text {fill: #f00;font-size: 15px;font-weight: bold;}"
+			]
+		},
+		MultilineLabel: {
+			options: {
+				data: {
+					columns: [
+						["data1", 30],
+						["data2", 50],
+						["data3", 45]
+					],
+					type: "pie"
+				},
+				pie: {
+					label: {
+						format: function(value, ratio, id) {
+							return value +"\nHours";
+								}
+					}
+				}
+			}
+		},		
 		OuterRadius: [
 			{
 				options: {
@@ -5131,24 +5258,7 @@ d3.select(".chart_area")
 					startingAngle: 1
 				}
 			}
-		},
-		ExpandRate: {
-			options: {
-				data: {
-					columns: [
-						["data1", 30],
-						["data2", 45],
-						["data3", 25]
-					],
-					type: "pie"
-				},
-				pie: {
-					expand: {
-						rate: 1.007
-					}
-				}
-			}
-		}
+		}		
 	},
 	RadarChartOptions: {
 		RadarAxis: {

--- a/src/ChartInternal/data/IData.ts
+++ b/src/ChartInternal/data/IData.ts
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
+ * @ignore
  */
 type TDataRow = {
     value: number | null;

--- a/src/config/Options/shape/arc.ts
+++ b/src/config/Options/shape/arc.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/**
+ * area config options
+ */
+export default {
+	/**
+	 * Set arc options
+	 * @name arc
+	 * @memberof Options
+	 * @type {object}
+	 * @property {object} arc Arc object
+	 * @property {number|Function} [arc.cornerRadius=0] Set corner radius of Arc(donut/gauge/pie/polar) shape.
+	 *  - **NOTE:**
+	 * 	  - Corner radius can't surpass the `(outerRadius - innerRadius) /2` of indicated shape.
+	 * 	  - When specified value is greater than the limitation, the radius value will be adjusted to meet the condition.
+	 * @property {number} [arc.cornerRadius.ratio=0] Set ratio relative of outer radius.
+	 * @see [Demo: Donut corner radius](https://naver.github.io/billboard.js/demo/#DonutChartOptions.DonutCornerRadius)
+	 * @see [Demo: Gauge corner radius](https://naver.github.io/billboard.js/demo/#GaugeChartOptions.GaugeCornerRadius)
+	 * @see [Demo: Donut corner radius](https://naver.github.io/billboard.js/demo/#PieChartOptions.CornerRadius)
+	 * @example
+	 *  arc: {
+	 *      cornerRadius: 12,
+	 *
+	 *      // can customize corner radius for each data with function callback
+	 *      //
+	 *      // The function will receive:
+	 *      // - id {string}: Data id
+	 *      // - value {number}: Data value
+	 *      // - outerRadius {number}: Outer radius value
+	 *      cornerRadius: function(id, value, outerRadius) {
+	 *          return (id === "data1" && value > 10) ?
+	 *          	50 : outerRadius * 1.2;
+	 *      },
+	 *
+	 *      // set ratio relative of outer radius
+	 *      cornerRadius: {
+	 *          ratio: 0.5
+	 *      }
+	 *  }
+	 */
+	arc_cornerRadius: <
+		number|((id: string, value: number) => number)
+	> 0,
+	arc_cornerRadius_ratio: 0
+};

--- a/src/config/Options/shape/gauge.ts
+++ b/src/config/Options/shape/gauge.ts
@@ -39,7 +39,7 @@ export default {
 	 *   - `startingAngle < -1 * Math.PI` defaults to `Math.PI`
 	 *   - `startingAngle >  Math.PI` defaults to `Math.PI`
 	 * @property {number} [gauge.arcLength=100] Set the length of the arc to be drawn in percent from -100 to 100.<br>
-	 * Negative value will draw the arc **counterclockwise**.
+	 * Negative value will draw the arc **counterclockwise**. Need to be used in conjunction with `gauge.fullCircle=true`.
 	 *
 	 * **Limitations:**
 	 * - -100 <= arcLength (in percent) <= 100
@@ -52,7 +52,7 @@ export default {
 	 * **Available Values:**
 	 * - single
 	 * - multi
-	 * @property {string} [gauge.arcs.minWidth=5] Set minimal width of gauge arcs until the innerRadius disappears.
+	 * @property {number} [gauge.arcs.minWidth=5] Set minimal width of gauge arcs until the innerRadius disappears.
 	 * @see [Demo: archLength](https://naver.github.io/billboard.js/demo/#GaugeChartOptions.GaugeArcLength)
 	 * @see [Demo: startingAngle](https://naver.github.io/billboard.js/demo/#GaugeChartOptions.GaugeStartingAngle)
 	 * @example

--- a/src/config/resolver/shape.ts
+++ b/src/config/resolver/shape.ts
@@ -38,6 +38,7 @@ import optScatter from "../Options/shape/scatter";
 import optSpline from "../Options/shape/spline";
 
 // Non-Axis based
+import optArc from "../Options/shape/arc";
 import optDonut from "../Options/shape/donut";
 import optGauge from "../Options/shape/gauge";
 import optPie from "../Options/shape/pie";
@@ -121,10 +122,18 @@ let spline = (): string => (extendLine(undefined, [optSpline]), (spline = () => 
 let step = (): string => (extendLine(), (step = () => TYPE.STEP)());
 
 // Arc types
-let donut = (): string => (extendArc(undefined, [optDonut]), (donut = () => TYPE.DONUT)());
-let gauge = (): string => (extendArc([shapeGauge], [optGauge]), (gauge = () => TYPE.GAUGE)());
-let pie = (): string => (extendArc(undefined, [optPie]), (pie = () => TYPE.PIE)());
-let polar = (): string => (extendArc([shapePolar], [optPolar]), (polar = () => TYPE.POLAR)());
+let donut = (): string => (
+	extendArc(undefined, [optArc, optDonut]), (donut = () => TYPE.DONUT)()
+);
+let gauge = (): string => (
+	extendArc([shapeGauge], [optArc, optGauge]), (gauge = () => TYPE.GAUGE)()
+);
+let pie = (): string => (
+	extendArc(undefined, [optArc, optPie]), (pie = () => TYPE.PIE)()
+);
+let polar = (): string => (
+	extendArc([shapePolar], [optArc, optPolar]), (polar = () => TYPE.POLAR)()
+);
 let radar = (): string => (
 	extendArc([shapePoint, shapeRadar], [optPoint, optRadar]), (radar = () => TYPE.RADAR)()
 );

--- a/test/shape/arc-spec.ts
+++ b/test/shape/arc-spec.ts
@@ -3,6 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 /* eslint-disable */
+// @ts-nocheck
 /* global describe, beforeEach, it, expect */
 import {expect} from "chai";
 import sinon from "sinon";
@@ -725,6 +726,94 @@ describe("SHAPE ARC", () => {
 
 		it("check Gauge's expand", done => {
 			checkExpand(done);
+		});
+	});
+
+	describe("Arc options", () => {
+		let args = {
+			data: {
+				columns: [
+					["data1", 30],
+					["data2", 45],
+					["data3", 25]
+				],
+				type: "donut"
+			},
+			arc: {
+				cornerRadius: 25
+			}
+		};
+
+		beforeEach(() => {
+			return new Promise(resolve => {
+				args.onrendered = resolve;
+				chart = util.generate(args);
+			});
+		});
+
+		it("check the corner radius applied correctly.", () => {
+			const expected = [
+				["M57.22067150815714,176.10711868676853", "25,25,0,0,1,37.919005536927386,208.42881643163085"],
+				["M7.105427357601002e-15,-185.1699827185821", "25,25,0,0,1,28.34492908750335,-209.9452011716972"],
+				["M-185.1699827185821,-1.3500311979441904e-13", "25,25,0,0,1,-209.94520117169716,-28.344929087503502"]
+			];
+
+			chart.$.arc.selectAll("path").each(function(d, i) {
+				const path = this.getAttribute("d").split("A").splice(0, 2);
+
+				expect(path).to.be.deep.equal(expected[i]);
+			});
+		});
+
+		it("set option: ratio", () => {
+			args.arc.cornerRadius = {
+				ratio: 0.2
+			};
+		});
+
+		it("check the corner radius in 'ratio' value,  applied correctly.", done => {
+			const expected = [
+				["M28.424419731594476,87.48136866168787", "23.75,23.75,0,0,1,7.296034336980716,118.52565284761607"],
+				["M7.105427357601002e-15,-91.98335447242616", "23.75,23.75,0,0,1,29.687500000000007,-114.9791930905327"],
+				["M-91.98335447242614,-7.105427357601002e-14", "23.75,23.75,0,0,1,-114.97919309053266,-29.68750000000009"]
+			];
+
+			// when resizes
+			chart.resize({width: 250});
+
+			setTimeout(() => {
+				chart.$.arc.selectAll("path").each(function(d, i) {
+					const path = this.getAttribute("d").split("A").splice(0, 2);
+
+					expect(path).to.be.deep.equal(expected[i]);
+				});
+
+				done();
+			}, 300);
+		});
+
+		it("set option: function", () => {
+			args.arc.cornerRadius = function(id, value, outerRadius) {
+				return ({
+					data1: outerRadius * 0.1,
+					data2: value > 45 ? outerRadius * 0.5 : 0,
+					data3: 60
+				})[id];
+			};
+		});
+
+		it("check the corner radius with 'function', applied correctly.", () => {
+			const expected = [
+				["M58.553899896666884,180.21037374937964", "21.185000000000002,21.185000000000002,0,0,1,42.67307510994895,207.50766530579213"],
+				["M1.2972071219968338e-14,-211.85", "211.85,211.85,0,0,1,65.46525025833253,201.4813229771283L39.27915015499951,120.88879378627696"],
+				["M-164.09830437880822,-1.2789769243681803e-13", "42.370000000000005,42.370000000000005,0,0,1,-205.12288047351026,-52.96250000000016"]
+			];
+
+			chart.$.arc.selectAll("path").each(function(d, i) {
+				const path = this.getAttribute("d").split("A").splice(0, 2);
+
+				expect(path).to.be.deep.equal(expected[i]);
+			});
 		});
 	});
 });

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -3,12 +3,27 @@
  * billboard.js project is licensed under the MIT license
  */
 import {Axis} from "./axis";
-import {ChartTypes, d3Selection, DataItem, GaugeTypes, PrimitiveArray} from "./types";
+import {ChartTypes, d3Selection, DataItem, PrimitiveArray} from "./types";
 import Bubblecompare from "./plugin/bubblecompare/index";
 import Stanford from "./plugin/stanford/index";
 import TextOverlap from "./plugin/textoverlap/index";
 import {Chart} from "./chart";
 import {IArcData, IData, IDataRow} from "../src/ChartInternal/data/IData";
+import {
+	ArcOptions,
+	AreaOptions,
+	BarOptions,
+	BubbleOptions,
+	CandlestickOptions,
+	DonutOptions,
+	GaugeOptions,
+	LineOptions,
+	PieOptions,
+	PolarOptions,
+	RadarOptions,
+	ScatterOptions,
+	SplineOptions
+} from "./options.shape";
 
 export interface ChartOptions {
 	/**
@@ -242,600 +257,19 @@ export interface ChartOptions {
 
 	point?: PointOptions;
 
-	line?: {
-		/**
-		 * Set if null data point will be connected or not.
-		 * If true set, the region of null data will be connected without any data point.
-		 * If false set, the region of null data will not be connected and get empty.
-		 */
-		connectNull?: boolean;
-
-		/**
-		 * Change step type for step chart.
-		 * 'step', 'step-before' and 'step-after' can be used.
-		 */
-		step?: {
-			type?: "step" | "step-before" | "step-after";
-		};
-
-		/**
-		 * Set if min or max value will be 0 on line chart.
-		 */
-		zerobased?: boolean;
-
-		/**
-		 * If set, used to set a css class on each line.
-		 */
-		classes?: string[];
-
-		/**
-		 * Set to false to not draw points on linecharts. Or pass an array of line ids to draw points for.
-		 */
-		point?: boolean | string[];
-	};
-
-	scatter?: {
-		/**
-		 * Set if min or max value will be 0 on scatter chart.
-		 */
-		zerobased?: boolean;
-	};
-
-	area?: {
-		/**
-		 * Set background area above the data chart line.
-		 */
-		above?: boolean;
-
-		/**
-		 * Set background area `below` the data chart line.
-		 *  - **NOTE**: Can't be used along with `above` option. When above & below options are set to true, `above` will be prioritized.
-		 */
-		below?: boolean;
-
-		/**
-		 * Set area node to be positioned over line node.
-		 */
-		front?: boolean;
-
-		/**
-		 * Set the linear gradient on area.<br><br>
-		 * Or customize by giving below object value:
-		 *  - x {Array}: `x1`, `x2` value
-		 *  - y {Array}: `y1`, `y2` value
-		 *  - stops {Array}: Each item should be having `[offset, stop-color, stop-opacity]` values.
-		 */
-		linearGradient?: boolean | LinearGradientOptions;
-
-		/**
-		 * Set if min or max value will be 0 on area chart.
-		 */
-		zerobased?: boolean;
-	};
-
-	bar?: {
-		/**
-		 * Set threshold ratio to show/hide labels.
-		 */
-		label?: {
-			threshold?: number;
-		}
-
-		/**
-		 * Remove nullish data on bar indices positions.
-		 */
-		indices?: {
-			removeNull?: boolean;
-		}
-
-		/**
-		 * Set the linear gradient on bar.<br><br>
-		 * Or customize by giving below object value:
-		 *  - x {Array}: `x1`, `x2` value
-		 *  - y {Array}: `y1`, `y2` value
-		 *  - stops {Array}: Each item should be having `[offset, stop-color, stop-opacity]` values.
-		 */
-		linearGradient?: boolean | LinearGradientOptions;
-
-		/**
-		 * Bars will be rendered at same position, which will be overlapped each other. (for non-grouped bars only)
-		 */
-		orverlap?: boolean;
-
-		/**
-		 * The padding pixel value between each bar.
-		 */
-		padding?: number;
-
-		/**
-		 * Set the radius of bar edge in pixel.
-		 * - NOTE: Only for non-stacking bars.
-		 */
-		radius?: number | {
-			/**
-			 * Set the radius ratio of bar edge in relative the bar's width.
-			 */
-			ratio?: number;
-		};
-
-		/**
-		 * The senstivity offset value for interaction boundary.
-		 */
-		sensitivity?: number;
-
-		/**
-		 * Change the width of bar chart. If ratio is specified, change the width of bar chart by ratio.
-		 */
-		width?: number | {
-			/**
-			 * Set the width of each bar by ratio
-			 */
-			ratio: number;
-
-			/**
-			 * Set max width of each bar
-			 */
-			max?: number;
-		} | {
-			/**
-			 * Set the width option for specific dataset
-			 */
-			[key: string]: number | {
-				ratio: number;
-				max: number;
-			}
-		};
-
-		/**
-		 * Set if min or max value will be 0 on bar chart.
-		 */
-		zerobased?: boolean;
-	};
-
-	bubble?: {
-		/**
-		 * Set the max bubble radius value
-		 */
-		maxR?: ((this: Chart, d: {}) => number) | number;
-
-		/**
-		 * Set if min or max value will be 0 on bubble chart.
-		 */
-		zerobased?: boolean;
-	};
-
-	candlestick?: {
-		/**
-		 * Change the width of bar chart. If ratio is specified, change the width of bar chart by ratio.
-		 */
-		width?: number | {
-			/**
-			 * Set the width of each bar by ratio
-			 */
-			ratio: number;
-
-			/**
-			 * Set max width of each bar
-			 */
-			max?: number;
-		} | {
-			/**
-			 * Set the width option for specific dataset
-			 */
-			[key: string]: number | {
-				ratio: number;
-				max: number;
-			}
-		};
-
-		color?: {
-			/**
-			 * Change down value color.
-			 */
-			down: string | {
-				/**
-				 * Change down value color for indicated dataset only.
-				 */
-				[key: string]: string;
-			}
-		}
-	};
-
-	radar?: {
-		axis?: {
-			/**
-			 * The max value of axis. If not given, it'll take the max value from the given data.
-			 */
-			max?: number;
-
-			line?: {
-				/**
-				 * Show or hide axis line.
-				 */
-				show?: boolean;
-			};
-
-			text?: {
-				position?: {
-					/**
-					 * x coordinate position, relative the original
-					 */
-					x?: number;
-
-					/**
-					 * y coordinate position, relative the original
-					 */
-					y?: number;
-				};
-
-				/**
-				 * Show or hide axis text.
-				 */
-				show?: boolean;
-			};
-		};
-
-		direction?: {
-			/**
-			 * Set the direction to be drawn.
-			 */
-			clockwise?: boolean;
-		};
-
-		level?: {
-			/**
-			 * Set the level depth.
-			 */
-			depth?: number;
-
-			/**
-			 * Show or hide level.
-			 */
-			show?: boolean;
-
-			text?: {
-				/**
-				 * Set format function for the level value.
-				 */
-				format?: (this: Chart, x: string) => string;
-
-				/**
-				 * Show or hide level text.
-				 */
-				show?: boolean;
-			};
-		}
-
-		size?: {
-			/**
-			 * Set size ratio.
-			 */
-			ratio?: number;
-		}
-	};
-
-	polar?: {
-		label?: {
-			/**
-			 * Show or hide label on each polar piece.
-			 */
-			show?: boolean;
-
-			/**
-			 * Set threshold ratio to show/hide labels.
-			 */
-			threshold?: number;
-
-			/**
-			 * Set formatter for the label on each polar piece.
-			 */
-			format?(this: Chart, value: number, ratio: number, id: string): string;
-
-			/**
-			 * Set ratio of labels position.
-			 */
-			ratio?: ((this: Chart, d: DataItem, radius: number, h: number) => void) | number
-		};
-		level?: {
-			/**
-			 * Set the level depth.
-			 */
-			depth?: number;
-
-			/**
-			 * Set level max value.
-			 */
-			max?: number;
-
-			/**
-			 * Show or hide level.
-			 */
-			show?: boolean;
-
-			text?: {
-				/**
-				 * Set label text's background color.
-				 */
-				backgroundColor?: string;
-
-				/**
-				 * Set format function for the level value.
-				 */
-				format?: (this: Chart, x: string) => string;
-
-				/**
-				 * Show or hide level text.
-				 */
-				show?: boolean;
-			}
-		};
-
-		/**
-		 * Set padding between data.
-		 */
-		padAngle?: number;
-
-		/**
-		 * Sets the gap between pie arcs.
-		 */
-		padding?: number;
-
-		/**
-		 * Set starting angle where data draws.
-		 */
-		startAngle?: number;
-	};
-
-	pie?: {
-		label?: {
-			/**
-			 * Show or hide label on each pie piece.
-			 */
-			show?: boolean;
-
-			/**
-			 * Set threshold ratio to show/hide labels.
-			 */
-			threshold?: number;
-
-			/**
-			 * Set formatter for the label on each pie piece.
-			 */
-			format?(this: Chart, value: number, ratio: number, id: string): string;
-
-			/**
-			 * Set ratio of labels position.
-			 */
-			ratio?: ((this: Chart, d: DataItem, radius: number, h: number) => void) | number
-		};
-
-		/**
-		 * Enable or disable expanding pie pieces.
-		 */
-		expand?: boolean | {
-			/**
-			 * Set expand transition time in ms.
-			 */
-			duration?: number;
-
-			/**
-			 * Set expand rate.
-			 */
-			rate?: number;
-		};
-
-		/**
-		 * Sets the inner radius of pie arc.
-		 */
-		innerRadius?: number | {
-			[key: string]: number
-		};
-
-		/**
-		 * Sets the outer radius of pie arc.
-		 */
-		outerRadius?: number | {
-			[key: string]: number
-		};
-
-		/**
-		 * Set padding between data.
-		 */
-		padAngle?: number;
-
-		/**
-		 * Sets the gap between pie arcs.
-		 */
-		padding?: number;
-
-		/**
-		 * Set starting angle where data draws.
-		 */
-		startingAngle?: number;
-	};
-
-	donut?: {
-		label?: {
-			/**
-			 * Show or hide label on each donut piece.
-			 */
-			show?: boolean;
-
-			/**
-			 * Set formatter for the label on each donut piece.
-			 */
-			format?: (this: Chart, value: number, ratio: number, id: string) => string;
-
-			/**
-			 * Set ratio of labels position.
-			 */
-			ratio?: number | ((this: Chart, d: DataItem, radius: number, h: number) => number)
-
-			/**
-			 * Set threshold ratio to show/hide labels.
-			 */
-			threshold?: number;
-		};
-
-		/**
-		 * Enable or disable expanding donut pieces.
-		 */
-		expand?: boolean | {
-			/**
-			 * Set expand transition time in ms.
-			 */
-			duration?: number;
-
-			/**
-			 * Set expand rate.
-			 */
-			rate?: number;
-		};
-
-		/**
-		 * Set padding between data.
-		 */
-		padAngle?: number;
-
-		/**
-		 * Set starting angle where data draws.
-		 */
-		startingAngle?: number;
-
-		/**
-		 * Set width of donut chart.
-		 */
-		width?: number;
-
-		/**
-		 * Set title of donut chart.
-		 */
-		title?: string;
-	};
-
-	gauge?: {
-		/**
-		 * Set background color. (The `.bb-chart-arcs-background` element)
-		 */
-		background?: string;
-
-		/**
-		 * Whether this should be displayed
-		 * as a full circle instead of a
-		 * half circle.
-		 */
-		fullCircle?: boolean;
-
-		label?: {
-			/**
-			 * Show or hide label on gauge.
-			 */
-			show?: boolean;
-
-			/**
-			 * Set formatter for the label on gauge.
-			 */
-			format?(this: Chart, value: any, ratio: number): string;
-
-			/**
-			 * Set customized min/max label text.
-			 */
-			extents?(this: Chart, value: number, isMax: boolean): string | number;
-
-			/**
-			 * Set threshold ratio to show/hide labels.
-			 */
-			threshold?: number;
-		};
-
-		/**
-		 * Enable or disable expanding gauge pieces.
-		 */
-		expand?: boolean | {
-			/**
-			 * Set expand transition time in ms.
-			 */
-			duration?: number;
-
-			/**
-			 * Set expand rate.
-			 */
-			rate?: number;
-		};
-
-		/**
-		 * Set type of the gauge.
-		 */
-		type?: GaugeTypes;
-
-		/**
-		 * Set min value of the gauge.
-		 */
-		min?: number;
-
-		/**
-		 * Set max value of the gauge.
-		 */
-		max?: number;
-
-		/**
-		 * Set starting angle where data draws.
-		 */
-		startingAngle?: number;
-
-		/**
-		 * Set title of gauge chart. Use `\n` character to enter line break.
-		 */
-		title?: string;
-
-		/**
-		 * Set units of the gauge.
-		 */
-		units?: string;
-
-		/**
-		 * Set width of gauge chart.
-		 */
-		width?: number;
-
-		/**
-		 * Set minimal width of gauge arcs until the innerRadius disappears.
-		 */
-		arcs?: {
-			minWidth?: number;
-		};
-
-		/**
-		 * Set the length of the arc to be drawn in percent from -100 to 100.
-		 * Negative value will draw the arc **counterclockwise**.
-		 */
-		arcLength?: number;
-	};
-
-	spline?: {
-		interpolation?: {
-			/**
-			 * Set custom spline interpolation
-			 */
-			type?: "basis"
-			| "basis-open"
-			| "bundle"
-			| "cardinal"
-			| "cardinal-closed"
-			| "cardinal-open"
-			| "catmull-rom"
-			| "catmull-rom-closed"
-			| "catmull-rom-open"
-			| "monotone-x"
-			| "monotone-y"
-			| "natural"
-			| "linear-closed"
-			| "linear"
-			| "step"
-			| "step-after"
-			| "step-before"
-		};
-	};
+	arc?: ArcOptions;
+	area?: AreaOptions;
+	bar?: BarOptions;
+	bubble?: BubbleOptions;
+	candlestick?: CandlestickOptions;
+	donut?: DonutOptions;
+	gauge?: GaugeOptions;
+	line?: LineOptions;
+	polar?: PolarOptions;
+	pie?: PieOptions;
+	radar?: RadarOptions;
+	scatter?: ScatterOptions;
+	spline?: SplineOptions;
 
 	/**
 	 * Set a callback to execute when the chart is initialized.
@@ -944,27 +378,6 @@ export interface ChartOptions {
 		 */
 		position?: "center" | "right" | "left";
 	};
-}
-
-export interface LinearGradientOptions {
-	/**
-	 * x1, x2 attributes
-	 */
-	x?: [number, number];
-
-	/**
-	 * y1, y2 attributes
-	 */
-	y?: [number, number];
-
-	/**
-	 * The ramp of colors to use on a gradient
-	 *
-	 * offset, stop-color, stop-opacity
-	 * - setting 'null' for stop-color, will set its original data color
-	 * - setting 'function' for stop-color, will pass data id as argument. It should return color string or null value
-	 */
-	stops?: Array<[number, string | null | ((this: Chart, id: string) => string), number]>;
 }
 
 export interface RegionOptions {
@@ -1474,7 +887,7 @@ export interface Grid {
 		 * If x axis is category axis, value can be category name.
 		 * If x axis is timeseries axis, value can be date string, Date object and unixtime integer.
 		 */
-		lines?: LineOptions[];
+		lines?: GridLineOptions[];
 	};
 
 	y?: {
@@ -1487,7 +900,7 @@ export interface Grid {
 		 * Show additional grid lines along y axis.
 		 * This option accepts array including object that has value, text, position and class.
 		 */
-		lines?: LineOptions[];
+		lines?: GridLineOptions[];
 
 		/**
 		 * Number of y grids to be shown.
@@ -1496,7 +909,7 @@ export interface Grid {
 	};
 }
 
-export interface LineOptions {
+export interface GridLineOptions {
 	value: string | number | Date;
 	text?: string;
 	axis?: string;

--- a/types/options.shape.d.ts
+++ b/types/options.shape.d.ts
@@ -1,0 +1,634 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+import {DataItem, GaugeTypes} from "./types";
+import {Chart} from "./chart";
+
+export interface ArcOptions {
+	/**
+	 *  Set corner radius of Arc(donut/gauge/pie/polar) shape.
+	 *  - **NOTE:**
+	 * 	  - Corner radius can't surpass the `(outerRadius - innerRadius) /2` of indicated shape.
+	 * 	  - When specified value is greater than the limitation, the radius value will be adjusted to meet the condition.
+	 */
+	cornerRadius?: number | ((id: string, value: number, outerRadius: number) => number) | {
+		ratio?: number
+	};
+}
+
+export interface AreaOptions {
+	/**
+	 * Set background area above the data chart line.
+	 */
+	above?: boolean;
+
+	/**
+	 * Set background area `below` the data chart line.
+	 *  - **NOTE**: Can't be used along with `above` option. When above & below options are set to true, `above` will be prioritized.
+	 */
+	below?: boolean;
+
+	/**
+	 * Set area node to be positioned over line node.
+	 */
+	front?: boolean;
+
+	/**
+	 * Set the linear gradient on area.<br><br>
+	 * Or customize by giving below object value:
+	 *  - x {Array}: `x1`, `x2` value
+	 *  - y {Array}: `y1`, `y2` value
+	 *  - stops {Array}: Each item should be having `[offset, stop-color, stop-opacity]` values.
+	 */
+	linearGradient?: boolean | LinearGradientOptions;
+
+	/**
+	 * Set if min or max value will be 0 on area chart.
+	 */
+	zerobased?: boolean;
+}
+
+export interface BarOptions {
+	/**
+	 * Set threshold ratio to show/hide labels.
+	 */
+	label?: {
+		threshold?: number;
+	};
+
+	/**
+	 * Remove nullish data on bar indices positions.
+	 */
+	indices?: {
+		removeNull?: boolean;
+	};
+
+	/**
+	 * Set the linear gradient on bar.<br><br>
+	 * Or customize by giving below object value:
+	 *  - x {Array}: `x1`, `x2` value
+	 *  - y {Array}: `y1`, `y2` value
+	 *  - stops {Array}: Each item should be having `[offset, stop-color, stop-opacity]` values.
+	 */
+	linearGradient?: boolean | LinearGradientOptions;
+
+	/**
+	 * Bars will be rendered at same position, which will be overlapped each other. (for non-grouped bars only)
+	 */
+	orverlap?: boolean;
+
+	/**
+	 * The padding pixel value between each bar.
+	 */
+	padding?: number;
+
+	/**
+	 * Set the radius of bar edge in pixel.
+	 * - NOTE: Only for non-stacking bars.
+	 */
+	radius?: number | {
+		/**
+		 * Set the radius ratio of bar edge in relative the bar's width.
+		 */
+		ratio?: number;
+	};
+
+	/**
+	 * The senstivity offset value for interaction boundary.
+	 */
+	sensitivity?: number;
+
+	/**
+	 * Change the width of bar chart. If ratio is specified, change the width of bar chart by ratio.
+	 */
+	width?: number | {
+		/**
+		 * Set the width of each bar by ratio
+		 */
+		ratio: number;
+
+		/**
+		 * Set max width of each bar
+		 */
+		max?: number;
+	} | {
+		/**
+		 * Set the width option for specific dataset
+		 */
+		[key: string]: number | {
+			ratio: number;
+			max: number;
+		}
+	};
+
+	/**
+	 * Set if min or max value will be 0 on bar chart.
+	 */
+	zerobased?: boolean;
+}
+
+export interface BubbleOptions {
+	/**
+	 * Set the max bubble radius value
+	 */
+	maxR?: ((this: Chart, d: {}) => number) | number;
+
+	/**
+	 * Set if min or max value will be 0 on bubble chart.
+	 */
+	zerobased?: boolean;
+}
+
+export interface CandlestickOptions {
+	/**
+	 * Change the width of bar chart. If ratio is specified, change the width of bar chart by ratio.
+	 */
+	width?: number | {
+		/**
+		 * Set the width of each bar by ratio
+		 */
+		ratio: number;
+
+		/**
+		 * Set max width of each bar
+		 */
+		max?: number;
+	} | {
+		/**
+		 * Set the width option for specific dataset
+		 */
+		[key: string]: number | {
+			ratio: number;
+			max: number;
+		}
+	};
+
+	color?: {
+		/**
+		 * Change down value color.
+		 */
+		down: string | {
+			/**
+			 * Change down value color for indicated dataset only.
+			 */
+			[key: string]: string;
+		}
+	};
+}
+
+export interface DonutOptions {
+	label?: {
+		/**
+		 * Show or hide label on each donut piece.
+		 */
+		show?: boolean;
+
+		/**
+		 * Set formatter for the label on each donut piece.
+		 */
+		format?: (this: Chart, value: number, ratio: number, id: string) => string;
+
+		/**
+		 * Set ratio of labels position.
+		 */
+		ratio?: number | ((this: Chart, d: DataItem, radius: number, h: number) => number)
+
+		/**
+		 * Set threshold ratio to show/hide labels.
+		 */
+		threshold?: number;
+	};
+
+	/**
+	 * Enable or disable expanding donut pieces.
+	 */
+	expand?: boolean | {
+		/**
+		 * Set expand transition time in ms.
+		 */
+		duration?: number;
+
+		/**
+		 * Set expand rate.
+		 */
+		rate?: number;
+	};
+
+	/**
+	 * Set padding between data.
+	 */
+	padAngle?: number;
+
+	/**
+	 * Set starting angle where data draws.
+	 */
+	startingAngle?: number;
+
+	/**
+	 * Set width of donut chart.
+	 */
+	width?: number;
+
+	/**
+	 * Set title of donut chart.
+	 */
+	title?: string;
+}
+
+export interface GaugeOptions {
+	/**
+	 * Set background color. (The `.bb-chart-arcs-background` element)
+	 */
+	background?: string;
+
+	/**
+	 * Whether this should be displayed
+	 * as a full circle instead of a
+	 * half circle.
+	 */
+	fullCircle?: boolean;
+
+	label?: {
+		/**
+		 * Show or hide label on gauge.
+		 */
+		show?: boolean;
+
+		/**
+		 * Set formatter for the label on gauge.
+		 */
+		format?(this: Chart, value: any, ratio: number): string;
+
+		/**
+		 * Set customized min/max label text.
+		 */
+		extents?(this: Chart, value: number, isMax: boolean): string | number;
+
+		/**
+		 * Set threshold ratio to show/hide labels.
+		 */
+		threshold?: number;
+	};
+
+	/**
+	 * Enable or disable expanding gauge pieces.
+	 */
+	expand?: boolean | {
+		/**
+		 * Set expand transition time in ms.
+		 */
+		duration?: number;
+
+		/**
+		 * Set expand rate.
+		 */
+		rate?: number;
+	};
+
+	/**
+	 * Set type of the gauge.
+	 */
+	type?: GaugeTypes;
+
+	/**
+	 * Set min value of the gauge.
+	 */
+	min?: number;
+
+	/**
+	 * Set max value of the gauge.
+	 */
+	max?: number;
+
+	/**
+	 * Set starting angle where data draws.
+	 */
+	startingAngle?: number;
+
+	/**
+	 * Set title of gauge chart. Use `\n` character to enter line break.
+	 */
+	title?: string;
+
+	/**
+	 * Set units of the gauge.
+	 */
+	units?: string;
+
+	/**
+	 * Set width of gauge chart.
+	 */
+	width?: number;
+
+	/**
+	 * Set minimal width of gauge arcs until the innerRadius disappears.
+	 */
+	arcs?: {
+		minWidth?: number;
+	};
+
+	/**
+	 * Set the length of the arc to be drawn in percent from -100 to 100.
+	 * Negative value will draw the arc **counterclockwise**.
+	 */
+	arcLength?: number;
+}
+
+export interface LineOptions {
+	/**
+	 * Set if null data point will be connected or not.
+	 * If true set, the region of null data will be connected without any data point.
+	 * If false set, the region of null data will not be connected and get empty.
+	 */
+	connectNull?: boolean;
+
+	/**
+	 * Change step type for step chart.
+	 * 'step', 'step-before' and 'step-after' can be used.
+	 */
+	step?: {
+		type?: "step" | "step-before" | "step-after";
+	};
+
+	/**
+	 * Set if min or max value will be 0 on line chart.
+	 */
+	zerobased?: boolean;
+
+	/**
+	 * If set, used to set a css class on each line.
+	 */
+	classes?: string[];
+
+	/**
+	 * Set to false to not draw points on linecharts. Or pass an array of line ids to draw points for.
+	 */
+	point?: boolean | string[];
+}
+
+export interface PieOptions {
+	label?: {
+		/**
+		 * Show or hide label on each pie piece.
+		 */
+		show?: boolean;
+
+		/**
+		 * Set threshold ratio to show/hide labels.
+		 */
+		threshold?: number;
+
+		/**
+		 * Set formatter for the label on each pie piece.
+		 */
+		format?(this: Chart, value: number, ratio: number, id: string): string;
+
+		/**
+		 * Set ratio of labels position.
+		 */
+		ratio?: ((this: Chart, d: DataItem, radius: number, h: number) => void) | number
+	};
+
+	/**
+	 * Enable or disable expanding pie pieces.
+	 */
+	expand?: boolean | {
+		/**
+		 * Set expand transition time in ms.
+		 */
+		duration?: number;
+
+		/**
+		 * Set expand rate.
+		 */
+		rate?: number;
+	};
+
+	/**
+	 * Sets the inner radius of pie arc.
+	 */
+	innerRadius?: number | {
+		[key: string]: number
+	};
+
+	/**
+	 * Sets the outer radius of pie arc.
+	 */
+	outerRadius?: number | {
+		[key: string]: number
+	};
+
+	/**
+	 * Set padding between data.
+	 */
+	padAngle?: number;
+
+	/**
+	 * Sets the gap between pie arcs.
+	 */
+	padding?: number;
+
+	/**
+	 * Set starting angle where data draws.
+	 */
+	startingAngle?: number;
+}
+
+export interface PolarOptions {
+	label?: {
+		/**
+		 * Show or hide label on each polar piece.
+		 */
+		show?: boolean;
+
+		/**
+		 * Set threshold ratio to show/hide labels.
+		 */
+		threshold?: number;
+
+		/**
+		 * Set formatter for the label on each polar piece.
+		 */
+		format?(this: Chart, value: number, ratio: number, id: string): string;
+
+		/**
+		 * Set ratio of labels position.
+		 */
+		ratio?: ((this: Chart, d: DataItem, radius: number, h: number) => void) | number
+	};
+	level?: {
+		/**
+		 * Set the level depth.
+		 */
+		depth?: number;
+
+		/**
+		 * Set level max value.
+		 */
+		max?: number;
+
+		/**
+		 * Show or hide level.
+		 */
+		show?: boolean;
+
+		text?: {
+			/**
+			 * Set label text's background color.
+			 */
+			backgroundColor?: string;
+
+			/**
+			 * Set format function for the level value.
+			 */
+			format?: (this: Chart, x: string) => string;
+
+			/**
+			 * Show or hide level text.
+			 */
+			show?: boolean;
+		}
+	};
+
+	/**
+	 * Set padding between data.
+	 */
+	padAngle?: number;
+
+	/**
+	 * Sets the gap between pie arcs.
+	 */
+	padding?: number;
+
+	/**
+	 * Set starting angle where data draws.
+	 */
+	startAngle?: number;
+}
+
+export interface RadarOptions {
+	axis?: {
+		/**
+		 * The max value of axis. If not given, it'll take the max value from the given data.
+		 */
+		max?: number;
+
+		line?: {
+			/**
+			 * Show or hide axis line.
+			 */
+			show?: boolean;
+		};
+
+		text?: {
+			position?: {
+				/**
+				 * x coordinate position, relative the original
+				 */
+				x?: number;
+
+				/**
+				 * y coordinate position, relative the original
+				 */
+				y?: number;
+			};
+
+			/**
+			 * Show or hide axis text.
+			 */
+			show?: boolean;
+		};
+	};
+
+	direction?: {
+		/**
+		 * Set the direction to be drawn.
+		 */
+		clockwise?: boolean;
+	};
+
+	level?: {
+		/**
+		 * Set the level depth.
+		 */
+		depth?: number;
+
+		/**
+		 * Show or hide level.
+		 */
+		show?: boolean;
+
+		text?: {
+			/**
+			 * Set format function for the level value.
+			 */
+			format?: (this: Chart, x: string) => string;
+
+			/**
+			 * Show or hide level text.
+			 */
+			show?: boolean;
+		};
+	};
+
+	size?: {
+		/**
+		 * Set size ratio.
+		 */
+		ratio?: number;
+	};
+}
+
+export interface ScatterOptions {
+	/**
+	 * Set if min or max value will be 0 on scatter chart.
+	 */
+	zerobased?: boolean;
+}
+
+export interface SplineOptions {
+	interpolation?: {
+		/**
+		 * Set custom spline interpolation
+		 */
+		type?: "basis"
+		| "basis-open"
+		| "bundle"
+		| "cardinal"
+		| "cardinal-closed"
+		| "cardinal-open"
+		| "catmull-rom"
+		| "catmull-rom-closed"
+		| "catmull-rom-open"
+		| "monotone-x"
+		| "monotone-y"
+		| "natural"
+		| "linear-closed"
+		| "linear"
+		| "step"
+		| "step-after"
+		| "step-before"
+	};
+}
+
+export interface LinearGradientOptions {
+	/**
+	 * x1, x2 attributes
+	 */
+	x?: [number, number];
+
+	/**
+	 * y1, y2 attributes
+	 */
+	y?: [number, number];
+
+	/**
+	 * The ramp of colors to use on a gradient
+	 *
+	 * offset, stop-color, stop-opacity
+	 * - setting 'null' for stop-color, will set its original data color
+	 * - setting 'function' for stop-color, will pass data id as argument. It should return color string or null value
+	 */
+	stops?: Array<[number, string | null | ((this: Chart, id: string) => string), number]>;
+}


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2936

## Details
<!-- Detailed description of the change/feature -->
Implement option to make corner radius for arc types: donut/gauge/pie/polar

```js
arc: {
    cornerRadius: 12,

    // can customize corner radius for each data with function callback
    //
    // The function will receive:
    // - id {string}: Data id
    // - value {number}: Data value
    // - outerRadius {number}: Outer radius value
    cornerRadius: function(id, value, outerRadius) {
        return (id === "data1" && value > 10) ?
            50 : outerRadius * 1.2;
    },

    // set ratio relative of outer radius
    cornerRadius: {
        ratio: 0.5
    }
}
```

<img width="450" alt="image" src="https://user-images.githubusercontent.com/2178435/199891094-2d5a23b9-2df3-44ac-91ae-4297f7f9b430.png">
