### PR TITLE
fix(api): Fix tooltip.hide() error call for Arc types

### DIFF
--- a/src/Chart/api/tooltip.ts
+++ b/src/Chart/api/tooltip.ts
@@ -133,10 +133,10 @@ const tooltip = {
 		inputType === "touch" && $$.callOverOutForTouch();
 
 		$$.hideTooltip(true);
-		$$.hideGridFocus();
+		$$.hideGridFocus?.();
 
 		$$.unexpandCircles?.();
-		$$.expandBarTypeShapes(false);
+		$$.expandBarTypeShapes?.(false);
 	}
 };
 

--- a/test/esm/donut-spec.ts
+++ b/test/esm/donut-spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+/* global describe, beforeEach, it, expect */
+import {expect} from "chai";
+import bb, {donut} from "../../src/index.esm";
+
+describe("ESM donut", function() {
+    let chart;
+
+    const args: any = {
+        data: {
+            columns: [
+                ["data1", 30],
+                ["data2", 120]
+            ],
+            type: donut()
+        }
+    };
+    
+	beforeEach(() => {
+		chart = bb.generate(args);
+	});
+
+    it("should tooltip.hide() work", done => {
+        const {internal} = chart;
+        const {hideGridFocus} = internal;
+        
+        internal.hideGridFocus = null;
+
+        setTimeout(() => {
+            // when
+            chart.tooltip.show({index: 0});
+
+            expect(chart.tooltip.hide()).to.not.throw;
+            expect(chart.$.tooltip.style("display")).to.be.equal("none");
+            
+            // revert internal method
+            internal.hideGridFocus = hideGridFocus;
+
+            done();
+        }, 500);        
+    });
+});


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3038

## Details
<!-- Detailed description of the change/feature -->
Make optional chaining when calling internal .hideGridFocus() to prevent error from Arc types.