### PR TITLE
refactor(browser): update raf, ric to not override global

### DIFF
--- a/src/Chart/api/load.ts
+++ b/src/Chart/api/load.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {window} from "../../module/browser";
+import {requestIdleCallback} from "../../module/browser";
 import {isString, isArray} from "../../module/util";
 import {callDone} from "../../ChartInternal/data/load";
 
@@ -179,7 +179,7 @@ export default {
 			$$.unload($$.mapToTargetIds(args.unload === true ? null : args.unload), () => {
 				// to mitigate improper rendering for multiple consecutive calls
 				// https://github.com/naver/billboard.js/issues/2121
-				window.requestIdleCallback(() => $$.loadFromArgs(args));
+				requestIdleCallback(() => $$.loadFromArgs(args));
 			});
 		} else {
 			$$.api.tooltip.hide();

--- a/src/Chart/api/zoom.ts
+++ b/src/Chart/api/zoom.ts
@@ -21,9 +21,9 @@ function withinRange(
 
 	return domain.every((v, i) => (
 		i === 0 ? (
-			isInverted ? v <= min : v >= min
+			isInverted ? +v <= min : +v >= min
 		) : (
-			isInverted ? v >= max : v <= max
+			isInverted ? +v >= max : +v <= max
 		)
 	) && !(domain.every((v, i) => v === current[i])));
 }

--- a/src/module/browser.ts
+++ b/src/module/browser.ts
@@ -7,7 +7,12 @@
  * @private
  */
 /* eslint-disable no-new-func, no-undef */
-export {win as window, doc as document};
+export {
+	win as window,
+	doc as document,
+	requestAnimationFrame, cancelAnimationFrame,
+	requestIdleCallback, cancelIdleCallback
+};
 
 const win = (() => {
 	const root = (typeof globalThis === "object" && globalThis !== null && globalThis.Object === Object && globalThis) ||
@@ -19,9 +24,12 @@ const win = (() => {
 /* eslint-enable no-new-func, no-undef */
 
 // fallback for non-supported environments
-win.requestIdleCallback = win.requestIdleCallback || (cb => setTimeout(cb, 1));
-// win.cancelIdleCallback = win.cancelIdleCallback || (id => clearTimeout(id));
-win.requestAnimationFrame = win.requestAnimationFrame || (cb => setTimeout(cb, 1));
+const hasRAF = typeof win.requestAnimationFrame === "function";
+const hasRIC = typeof win.requestIdleCallback === "function";
+
+const requestAnimationFrame = hasRAF ? win.requestAnimationFrame : (cb => setTimeout(cb, 1));
+const cancelAnimationFrame = hasRAF ? win.cancelAnimationFrame : (id => clearTimeout(id));
+const requestIdleCallback = hasRIC ? win.requestIdleCallback : requestAnimationFrame;
+const cancelIdleCallback = hasRIC ? win.cancelIdleCallback : cancelAnimationFrame;
 
 const doc = win?.document;
-

--- a/src/module/generator.ts
+++ b/src/module/generator.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import type {d3Transition} from "../../types/types";
-import {window} from "./browser";
+import {window, requestIdleCallback} from "./browser";
 import {isArray, isNumber, isTabVisible, runUntil} from "./util";
 
 const {setTimeout, clearTimeout} = window;
@@ -22,7 +22,7 @@ export function generateResize(option: boolean|number) {
 		// Delay all resize functions call, to prevent unintended excessive call from resize event
 		callResizeFn.clear();
 
-		if (option === false && window.requestIdleCallback) {
+		if (option === false) {
 			requestIdleCallback(() => {
 				fn.forEach((f: Function) => f());
 			}, {timeout: 200});

--- a/src/module/util.ts
+++ b/src/module/util.ts
@@ -6,7 +6,7 @@
 import {pointer as d3Pointer} from "d3-selection";
 import {brushSelection as d3BrushSelection} from "d3-brush";
 import type {d3Selection} from "../../types/types";
-import {document, window} from "./browser";
+import {document, window, requestAnimationFrame} from "./browser";
 
 export {
 	addCssRules,
@@ -808,7 +808,7 @@ function convertInputType(mouse: boolean, touch: boolean): "mouse" | "touch" | n
  */
 function runUntil(fn: Function, conditionFn: Function): void {
 	if (conditionFn() === false) {
-		window.requestAnimationFrame(() => runUntil(fn, conditionFn));
+		requestAnimationFrame(() => runUntil(fn, conditionFn));
 	} else {
 		fn();
 	}

--- a/test/api/chart-spec.ts
+++ b/test/api/chart-spec.ts
@@ -66,7 +66,9 @@ describe("API chart", () => {
 				expect(util.getBBox(path).width).to.be.equal(barWidth * 2);
 
 				done();
-			}, 500);
+			}, 300);
+
+			setTimeout(done, 500);
 		});
 	});
 

--- a/test/assets/module/browser.ts
+++ b/test/assets/module/browser.ts
@@ -3,4 +3,4 @@
  */
 /* eslint-disable */
 // @ts-nocheck
-export {window, document} from "../../../src/module/browser";
+export {window, document, requestAnimationFrame, requestIdleCallback} from "../../../src/module/browser";


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3159

## Details
<!-- Detailed description of the change/feature -->
Do not override requestAnimationFrame neither requestIdleCallback to prevent any possible side-effects.