### PR TITLE
Support TypeScript >= 4.7 "node16"/"nodenext" moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
 	"type": "module",
 	"exports": {
 		".": {
+      		"types": "./types/index.d.ts",
 			"import": "./dist-esm/billboard.js",
 			"require": "./dist/billboard.pkgd.js"
 		},
 		"./dist/plugin/*": {
+			"types": "./types/plugin/*.d.ts",
 			"import": "./dist-esm/plugin/*.js",
 			"require": "./dist/plugin/pkgd/*.js"
 		},

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"type": "module",
 	"exports": {
 		".": {
-      		"types": "./types/index.d.ts",
+			"types": "./types/index.d.ts",
 			"import": "./dist-esm/billboard.js",
 			"require": "./dist/billboard.pkgd.js"
 		},


### PR DESCRIPTION
## Issue
Fixes #2952

## Details
This minimal update to package.json fixes the issue, and billboard.js can be used in true cross-platform ESM module based projects where TypeScript compiler option `moduleResolution` is set to `node16` or `nodenext`
