### PR TITLE
Fix to referenced but missing d3 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
 	"license": "MIT",
 	"readmeFilename": "README.md",
 	"dependencies": {
+		"@types/d3-selection": "*",
+		"@types/d3-transition": "*",
 		"d3-axis": "^3.0.0",
 		"d3-brush": "^3.0.0",
 		"d3-drag": "^3.0.0",


### PR DESCRIPTION
## Issue
Fixes #2954

## Details
This fixes issue #2954 - so that compilation will work again in TypeScript projects with the billboard package installed.

I have added the 2 required types packages (with version "*") to _package.json_  `dependencies`.
The two dependencies/versions are identical to the way they appear in the `dependencies` section of _package.json_ inside the `@types/d3`  package.

**NB!** The yarn.lock file should probably also have been updated, but I unfortunately have little experience with yarn.
I hope you someone else can take care of that after merging the PR.