### PR TITLE
fix(plugin): Fix stanford scale to accept 0 as min value

### DIFF
--- a/src/Plugin/stanford/ColorScale.ts
+++ b/src/Plugin/stanford/ColorScale.ts
@@ -4,7 +4,7 @@
  */
 import {axisRight as d3AxisRight} from "d3-axis";
 import {format as d3Format} from "d3-format";
-import {scaleSequential as d3ScaleSequential, scaleLog as d3ScaleLog} from "d3-scale";
+import {scaleSequential as d3ScaleSequential, scaleSymlog as d3ScaleSymlog} from "d3-scale";
 import CLASS from "./classes";
 import {isFunction, getRange} from "./util";
 
@@ -55,7 +55,7 @@ export default class ColorScale {
 			.attr("fill", d => inverseScale(d));
 
 		// Legend Axis
-		const axisScale = d3ScaleLog()
+		const axisScale = d3ScaleSymlog()
 			.domain([target.minEpochs, target.maxEpochs])
 			.range([
 				points[0] + config.padding_top + points[points.length - 1] + barHeight - 1,

--- a/test/plugin/stanford/stanford-spec.ts
+++ b/test/plugin/stanford/stanford-spec.ts
@@ -7,6 +7,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import util from "../../assets/util";
 import Stanford from "../../../src/Plugin/stanford/index";
+import CLASS from "../../../src/Plugin/stanford/classes";
 import {compareEpochs, getCentroid, getRegionArea, pointInRegion} from "../../../src/Plugin/stanford/util";
 
 describe("PLUGIN: STANFORD", () => {
@@ -245,6 +246,45 @@ describe("PLUGIN: STANFORD", () => {
 
 			expect(tooltip.select(".value").text()).to.be.equal("20/01/70");
 			expect(tooltip.select(".name").text()).to.be.equal("Epochs");
+		});
+	});
+
+	describe("scale", () => {
+		before(() => {
+			args = {
+				data: {
+					x: "HPE",
+					columns: [
+						["HPE", 2.5, 2.5, 3.5],
+						["HPL", 24.5, 24, 67.5]
+					],
+					type: "scatter"
+				},
+				plugins: [
+					new Stanford({
+						epochs: [
+							1,
+							32,
+							103,
+							124
+						],
+						scale: {
+							min: 0,
+							max: 10000,
+							format: "pow10"
+						},
+						padding: {
+							top: 15
+						}
+					})
+				]
+			};
+		});
+
+		it("specifying 0(zero) for min value", () => {
+			chart.$.svg.selectAll(`.${CLASS.colorScale} .tick text`).each(function(d, i) {
+				expect(this.textContent).to.be.equal(`10${i}`);
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2999

## Details
<!-- Detailed description of the change/feature -->
Replace d3-scaleLog to d3-scaleSymLog to handle 0(zero) for scale start value