### PR TITLE
fix(data): Fix tooltip event bound when data.xSort=false set

### DIFF
--- a/src/ChartInternal/data/IData.ts
+++ b/src/ChartInternal/data/IData.ts
@@ -19,7 +19,7 @@ export interface ITreemapData {
 }
 
 export interface IDataRow extends TDataRow {
-    x: number;
+    x: number | string | Date;
 }
 export interface IArcDataRow extends TDataRow {
     ratio: number;

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -122,7 +122,6 @@ export default {
 
 	isMultipleX(): boolean {
 		return notEmpty(this.config.data_xs) ||
-			!this.config.data_xSort ||
 			this.hasType("bubble") ||
 			this.hasType("scatter");
 	},
@@ -407,7 +406,7 @@ export default {
 			target = sortValue(getUnique(target))
 				.map((x, index) => ({x, index}));
 		} else if (length) {
-			target = target[0].values;
+			target = target[0].values.concat();
 		}
 
 		return target;

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -66,6 +66,10 @@ export default {
 			// Set data and update eventReceiver.data
 			const xAxisTickValues = $$.getMaxDataCountTarget();
 
+			if (!config.data_xSort) {
+				xAxisTickValues.sort((a, b) => a.x - b.x);
+			}
+
 			// update data's index value to be alinged with the x Axis
 			$$.updateDataIndexByX(xAxisTickValues);
 			$$.updateXs(xAxisTickValues);

--- a/test/internals/data-spec.ts
+++ b/test/internals/data-spec.ts
@@ -608,6 +608,35 @@ describe("DATA", () => {
 		});
 	});
 
+	describe("data.xSort", () => {
+		before(() => {
+			args = {
+				data: {
+					xSort: false,
+					x: "x",
+					columns: [
+						["x", 3, 1, 2],
+						["data1", 300, 350, 300]
+					]
+				}
+			};
+		});
+
+		it("line path should rendered correctly.", () => {
+			expect(chart.$.line.lines.attr("d")).to.be.equal("M593,390.583L6,36.417L299,390.583");
+		});
+
+		it("check for tooltip show", () => {
+			const {tooltip} = chart.$;
+
+			// when
+			chart.tooltip.show({x: 2});
+
+			expect(tooltip.select(".name").text()).to.be.equal("data1");
+			expect(+tooltip.select(".value").text()).to.be.equal(300);
+		});
+	});
+
 	describe("inner functions", () => {
 		it("should check returns of mapToTargetIds", () => {
 			const internal = chart.internal;


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3100

## Details
<!-- Detailed description of the change/feature -->
- Remove condition to determine as multipleX type
- Make data to be sorted to handle correctly event receiver area


![Feb-24-2023 13-33-06](https://user-images.githubusercontent.com/2178435/221092355-6d975527-f6ac-4665-8cd8-977bbaf671ad.gif)

