### PR TITLE
chore(jsdoc): Add taffydb to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
 		"sinon": "^14.0.2",
 		"string-replace-loader": "^3.1.0",
 		"style-loader": "^3.3.1",
+		"taffydb": "^2.7.3",
 		"terser-webpack-plugin": "^5.3.6",
 		"tslib": "^2.4.1",
 		"typescript": "4.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12448,6 +12448,11 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+taffydb@^2.7.3:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.7.3.tgz#2ad37169629498fca5bc84243096d3cde0ec3a34"
+  integrity sha512-GQ3gtYFSOAxSMN/apGtDKKkbJf+8izz5YfbGqIsUc7AMiQOapARZ76dhilRY2h39cynYxBFdafQo5HUL5vgkrg==
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
Add taffydb module as jsdoc generation fails as:
- FATAL: Unable to load template: Cannot find module 'taffydb'