### PR TITLE
fix(types): Add missing param definition for gauge.label.format

### DIFF
--- a/types/options.shape.d.ts
+++ b/types/options.shape.d.ts
@@ -257,7 +257,7 @@ export interface GaugeOptions {
 		/**
 		 * Set formatter for the label on gauge.
 		 */
-		format?(this: Chart, value: any, ratio: number): string;
+		format?(this: Chart, value: any, ratio: number, id: string): string;
 
 		/**
 		 * Set customized min/max label text.


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2946

## Details
<!-- Detailed description of the change/feature -->
Add missing 'id' param definition