### PR TITLE
fix(axis): fix axis.y/y2.tick.format context error

### DIFF
--- a/src/ChartInternal/internals/format.ts
+++ b/src/ChartInternal/internals/format.ts
@@ -19,7 +19,7 @@ function getFormat($$, typeValue: AxisType, v: number): number | string {
 	const format = config[type] ?
 		config[type] : $$.defaultValueFormat;
 
-	return format(v);
+	return format.call($$.api, v);
 }
 
 export default {

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -1570,6 +1570,34 @@ describe("AXIS", function() {
 		});
 	});
 
+	describe("axis.y.tick.format", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100]
+					],
+				},
+				axis: {
+					y: {
+						tick: {
+							format: function(x) {
+								return this.data.values("data1")[0];
+							}
+						}
+					}
+				}
+			};
+		});
+
+		it("tick.format context should be chart instance itself.", () => {
+			// when
+			chart.tooltip.show({x:1});
+
+			expect(+chart.$.tooltip.select(".value").text()).to.be.equal(30);
+		});
+	});
+
 	describe("axis.y.tick.rotate", () => {
 		describe("y Axis", () => {
 			before(() => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2976

## Details
<!-- Detailed description of the change/feature -->
Make format function to be called within current instance context