### PR TITLE
fix(axis): Fix axis label overlap when has no data

### DIFF
--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -580,7 +580,7 @@ class Axis {
 		const currentTickMax = current.maxTickWidths[id];
 		let maxWidth = 0;
 
-		if (withoutRecompute || !config[`axis_${id}_show`] || $$.filterTargetsToShow().length === 0) {
+		if (withoutRecompute || !config[`axis_${id}_show`] || (currentTickMax.size > 0 && $$.filterTargetsToShow().length === 0)) {
 			return currentTickMax.size;
 		}
 

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -2582,7 +2582,8 @@ describe("AXIS", function() {
 				},
 				axis: {
 					y: {
-						label: "Your Y Axis"
+						label: "Your Y Axis",
+						position: ""
 					}
 				}
 			};
@@ -2591,8 +2592,39 @@ describe("AXIS", function() {
 		it("<clipPath> width shouldn't truncate y axis tick when has no data", () => {
 			const rect = chart.internal.$el.defs.selectAll("clipPath[id$='yaxis'] rect");
 
-			expect(+rect.attr("width")).to.be.equal(50);
+			expect(+rect.attr("width")).to.be.equal(60);
 		});
+
+		it("set options: axis.y.label", () => {
+			args.axis.y.label = {
+				text: "Your Y Axis",
+				position: "outer-middle"
+			};
+
+			args.axis.y2 = {
+				show: true,
+				label: args.axis.y.label
+			}
+		});
+
+		it("label text shouldn't be overlapped with tick text", () => {
+			const y = chart.$.main.select(`.${$AXIS.axisY}`);
+			const y2 = chart.$.main.select(`.${$AXIS.axisY2}`);
+
+			[y, y2].forEach((v, i) => {
+				const labelRect = v.select("text").node().getBoundingClientRect();
+				const tickRect = v.select(".tick:nth-child(7)").node().getBoundingClientRect();
+
+				// y axis
+				if (i === 0) {
+					expect(labelRect.x + labelRect.width < tickRect.x).to.be.true;
+
+				// y2 axis
+				} else {
+					expect(labelRect.x > tickRect.x + tickRect.width).to.be.true
+				}
+			});
+		})
 	});
 
 	describe("Axes tick culling", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2974

## Details
<!-- Detailed description of the change/feature -->
Make calculate tick width size when has no data.

<img width="448" alt="image" src="https://user-images.githubusercontent.com/2178435/204214898-cc4c0b7c-0f4a-4ddf-96d6-e6a9d6e7b522.png">
