### PR TITLE
fix(bar): Fix broken bar shape transition with grouped radius option

### DIFF
--- a/src/ChartInternal/shape/bar.ts
+++ b/src/ChartInternal/shape/bar.ts
@@ -180,14 +180,13 @@ export default {
 			let radius = 0;
 
 			const isGrouped = $$.isGrouped(d.id);
-			// const hasRadius = d.value !== 0 && getRadius;
 			const isRadiusData = getRadius && isGrouped ? $$.isStackingRadiusData(d) : false;
 
-			if (getRadius && (!isGrouped || isRadiusData)) {
+			if (getRadius) {
 				const index = isRotated ? indexY : indexX;
 				const barW = points[2][index] - points[0][index];
 
-				radius = getRadius(barW);
+				radius = !isGrouped || isRadiusData ? getRadius(barW) : 0;
 
 				const arc = `a${radius},${radius} ${isNegative ? `1 0 0` : `0 0 1`} `;
 

--- a/test/shape/bar-spec.ts
+++ b/test/shape/bar-spec.ts
@@ -815,6 +815,7 @@ describe("SHAPE BAR", () => {
 
 		it("should apply bar radius for stacking bars", () => {
 			let radiusCount = 0;
+			let nonRadiusCount = 0;
 			const expected = [
 				[
 					{id: "data1", value: -80},
@@ -831,17 +832,20 @@ describe("SHAPE BAR", () => {
 			];
 
 			chart.$.bar.bars.each(function(d) {
-				const hasRadius = this.getAttribute("d").indexOf("a") > -1;
+				const hasRadius = !/a0,0/.test(this.getAttribute("d"));
 
 				if (hasRadius) {
 					const found = expected[d.index].some(v => v.id === d.id && v.value === d.value);
 
 					expect(found).to.be.true;
 					radiusCount++;
+				} else {
+					nonRadiusCount++;
 				}
 			});
 
 			expect(radiusCount).to.be.equal(8);
+			expect(nonRadiusCount).to.be.equal(4);
 		});
 
 		it("set options", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#2642

## Details
<!-- Detailed description of the change/feature -->
During the path data update with arc command, include arc path data even isn't arc type shape to prevent broken shape rendering during the transition.

![Mar-03-2023 16-38-53](https://user-images.githubusercontent.com/2178435/222660323-067403a8-a381-4dde-b911-f00fd78c422a.gif)
