### PR TITLE
feat(axis): Intent to ship axis.x.inverted

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1274,6 +1274,87 @@ var demos = {
 				}
 			}
 		],
+		InvertedAxis: [
+			{
+				options: {
+					title: {
+						text: "inverted timeseries x Aaxis"
+					},
+					data: {
+						x: "x",
+						columns: [
+							["x", "2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04", "2023-01-06"],
+							["data1", 30, 200, 100, 400, 150]
+						],
+						type: "line"
+					},
+					axis: {
+						x: {
+							inverted: true,
+							type: "timeseries",
+							tick: {
+								format: "%Y-%m-%d"
+							}
+						}
+					}
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "inverted indexed x & y Aaxis"
+					},
+					data: {
+						columns: [
+							["data1", 30, 200, 100, 400, 150],
+							["data2", 330, 150, 210, 330, 270]
+						],
+						types: {
+							data1: "bar",
+							data2: "area-spline"
+						}
+					},
+					axis: {
+						x: {
+							inverted: true
+						},
+						y: {
+							inverted: true
+						}
+					}
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "inverted category x Aaxis"
+					},
+					data: {
+						x: "x",
+						columns: [
+							["x", "Type A", "Type B", "Type C", "Type D", "Type E"],
+							["data1", 130, 300, 200, 300, 260],
+							["data2", 30, 200, 100, 400, 150]
+						],
+						type: "line",
+						axes: {
+							data1: "y",
+							data2: "y2"
+						}
+					},
+					axis: {
+						x: {
+							inverted: true,
+							type: "category"
+						},
+						y2: {
+							show: true,
+							inverted: true
+						}
+					}
+				}
+			}
+		],
 		LogScales: {
 			options: {
 				data: {

--- a/src/Chart/api/zoom.ts
+++ b/src/Chart/api/zoom.ts
@@ -10,14 +10,21 @@ import {extend, getMinMax, isDefined, isObject, parseDate} from "../../module/ut
  * @param {Array} domain Target domain value
  * @param {Array} current Current zoom domain value
  * @param {Array} range Zoom range value
+ * @param {boolean} isInverted Whether the axis is inverted or not
  * @returns {boolean}
  * @private
  */
-function withinRange(domain: (number|Date)[], current, range: number[]): boolean {
+function withinRange(
+	domain: (number|Date)[], current, range: number[], isInverted = false
+): boolean {
 	const [min, max] = range;
 
 	return domain.every((v, i) => (
-		i === 0 ? (v >= min) : (v <= max)
+		i === 0 ? (
+			isInverted ? v <= min : v >= min
+		) : (
+			isInverted ? v >= max : v <= max
+		)
 	) && !(domain.every((v, i) => v === current[i])));
 }
 
@@ -45,6 +52,7 @@ const zoom = function(domainValue?: (Date|number|string)[]): (Date|number)[]|und
 	const $$ = this.internal;
 	const {$el, axis, config, org, scale} = $$;
 	const isRotated = config.axis_rotated;
+	const isInverted = config.axis_x_inverted;
 	const isCategorized = axis.isCategorized();
 	let domain = domainValue;
 
@@ -53,7 +61,14 @@ const zoom = function(domainValue?: (Date|number|string)[]): (Date|number)[]|und
 			domain = domain.map(x => parseDate.bind($$)(x));
 		}
 
-		if (withinRange(domain as (number|Date)[], $$.getZoomDomain(true), $$.getZoomDomain())) {
+		const isWithinRange = withinRange(
+			domain as (number|Date)[],
+			$$.getZoomDomain(true),
+			$$.getZoomDomain(),
+			isInverted
+		);
+
+		if (isWithinRange) {
 			if (isCategorized) {
 				domain = domain.map((v, i) => Number(v) + (i === 0 ? 0 : 1));
 			}

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -292,6 +292,7 @@ class Axis {
 			owner: $$
 		}, isX && {
 			isCategory,
+			isInverted: config.axis_x_inverted,
 			tickMultiline: config.axis_x_tick_multiline,
 			tickWidth: config.axis_x_tick_width,
 			tickTitle: isCategory && config.axis_x_tick_tooltip && $$.api.categories(),

--- a/src/ChartInternal/Axis/AxisRenderer.ts
+++ b/src/ChartInternal/Axis/AxisRenderer.ts
@@ -379,8 +379,13 @@ export default class AxisRenderer {
 
 		if (!tickWidth || tickWidth <= 0) {
 			tickWidth = isLeftRight ? 95 : (
-				params.isCategory ?
-					(Math.ceil(scale(ticks[1]) - scale(ticks[0])) - 12) : 110
+				params.isCategory ?	(
+					Math.ceil(
+						params.isInverted ?
+							scale(ticks[0]) - scale(ticks[1]) :
+							scale(ticks[1]) - scale(ticks[0])
+					) - 12
+				) : 110
 			);
 		}
 

--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -377,7 +377,7 @@ export default class ChartInternal {
 
 			// Set domains for each scale
 			if (x) {
-				x.domain(sortValue($$.getXDomain($$.data.targets)));
+				x.domain(sortValue($$.getXDomain($$.data.targets), !config.axis_x_inverted));
 				subX.domain(x.domain());
 
 				// Save original x domain for zoom update

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -397,6 +397,7 @@ export default {
 	getMaxDataCountTarget() {
 		let target = this.filterTargetsToShow() || [];
 		const length = target.length;
+		const isInverted = this.config.axis_x_inverted;
 
 		if (length > 1) {
 			target = target.map(t => t.values)
@@ -404,7 +405,7 @@ export default {
 				.map(v => v.x);
 
 			target = sortValue(getUnique(target))
-				.map((x, index) => ({x, index}));
+				.map((x, index, array) => ({x, index: isInverted ? array.length - index - 1 : index}));
 		} else if (length) {
 			target = target[0].values.concat();
 		}

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -28,6 +28,7 @@ export default {
 		const $$ = this;
 		const {config, state, $el} = $$;
 		const isMultipleX = $$.isMultipleX();
+		const isInverted = config.axis_x_inverted;
 
 		if ($el.eventRect) {
 			$$.updateEventRect($el.eventRect, true);
@@ -66,8 +67,8 @@ export default {
 			// Set data and update eventReceiver.data
 			const xAxisTickValues = $$.getMaxDataCountTarget();
 
-			if (!config.data_xSort) {
-				xAxisTickValues.sort((a, b) => a.x - b.x);
+			if (!config.data_xSort || isInverted) {
+				xAxisTickValues.sort((a, b) => (isInverted ? b.x - a.x : a.x - b.x));
 			}
 
 			// update data's index value to be alinged with the x Axis

--- a/src/ChartInternal/interactions/subchart.ts
+++ b/src/ChartInternal/interactions/subchart.ts
@@ -206,7 +206,6 @@ export default {
 			"M 0 18 A 6 6 0 0 1 6.5 23.5 V 29 A 6 6 0 0 1 0 35 Z M 2 23 V 30 M 4 23 V 30Z"
 		];
 
-
 		$$.brush.handle = brush.selectAll(`.${customHandleClass}`)
 			.data(isRotated ?
 				[{type: "n"}, {type: "s"}] :
@@ -335,7 +334,9 @@ export default {
 	 */
 	redrawForBrush() {
 		const $$ = this;
-		const {config: {subchart_onbrush: onBrush, zoom_rescale: withY}, scale} = $$;
+		const {config: {
+			subchart_onbrush: onBrush, zoom_rescale: withY
+		}, scale} = $$;
 
 		$$.redraw({
 			withTransition: false,

--- a/src/ChartInternal/interactions/zoom.ts
+++ b/src/ChartInternal/interactions/zoom.ts
@@ -109,7 +109,7 @@ export default {
 				$$.state.xTickOffset = $$.axis.x.tickOffset();
 			}
 
-			scale.zoom = $$.getCustomizedScale(newScale);
+			scale.zoom = $$.getCustomizedXScale(newScale);
 			$$.axis.x.scale(scale.zoom);
 
 			if (rescale) {
@@ -256,8 +256,15 @@ export default {
 			const xDomain = subX.domain();
 			const delta = 0.015; // arbitrary value
 
-			const isfullyShown = (zoomDomain[0] <= xDomain[0] || (zoomDomain[0] - delta) <= xDomain[0]) &&
-				(xDomain[1] <= zoomDomain[1] || xDomain[1] <= (zoomDomain[1] - delta));
+			const isfullyShown = $$.config.axis_x_inverted ? (
+				zoomDomain[0] >= xDomain[0] || (zoomDomain[0] + delta) >= xDomain[0]
+			) && (
+				xDomain[1] >= zoomDomain[1] || xDomain[1] >= (zoomDomain[1] + delta)
+			) : (
+				zoomDomain[0] <= xDomain[0] || (zoomDomain[0] - delta) <= xDomain[0]
+			) && (
+				xDomain[1] <= zoomDomain[1] || xDomain[1] <= (zoomDomain[1] - delta)
+			);
 
 			// check if the zoomed chart is fully shown, then reset scale when zoom is out as initial
 			if (force || isfullyShown) {

--- a/src/ChartInternal/internals/redraw.ts
+++ b/src/ChartInternal/internals/redraw.ts
@@ -66,7 +66,6 @@ export default {
 				}
 			});
 
-
 			// circles for select
 			$el.text && main.selectAll(`.${$SELECT.selectedCircles}`)
 				.filter($$.isBarType.bind($$))

--- a/src/ChartInternal/internals/scale.ts
+++ b/src/ChartInternal/internals/scale.ts
@@ -50,7 +50,7 @@ export default {
 		const $$ = this;
 		const scale = $$.scale.zoom || getScale($$.axis.getAxisType("x"), min, max);
 
-		return $$.getCustomizedScale(
+		return $$.getCustomizedXScale(
 			domain ? scale.domain(domain) : scale,
 			offset
 		);
@@ -89,15 +89,16 @@ export default {
 	},
 
 	/**
-	 * Get customized scale
+	 * Get customized x axis scale
 	 * @param {d3.scaleLinear|d3.scaleTime} scaleValue Scale function
 	 * @param {Function} offsetValue Offset getter to be sum
 	 * @returns {Function} Scale function
 	 * @private
 	 */
-	getCustomizedScale(scaleValue: Function | any, offsetValue): Function {
+	getCustomizedXScale(scaleValue: Function | any, offsetValue): Function {
 		const $$ = this;
 		const offset = offsetValue || (() => $$.axis.x.tickOffset());
+		const isInverted = $$.config.axis_x_inverted;
 		const scale = function(d, raw) {
 			const v = scaleValue(d) + offset();
 
@@ -120,7 +121,9 @@ export default {
 				if (!arguments.length) {
 					domain = this.orgDomain();
 
-					return [domain[0], domain[1] + 1];
+					return isInverted ?
+						[domain[0] + 1, domain[1]] :
+						[domain[0], domain[1] + 1];
 				}
 
 				scaleValue.domain(domain);

--- a/src/ChartInternal/internals/size.axis.ts
+++ b/src/ChartInternal/internals/size.axis.ts
@@ -89,7 +89,12 @@ export default {
 	},
 
 	getEventRectWidth(): number {
-		return Math.max(0, this.axis.x.tickInterval());
+		const $$ = this;
+		const {config, axis} = $$;
+		const isInverted = config.axis_x_inverted;
+		const tickInterval = axis.x.tickInterval();
+
+		return Math.max(0, isInverted ? Math.abs(tickInterval) : tickInterval);
 	},
 
 	/**

--- a/src/config/Options/axis/x.ts
+++ b/src/config/Options/axis/x.ts
@@ -511,6 +511,23 @@ export default {
 	axis_x_min: <number|undefined> undefined,
 
 	/**
+	 * Change the direction of x axis.<br><br>
+	 * If true set, the direction will be `right -> left`.
+	 * @name axis․x․inverted
+	 * @memberof Options
+	 * @type {boolean}
+	 * @default false
+	 * @see [Demo](https://naver.github.io/billboard.js/demo/#Axis.InvertedAxis)
+	 * @example
+	 * axis: {
+	 *   x: {
+	 *     inverted: true
+	 *   }
+	 * }
+	 */
+	axis_x_inverted: false,
+
+	/**
 	 * Set padding for x axis.<br><br>
 	 * If this option is set, the range of x axis will increase/decrease according to the values.
 	 * If no padding is needed in the rage of x axis, 0 should be set.

--- a/src/config/Options/axis/y.ts
+++ b/src/config/Options/axis/y.ts
@@ -96,11 +96,12 @@ export default {
 
 	/**
 	 * Change the direction of y axis.<br><br>
-	 * If true set, the direction will be from the top to the bottom.
+	 * If true set, the direction will be `top -> bottom`.
 	 * @name axis․y․inverted
 	 * @memberof Options
 	 * @type {boolean}
 	 * @default false
+	 * @see [Demo](https://naver.github.io/billboard.js/demo/#Axis.InvertedAxis)
 	 * @example
 	 * axis: {
 	 *   y: {

--- a/src/config/Options/axis/y2.ts
+++ b/src/config/Options/axis/y2.ts
@@ -83,11 +83,12 @@ export default {
 
 	/**
 	 * Change the direction of y2 axis.<br><br>
-	 * If true set, the direction will be from the top to the bottom.
+	 * If true set, the direction will be `top -> bottom`.
 	 * @name axis․y2․inverted
 	 * @memberof Options
 	 * @type {boolean}
 	 * @default false
+	 * @see [Demo](https://naver.github.io/billboard.js/demo/#Axis.InvertedAxis)
 	 * @example
 	 * axis: {
 	 *   y2: {

--- a/test/internals/axis-x-spec.ts
+++ b/test/internals/axis-x-spec.ts
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+// @ts-nocheck
+import {expect} from "chai";
+import {$AXIS} from "../../src/config/classes";
+import util from "../assets/util";
+
+describe("X AXIS", function() {
+	let chart;
+	let args: any = {
+		data: {
+			columns: [
+				["data1", 30, 200, 100, 400, 150]
+			],
+			type: "line"
+		},
+		axis: {
+			x: {
+				inverted: true,
+			}
+		}
+	};
+
+	beforeEach(() => {
+		chart = util.generate(args);
+	});
+
+	describe("axis.x.inverted", () => {
+		describe("different x axis types", () => {
+			it("check 'indexed' type axis", () => {
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} .tick`);
+				const xPos = [];
+				
+				ticks.each(function(v) {
+					xPos[v] = util.parseNum(this.getAttribute("transform").split(",")[0]);
+				});
+
+				xPos.reduce((prev, curr) => {
+					expect(prev > curr).to.be.true;
+
+					return curr;
+				});
+			});
+
+			it("set options: axis.x.type='timeseries'", () => {
+				args.axis.x.type = "timeseries";
+				args.axis.x.tick = {
+					format: "%Y-%m-%d"
+				};
+
+				args.data = {
+					x: "x",
+					columns: [
+						["x", "2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04", "2023-01-6"],
+						["data1", 30, 200, 100, 400, 150]
+					]
+				};
+			});
+
+			it("check 'timeseries' type axis", () => {
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} .tick`);
+				const xPos = [];
+				const expected = [
+					"2023-01-01 00:00:00",
+					"2023-01-02 00:00:00",
+					"2023-01-03 00:00:00",
+					"2023-01-04 00:00:00",
+					"2023-01-06 00:00:00",
+				].map(v => new Date(v));
+				
+				ticks.each(function(v, i) {
+					expect(v).to.be.deep.equal(expected[i]);
+					xPos[i] = util.parseNum(this.getAttribute("transform").split(",")[0]);
+				});
+
+				xPos.reduce((prev, curr) => {
+					expect(prev > curr).to.be.true;
+
+					return curr;
+				});
+			});
+
+			it("set options: axis.x.type='category'", () => {
+				args.axis.x.type = "category";
+				args.axis.x.tick = {};
+
+				args.data = {
+					x: "x",
+					columns: [
+						["x", "type a", "type b", "type c", "type d", "type e"],
+						["data1", 30, 200, 100, 400, 150]
+					]
+				};
+			});
+
+			it("check 'category' type axis", () => {
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} .tick`);
+
+				const xPos = [];
+				const expected = [
+					"type a", "type b", "type c", "type d", "type e" 
+				];
+				
+				ticks.each(function(v, i) {
+					expect(this.querySelector("tspan").textContent).to.be.equal(expected[i]);
+				
+					xPos[v] = util.parseNum(this.getAttribute("transform").split(",")[0]);
+				});
+
+				xPos.reduce((prev, curr) => {
+					expect(prev > curr).to.be.true;
+
+					return curr;
+				});
+			});
+
+			it("set options: axis.rotated", () => {
+				args = {
+					data: {
+						columns: [
+							["data1", 30, 200, 100, 400, 150]
+						],
+						type: "line"
+					},
+					axis: {
+						rotated: true,
+						x: {
+							inverted: true,
+						}
+					}
+				};
+			});
+
+			it("check 'rotated' type axis", () => {
+				const ticks = chart.$.main.selectAll(`.${$AXIS.axisX} .tick`);
+				const xPos = [];
+				
+				ticks.each(function(v) {
+					xPos[v] = util.parseNum(this.getAttribute("transform").split(",")[1]);
+				});
+
+				xPos.reduce((prev, curr) => {
+					expect(prev > curr).to.be.true;
+
+					return curr;
+				});
+			});
+		});
+
+		describe("subchart", () => {
+			before(() => {
+				args = {
+					data: {
+						columns: [
+							["data1", 30, 200, 100, 400, 150]
+						],
+						type: "line"
+					},
+					axis: {
+						x: {
+							inverted: true,
+						}
+					},
+					subchart: {
+						show: true,
+						init: {
+							range: [3, 1]
+						}
+					}
+				}
+			});
+
+			it("check initial zoom domain.", () => {
+				const {scale: {x, subX}, brush} = chart.internal;
+				const domain = x.domain().map(Math.round);
+				const brushSelection = brush.getSelection().select(".selection").node();
+
+				expect(Math.round(brushSelection.getAttribute("width"))).to.be.closeTo(subX(1) - subX(3), 1);
+				expect(domain).to.be.deep.equal(args.subchart.init.range);
+
+			});
+		});
+
+		describe("zoom", () => {
+			before(() => {
+				args = {
+					data: {
+						columns: [
+							["data1", 30, 200, 100, 400, 150]
+						],
+						type: "line"
+					},
+					axis: {
+						x: {
+							inverted: true,
+						}
+					},
+					zoom: {
+						enabled: true
+					},
+					transition: {
+						duration: 0
+					}
+				}
+			});
+
+			it("shoud zoom & unzoomed.", () => {
+				const {line: {lines}} = chart.$;
+				const initialPath = lines.attr("d");
+
+				// when
+				chart.zoom([3, 2]);
+				
+				const {zoom} = chart.internal.scale;
+
+				expect(lines.attr("d")).to.be.equal("M1794,390.583L1196,227.858L597,323.579L-1,36.417L-599,275.718");
+
+				expect(zoom(2) - zoom(3)).to.be.closeTo(600, 5);
+
+				// when
+				chart.unzoom();
+
+				// chart has unzoomed?
+				expect(lines.attr("d")).to.be.equal(initialPath);
+			});
+		});
+	});
+});

--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -24,6 +24,12 @@ export interface AxisConfigurationBase {
 	 * Set additional axes for Axis
 	 */
 	axes?: AxesConfiguration[];
+
+	/**
+	 * Change the direction of axis.
+	 * If true set, the direction will be from: right -> left for x axis / top -> bottom for y/y2 axis.
+	 */
+	inverted?: boolean;
 }
 
 export interface xAxisConfiguration extends AxisConfigurationBase {
@@ -134,12 +140,6 @@ export interface yAxisConfigurationBase extends AxisConfigurationBase {
 	 * Set min value of y axis.
 	 */
 	min?: number;
-
-	/**
-	 * Change the direction of y axis.
-	 * If true set, the direction will be from the top to the bottom.
-	 */
-	inverted?: boolean;
 
 	/**
 	 * Set center value of y axis.
@@ -352,7 +352,8 @@ export interface YTickConfiguration {
 	 * Set formatter for y axis tick text.
 	 * This option accepts d3.format object as well as a function you define.
 	 */
-	format?: ((this: Chart, x: number) => string | number) | ((this: Chart, x: Date) => string | number);
+	format?: ((this: Chart, x: number) => string | number) |
+		((this: Chart, x: Date) => string | number);
 
 	/**
 	 * Setting for culling ticks.


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3137

## Details
<!-- Detailed description of the change/feature -->
Implement inversion option for x axis

```js
data: {
    x: "x",
    columns: [
        // when 'axis.x.inverted=true' is set, x axis and its data will appear as in following order.
        // "2023-01-06" -> "2023-01-04" -> "2023-01-03" -> "2023-01-02" -> "2023-01-01"
	["x", "2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04", "2023-01-06"],
	["data1", 30, 200, 100, 400, 150],
    ],
},
axis: {
    x: {
        inverted: true,
        type: "timeseries"
    }
}
```

![image](https://user-images.githubusercontent.com/2178435/228196963-e5aae32f-31fe-49f7-a77c-15895ab6ebca.png)
