### PR TITLE
fix(export): Fix Plugin class import

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 			"import": "./dist-esm/plugin/*.js",
 			"require": "./dist/plugin/pkgd/*.js"
 		},
-		"./dist/*": "./dist/*"
+		"./dist/*": "./dist/*",
+		"./src/Plugin/*": "./src/Plugin/*.js"
 	},
 	"scripts": {
 		"start": "webpack serve --open",


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3221

## Details
<!-- Detailed description of the change/feature -->
Fix Plugin class to be imported from the npm package module.

```js
// npm package to export Plugin class 
import Plugin from "billboard.js/src/Plugin/Plugin";

class MyPlugin extends Plugin { .. }
```