### PR TITLE
feat(padding): Intent to ship padding='fit'

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4474,6 +4474,36 @@ d3.select(".chart_area")
 				}
 			}
 		],
+		FitPadding: [
+			{
+				options: {
+					title: {
+						text: "default padding (padding=true)"
+					},
+					data: {
+						columns: [
+							["data", 130, 100, 140, 35, 110, 50]
+						],
+						type: "area"
+					},
+					padding: true
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "padding='fit'"
+					},
+					data: {
+						columns: [
+							["data", 130, 100, 140, 35, 110, 50]
+						],
+						type: "area"
+					},
+					padding: "fit"
+				}
+			}
+		],
 		ColorOnover: [
 			{
 				options: {

--- a/demo/tomorrow.css
+++ b/demo/tomorrow.css
@@ -126,3 +126,12 @@ code.html {
 #exportPreserveFontStyle svg {
   font-family: 'Alfa Slab One';
 }
+
+#fitPadding_1 svg {
+  border: 1px dashed blue;
+  margin-bottom: 20px;
+}
+
+#fitPadding_2 svg {
+  border: 1px dashed red;
+}

--- a/src/ChartInternal/internals/clip.ts
+++ b/src/ChartInternal/internals/clip.ts
@@ -86,7 +86,7 @@ export default {
 		const x = isInner ? -1 : (isRotated ? -(1 + left) : -(left - 1));
 		const y = -(isRotated ? 20 : margin.top);
 		const w = (isRotated ? width + 15 + left : margin.left + 20) + (isInner ? 20 : 0);
-		const h = (isRotated ? margin.bottom : (margin.top + height)) + 10;
+		const h = (isRotated ? margin.bottom + (config.padding === "fit" ? 10 : 0) : (margin.top + height)) + 10;
 
 		node
 			.attr("x", x)

--- a/src/ChartInternal/internals/legend.ts
+++ b/src/ChartInternal/internals/legend.ts
@@ -254,10 +254,13 @@ export default {
 	getLegendHeight(): number {
 		const $$ = this;
 		const {current, isLegendRight, legendItemHeight, legendStep} = $$.state;
+		const isFitPadding = $$.config.padding === "fit";
 
 		return $$.config.legend_show ? (
 			isLegendRight ?
-				current.height : Math.max(20, legendItemHeight) * (legendStep + 1)
+				current.height : (
+					isFitPadding ? 10 : Math.max(20, legendItemHeight)
+				) * (legendStep + 1)
 		) : 0;
 	},
 

--- a/src/ChartInternal/internals/size.axis.ts
+++ b/src/ChartInternal/internals/size.axis.ts
@@ -29,7 +29,9 @@ export default {
 			const gap = width === 0 ? 0.5 : 0;
 
 			return width + (
-				position.isInner ? (20 + gap) : 40
+				$$.config.padding === "fit" ?
+					position.isInner ? (10 + gap) : 10 :
+					position.isInner ? (20 + gap) : 40
 			);
 		} else {
 			return 40;
@@ -41,7 +43,8 @@ export default {
 		const {config, state} = $$;
 		const {current, rotatedPadding, isLegendRight, isLegendInset} = state;
 		const isRotated = config.axis_rotated;
-		let h = 30;
+		const isInner = config[`axis_${id}_inner`];
+		let h = config.padding === "fit" ? (isInner ? 1 : 20) : 30;
 
 		if (id === "x" && !config.axis_x_show) {
 			return 8;

--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -69,20 +69,25 @@ export default {
 		const $$ = this;
 		const {config, state: {hasAxis}} = $$;
 		const isRotated = config.axis_rotated;
+		const isFitPadding = config.padding === "fit";
 		const axisId = isRotated ? "x" : "y";
 		const axesLen = hasAxis ? config[`axis_${axisId}_axes`].length : 0;
-		const axisWidth = hasAxis ? $$.getAxisWidthByAxisId(axisId, withoutRecompute) : 0;
+		let axisWidth = hasAxis ? $$.getAxisWidthByAxisId(axisId, withoutRecompute) : 0;
 		let padding;
+
+		if (!isFitPadding) {
+			axisWidth = ceil10(axisWidth);
+		}
 
 		if (isValue(config.padding_left)) {
 			padding = config.padding_left;
 		} else if (hasAxis && isRotated) {
 			padding = !config.axis_x_show ?
-				1 : Math.max(ceil10(axisWidth), 40);
+				1 : (isFitPadding ? axisWidth : Math.max(axisWidth, 40));
 		} else if (hasAxis && (!config.axis_y_show || config.axis_y_inner)) { // && !config.axis_rotated
 			padding = $$.axis.getAxisLabelPosition("y").isOuter ? 30 : 1;
 		} else {
-			padding = ceil10(axisWidth);
+			padding = axisWidth;
 		}
 
 		return padding + (axisWidth * axesLen);
@@ -94,10 +99,14 @@ export default {
 		const defaultPadding = 10;
 		const legendWidthOnRight = $$.state.isLegendRight ? $$.getLegendWidth() + 20 : 0;
 		const axesLen = hasAxis ? config.axis_y2_axes.length : 0;
-		const axisWidth = hasAxis ? $$.getAxisWidthByAxisId("y2") : 0;
 		const xAxisTickTextOverflow = withXAxisTickTextOverflow ?
 			$$.axis.getXAxisTickTextY2Overflow(defaultPadding) : 0;
+		let axisWidth = hasAxis ? $$.getAxisWidthByAxisId("y2") : 0;
 		let padding;
+
+		if (config.padding !== "fit") {
+			axisWidth = ceil10(axisWidth);
+		}
 
 		if (isValue(config.padding_right)) {
 			padding = config.padding_right + (hasAxis ? 1 : 0); // 1 is needed not to hide tick line
@@ -109,7 +118,7 @@ export default {
 				xAxisTickTextOverflow
 			);
 		} else {
-			padding = Math.max(ceil10(axisWidth) + legendWidthOnRight, xAxisTickTextOverflow);
+			padding = Math.max(axisWidth + legendWidthOnRight, xAxisTickTextOverflow);
 		}
 
 		return padding + (axisWidth * axesLen);
@@ -282,6 +291,7 @@ export default {
 		const {config, state, $el: {legend}} = $$;
 		const isRotated = config.axis_rotated;
 		const isNonAxis = $$.hasArcType() || state.hasTreemap;
+		const isFitPadding = config.padding === "fit";
 
 		!isInit && $$.setContainerSize();
 
@@ -311,7 +321,7 @@ export default {
 			bottom: $$.getHorizontalAxisHeight("y") + legendHeightForBottom + padding.bottom,
 			left: subchartHeight + (isNonAxis ? 0 : padding.left)
 		} : {
-			top: 4 + padding.top, // for top tick text
+			top: (isFitPadding ? 0 : 4) + padding.top, // for top tick text
 			right: isNonAxis ? 0 : $$.getCurrentPaddingRight(true),
 			bottom: xAxisHeight + subchartHeight + legendHeightForBottom + padding.bottom,
 			left: isNonAxis ? 0 : padding.left

--- a/src/ChartInternal/internals/transform.ts
+++ b/src/ChartInternal/internals/transform.ts
@@ -37,7 +37,7 @@ export default {
 			y = isRotated ? state.height + padding : 0;
 		} else if (target === "y2") {
 			x = isRotated ? 0 : state.width + padding;
-			y = isRotated ? 1 - padding : 0;
+			y = isRotated && padding ? 1 - padding : 0;
 		} else if (target === "subX") {
 			x = 0;
 			y = isRotated ? 0 : state.height2;

--- a/src/config/Options/common/main.ts
+++ b/src/config/Options/common/main.ts
@@ -109,8 +109,9 @@ export default {
 	 * @name padding
 	 * @memberof Options
 	 * @type {object}
-	 * @property {object|boolean} [padding=true] Set padding of chart, and accepts object or boolean type.
+	 * @property {object|boolean|string} [padding=true] Set padding of chart, and accepts object or boolean type.
 	 * - `Object`: Specify each side's padding.
+	 * - `"fit"`: Reduce padding as much as possible to make chart fit to the container element for chart types w/axis.
 	 * - `false`: Remove padding completely and make shape to fully occupy the container element.
 	 *   - In this case, axes and subchart will be hidden.
 	 *   - To adjust some padding from this state, use `axis.[x|y].padding` option.
@@ -119,9 +120,13 @@ export default {
 	 * @property {number} [padding.bottom] padding on the bottom of chart
 	 * @property {number} [padding.left] padding on the left of chart
 	 * @see [Demo](https://naver.github.io/billboard.js/demo/#ChartOptions.Padding)
+	 * @see [Demo: Fit padding](https://naver.github.io/billboard.js/demo/#ChartOptions.FitPadding)
 	 * @example
 	 * // remove padding completely.
 	 * padding: false,
+	 *
+	 * // reduce padding and make fit to the container element.
+	 * padding: "fit",
 	 *
 	 * // or specify padding value for each side
 	 * padding: {

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -2444,7 +2444,7 @@ describe("AXIS", function() {
 
 		const checkY2Axes = (rotated?) => {
 			const main = chart.$.main;
-			const yAxisY = util.parseNum(main.select(`.${$AXIS.axis}-y2`).attr("transform"));
+			const yAxisY = util.parseNum(main.select(`.${$AXIS.axis}-y2`).attr("transform").split(",")[rotated ? 1 : 0]);
 			const axis1 = main.select(`.${$AXIS.axis}-y2-1`);
 
 			expect(util.parseNum(axis1.attr("transform"))).to.be[rotated ? "below" : "above"](yAxisY);

--- a/test/internals/core-spec.ts
+++ b/test/internals/core-spec.ts
@@ -374,6 +374,8 @@ describe("CORE", function() {
 	});
 
 	describe("padding", () => {
+		let margin;
+
 		before(() => {
 			args = {
 				data: {
@@ -446,6 +448,97 @@ describe("CORE", function() {
 
 			expect(width).to.be.equal(args.size.width);
 			expect(height).to.be.equal(args.size.height);
+		});
+
+		it("set options: padding = true", () => {
+			args.padding = true;
+			args.legend.show = true;
+			args.axis.y2 = {show: true};
+		});
+
+		it("set options: padding = 'fit'", () => {
+			// remember the margin when "padding=true"
+			margin = chart.internal.state.margin;
+
+			args.padding = "fit";
+		});
+
+		it("when padding set to 'fit', margin values should be below than normal.", () => {
+			const currMargin = chart.internal.state.margin;
+
+			Object.keys(margin).forEach(v => {
+				expect(currMargin[v]).to.be.below(margin[v]);
+			});
+		});
+
+		it("set options: legend.show=false", () => {
+			margin = chart.internal.state.margin;
+
+			args.legend.show = false;
+		});
+
+		it("check when legend is hidden.", () => {
+			expect(chart.internal.state.margin.bottom).to.be.below(margin.bottom);
+
+			margin = chart.internal.state.margin;
+		});
+
+		it("set options: legend.show=false", () => {
+			args.axis.y = { 
+				show: true,
+				inner: true
+			};
+
+			args.axis.y2 = { 
+				show: true,
+				inner: true
+			};
+		});
+
+		it("check when axes with inner option.", () => {
+			const currMargin = chart.internal.state.margin;
+
+			["left", "right"].forEach(v => {
+				expect(margin[v] - currMargin[v] > 20).to.be.true;
+			});
+		});
+
+		it("check element's position by its coordination.", () => {
+			const {svg, main} = chart.$;
+			const svgRect = svg.node().getBoundingClientRect();
+			let rect = main.select(`.${$AXIS.axisX}`).node().getBoundingClientRect();
+
+			expect(rect.x).to.closeTo(2, 1);
+
+			// y axis
+			rect = main.select(`.${$AXIS.axisY}`).node().getBoundingClientRect();			
+			expect(rect.y).to.closeTo(svgRect.y, 2);
+
+			// y2 axis
+			rect = main.select(`.${$AXIS.axisY2}`).node().getBoundingClientRect();			
+			expect(rect.x + rect.width).to.be.closeTo(svgRect.width, 2);
+		});		
+
+		it("set options: axis.rotated=true", () => {
+			args.axis.rotated = true;
+		});
+
+		it("check element's position by its coordination for rotated axis.", () => {
+			const {svg, main} = chart.$;
+			const svgRect = svg.node().getBoundingClientRect();
+
+			// x axis
+			let rect = main.select(`.${$AXIS.axisX}`).node().getBoundingClientRect();
+
+			expect(rect.x).to.closeTo(2, 1);
+
+			// y axis
+			rect = main.select(`.${$AXIS.axisY}`).node().getBoundingClientRect();			
+			expect(rect.y + rect.height).to.closeTo(svgRect.y + svgRect.height, 1);
+
+			// y2 axis
+			rect = main.select(`.${$AXIS.axisY2}`).node().getBoundingClientRect();			
+			expect(rect.y).to.be.closeTo(svgRect.y, 2);			
 		});
 	});
 });

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -108,11 +108,12 @@ export interface ChartOptions {
 	/**
 	 * Set padding of chart, and accepts object or boolean type.
 	 * - `Object`: Specify each side's padding.
+	 * - `"fit"`: Reduce padding as much as possible to make chart fit to the container element for chart types w/axis.
 	 * - `false`: Remove padding completely and make shape to fully occupy the container element.
 	 *   - In this case, axes and subchart will be hidden.
 	 *   - To adjust some padding from this state, use `axis.[x|y].padding` option.
 	 */
-	padding?: boolean | {
+	padding?: boolean | "fit" | {
 		/**
 		 * The padding on the top of the chart.
 		 */


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3118

## Details
<!-- Detailed description of the change/feature -->
Implement 'fit' option, which reduce padding as much as possible making chart to fit to the container element.

```js
bb.generate({
    padding: "fit",
    ...
});
```

- Checkout the difference of two chart element's padding. 
- The dotted border is the boundary of the bound element area. 

<img width="518" alt="image" src="https://user-images.githubusercontent.com/2178435/223085036-2c5f6d54-024a-4c71-97c3-74e640e7c00b.png">
