### PR TITLE
fix(gauge): fix when has no data

### DIFF
--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -343,10 +343,11 @@ export default {
 
 		if (!isNumber(total)) {
 			const sum = mergeArray($$.data.targets.map(t => t.values))
-				.map(v => v.value)
-				.reduce((p, c) => p + c);
+				.map(v => v.value);
 
-			$$.cache.add(cacheKey, total = sum);
+			total = sum.length ? sum.reduce((p, c) => p + c) : 0;
+
+			$$.cache.add(cacheKey, total);
 		}
 
 		if (subtractHidden) {

--- a/src/ChartInternal/internals/redraw.ts
+++ b/src/ChartInternal/internals/redraw.ts
@@ -40,17 +40,17 @@ export default {
 			$$.updateCircleY && ($$.circleY = $$.updateCircleY());
 		}
 
+		// Data empty label positioning and text.
+		config.data_empty_label_text && main.select(`text.${$TEXT.text}.${$COMMON.empty}`)
+			.attr("x", state.width / 2)
+			.attr("y", state.height / 2)
+			.text(config.data_empty_label_text)
+			.style("display", targetsToShow.length ? "none" : null);
+
 		// update axis
 		if (state.hasAxis) {
 			// @TODO: Make 'init' state to be accessible everywhere not passing as argument.
 			$$.axis.redrawAxis(targetsToShow, wth, transitions, flow, initializing);
-
-			// Data empty label positioning and text.
-			config.data_empty_label_text && main.select(`text.${$TEXT.text}.${$COMMON.empty}`)
-				.attr("x", state.width / 2)
-				.attr("y", state.height / 2)
-				.text(config.data_empty_label_text)
-				.style("display", targetsToShow.length ? "none" : null);
 
 			// grid
 			$$.hasGrid() && $$.updateGrid();

--- a/src/ChartInternal/shape/arc.ts
+++ b/src/ChartInternal/shape/arc.ts
@@ -758,6 +758,8 @@ export default {
 		const {config, state} = $$;
 		const hasMultiArcGauge = $$.hasMultiArcGauge();
 		const isFullCircle = config.gauge_fullCircle;
+		const showEmptyTextLabel = $$.filterTargetsToShow($$.data.targets).length === 0 &&
+			!!config.data_empty_label_text;
 
 		const startAngle = $$.getStartAngle();
 		const endAngle = isFullCircle ? startAngle + $$.getArcLength() : startAngle * -1;
@@ -779,7 +781,7 @@ export default {
 				.merge(backgroundArc)
 				.style("fill", (config.gauge_background) || null)
 				.attr("d", ({id}) => {
-					if (state.hiddenTargetIds.indexOf(id) >= 0) {
+					if (showEmptyTextLabel || state.hiddenTargetIds.indexOf(id) >= 0) {
 						return "M 0 0";
 					}
 
@@ -795,7 +797,7 @@ export default {
 
 			backgroundArc.exit().remove();
 		} else {
-			backgroundArc.attr("d", () => {
+			backgroundArc.attr("d", showEmptyTextLabel ? "M 0 0" : () => {
 				const d = {
 					data: [{value: config.gauge_max}],
 					startAngle,

--- a/test/internals/data-spec.ts
+++ b/test/internals/data-spec.ts
@@ -8,7 +8,7 @@ import {expect} from "chai";
 import {select as d3Select} from "d3-selection";
 import sinon from "sinon";
 import util from "../assets/util";
-import {$AREA, $AXIS, $BAR, $CIRCLE, $COMMON, $LINE, $SHAPE, $TEXT} from "../../src/config/classes";
+import {$ARC, $AREA, $AXIS, $BAR, $CIRCLE, $COMMON, $LINE, $SHAPE, $TEXT} from "../../src/config/classes";
 import {isNumber} from "../../src/module/util";
 
 describe("DATA", () => {
@@ -994,6 +994,49 @@ describe("DATA", () => {
 			const emptyLabelText = chart.$.main.select(`.${$TEXT.text}.${$COMMON.empty}`);
 
 			expect(emptyLabelText.empty()).to.be.true;
+		});
+
+		it("set option", () => {
+			args = {
+				data: {
+					columns: [],
+					type: "gauge",
+					empty: {
+						label: {
+							text: "No data to display."
+						}
+					}
+				}
+			};
+		});
+
+		it("should show empty text when empty data array is given.", () => {
+			const emptyText = chart.$.main.select("text").text();
+
+			expect(emptyText).to.be.equal(args.data.empty.label.text);
+		});
+
+		it("set option: data", () => {
+			args.data.columns = [["data", 10]];
+		});
+
+		it("check when no data is shown.", done => {
+			const bgArc = chart.$.main.select(`.${$ARC.chartArcsBackground}`);
+
+			// when
+			chart.toggle();
+
+			setTimeout(() => {
+				const emptyText = chart.$.main.select("text");
+
+				expect(emptyText.text()).to.be.equal(args.data.empty.label.text);
+				expect(emptyText.style("display")).to.be.equal("block");				
+
+				// background arc shouldn't be drawn
+				expect(bgArc.attr("d")).to.be.equal("M 0 0");
+
+				done();
+			}, 300);
 		});
 	});
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3066

## Details
<!-- Detailed description of the change/feature -->
- Make background arc to not draw when has no data to show
- Fix not throw error when empty array is given for data value

![Feb-01-2023 16-26-45](https://user-images.githubusercontent.com/2178435/215978380-0c849dbe-2332-4d6c-9078-ecb29064ac78.gif)
