### PR TITLE
refactor(api): make .load/unload() option 'resizeAfter' to default 'false'

### DIFF
--- a/src/Chart/api/load.ts
+++ b/src/Chart/api/load.ts
@@ -38,7 +38,7 @@ export default {
 	 *    | keys | Object |  Choose which JSON objects keys correspond to desired data.<br>**NOTE:** Only for JSON object given as array.<br>@see [data․keys](Options.html#.data%25E2%2580%25A4keys) |
 	 *    | mimeType | string |  Set 'json' if loading JSON via url.<br>@see [data․mimeType](Options.html#.data%25E2%2580%25A4mimeType) |
 	 *    | names | Object | Same as data.names() |
-	 *    | resizeAfter | boolean | Resize after the load. Default value is `true`. This option won't call `onresize` neither `onresized`. |
+	 *    | resizeAfter | boolean | Resize after the load. Default value is `false`.<br>- This option won't call `onresize` neither `onresized`.<br>- When set to 'true', will call `.flush(true)` at the end of load. |
 	 *    | type | string | The type of targets will be updated. |
 	 *    | types | Object | The types of targets will be updated. |
 	 *    | unload | Array | Specify the data will be unloaded before loading new data. If true given, all of data will be unloaded. If target ids given as String or Array, specified targets will be unloaded. If absent or false given, unload will not occur. |
@@ -54,7 +54,7 @@ export default {
 	 *    unload: ["data2", "data3"],
 	 *    url: "...",
 	 *    done: function() { ... }
-	 *    resizeAfter: false  // will not resize after load
+	 *    resizeAfter: true  // will resize after load
 	 * });
 	 * @example
 	 * const chart = bb.generate({
@@ -201,7 +201,7 @@ export default {
 	 *  | --- | --- | --- |
 	 *  | ids | String &vert; Array | Target id data to be unloaded. If not given, all data will be unloaded. |
 	 *  | done | Fuction | Callback after data is unloaded. |
-	 *  | resizeAfter | boolean | Resize after the unload. Default value is `true`. This option won't call `onresize` neither `onresized`. |
+	 *  | resizeAfter | boolean | Resize after the unload. Default value is `false`.<br>- This option won't call `onresize` neither `onresized`.<br>- When set to 'true', will call `.flush(true)` at the end of unload. |
 	 * @example
 	 *  // Unload data2 and data3
 	 *  chart.unload({
@@ -209,7 +209,7 @@ export default {
 	 *    done: function() {
 	 *       // called after the unloaded
 	 *    },
-	 *    resizeAfter: false  // will not resize after unload
+	 *    resizeAfter: true  // will resize after unload
 	 *  });
 	 */
 	unload(argsValue): void {

--- a/src/ChartInternal/data/load.ts
+++ b/src/ChartInternal/data/load.ts
@@ -11,14 +11,11 @@ import {endall} from "../../module/util";
  * @param {boolean} resizeAfter Weather to resize chart after the load
  * @private
  */
-export function callDone(fn, resizeAfter = true) {
+export function callDone(fn, resizeAfter = false) {
 	const $$ = this;
 	const {api} = $$;
 
-	if (resizeAfter !== false) {
-		$$.api.flush(true);
-	}
-
+	resizeAfter && $$.api.flush(true);
 	fn?.call(api);
 }
 

--- a/test/api/chart-spec.ts
+++ b/test/api/chart-spec.ts
@@ -48,7 +48,9 @@ describe("API chart", () => {
 			expect(chart.groups().length).to.be.equal(0);
 		});
 
-		it("should update groups correctly", done => {
+		it("should update groups correctly", function(done) {
+			this.timeout(1000);
+
 			const main = chart.$.main;
 			const path = main.select(`.${$BAR.bars}-data1 path`);
 			const barWidth = util.getBBox(path).width;

--- a/test/api/load-spec.ts
+++ b/test/api/load-spec.ts
@@ -861,6 +861,7 @@ describe("API load", function() {
 				   ["www6-abcd-abcd", 600, 200, 150, 300],
 				   ["www7-abcd-abcd", 700, 200, 150, 300]
 				],
+				resizeAfter: true,
 				done: function() {
 					const lastLegend = this.$.legend.select("g:last-child").node();
 					const chartNode = this.$.chart.node();
@@ -889,7 +890,6 @@ describe("API load", function() {
 				   ["www6-abcd-abcd", 600, 200, 150, 300],
 				   ["www7-abcd-abcd", 700, 200, 150, 300]
 				],
-				resizeAfter: false,
 				done: function() {
 					const lastLegend = this.$.legend.select("g:last-child").node();
 					const chartNode = this.$.chart.node();
@@ -919,6 +919,7 @@ describe("API load", function() {
 				done: function() {
 					this.unload({
                         ids: ["www-abcd-abcd", "www2-abcd-abcd", "www3-abcd-abcd"],
+						resizeAfter: true,
 						done: function() {
 							const lastLegend = this.$.legend.select("g:last-child").node();
 							const chartNode = this.$.chart.node();

--- a/test/internals/boost-spec.ts
+++ b/test/internals/boost-spec.ts
@@ -73,18 +73,16 @@ describe("BOOST", () => {
 		this.timeout(4000);
 
 		it("check if given function run on WebWorker thread.", done => {
-			const timeout = setTimeout(() => done(), 3500);
-
 			runWorker(true, function test_for_worker(p) {
 					return `${p}_123`;
 				},
 				function(res) {
-					timeout && clearTimeout(timeout);
-
 					expect(res).to.be.equal("abcd_123");
 					done();
 				}
 			)("abcd");
+
+			setTimeout(done, 3800);
 		});
 	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3157

## Details
<!-- Detailed description of the change/feature -->
To keep backward compatibility and prevent some unexpected behavior, set resizeAfter's default to false.