### PR TITLE
feat(legend): Intent to ship legent.item.interaction

### DIFF
--- a/src/ChartInternal/internals/legend.ts
+++ b/src/ChartInternal/internals/legend.ts
@@ -394,6 +394,7 @@ export default {
 		const isTouch = state.inputType === "touch";
 		const hasGauge = $$.hasType("gauge");
 		const useCssRule = config.boost_useCssRule;
+		const hasInteraction = config.legend_item_interaction;
 
 		item
 			.attr("class", function(id) {
@@ -420,48 +421,54 @@ export default {
 			}
 
 			item
-				.style("cursor", $$.getStylePropValue("pointer"))
-				.on("click", function(event, id) {
-					if (!callFn(config.legend_item_onclick, api, id)) {
-						if (event.altKey) {
-							api.hide();
-							api.show(id);
-						} else {
-							api.toggle(id);
+				.on("click", hasInteraction || isFunction(config.legend_item_onclick) ?
+					function(event, id) {
+						if (!callFn(config.legend_item_onclick, api, id)) {
+							if (event.altKey) {
+								api.hide();
+								api.show(id);
+							} else {
+								api.toggle(id);
 
-							d3Select(this)
-								.classed($FOCUS.legendItemFocused, false);
+								d3Select(this)
+									.classed($FOCUS.legendItemFocused, false);
+							}
 						}
-					}
 
-					isTouch && $$.hideTooltip();
-				});
+						isTouch && $$.hideTooltip();
+					} : null);
 
 			!isTouch && item
-				.on("mouseout", function(event, id) {
-					if (!callFn(config.legend_item_onout, api, id)) {
-						d3Select(this).classed($FOCUS.legendItemFocused, false);
+				.on("mouseout", hasInteraction || isFunction(config.legend_item_onout) ?
+					function(event, id) {
+						if (!callFn(config.legend_item_onout, api, id)) {
+							d3Select(this).classed($FOCUS.legendItemFocused, false);
 
-						if (hasGauge) {
-							$$.undoMarkOverlapped($$, `.${$GAUGE.gaugeValue}`);
+							if (hasGauge) {
+								$$.undoMarkOverlapped($$, `.${$GAUGE.gaugeValue}`);
+							}
+
+							$$.api.revert();
 						}
+					} : null)
+				.on("mouseover", hasInteraction || isFunction(config.legend_item_onover) ?
+					function(event, id) {
+						if (!callFn(config.legend_item_onover, api, id)) {
+							d3Select(this).classed($FOCUS.legendItemFocused, true);
 
-						$$.api.revert();
-					}
-				})
-				.on("mouseover", function(event, id) {
-					if (!callFn(config.legend_item_onover, api, id)) {
-						d3Select(this).classed($FOCUS.legendItemFocused, true);
+							if (hasGauge) {
+								$$.markOverlapped(id, $$, `.${$GAUGE.gaugeValue}`);
+							}
 
-						if (hasGauge) {
-							$$.markOverlapped(id, $$, `.${$GAUGE.gaugeValue}`);
+							if (!state.transiting && $$.isTargetToShow(id)) {
+								api.focus(id);
+							}
 						}
+					} : null);
 
-						if (!state.transiting && $$.isTargetToShow(id)) {
-							api.focus(id);
-						}
-					}
-				});
+			// set cursor when has some interaction
+			!item.empty() && item.on("click mouseout mouseover") &&
+				item.style("cursor", $$.getStylePropValue("pointer"));
 		}
 	},
 

--- a/src/config/Options/common/legend.ts
+++ b/src/config/Options/common/legend.ts
@@ -40,6 +40,10 @@ export default {
 	 *   - defines the max step the legend has (e.g. If 2 set and legend has 3 legend item, the legend 2 columns).
 	 * @property {boolean} [legend.equally=false] Set to all items have same width size.
 	 * @property {number} [legend.padding=0] Set padding value
+	 * @property {boolean} [legend.item.interaction=true] Set legend item interaction.<br>
+	 *  - **NOTE:**
+	 *    - This setting will not have effect on `.toggle()` method.
+	 *    - `legend.item.onXXX` listener options will work if set, regardless of this option value.
 	 * @property {Function} [legend.item.onclick=undefined] Set click event handler to the legend item.
 	 * @property {Function} [legend.item.onover=undefined] Set mouse/touch over event handler to the legend item.
 	 * @property {Function} [legend.item.onout=undefined] Set mouse/touch out event handler to the legend item.
@@ -85,6 +89,9 @@ export default {
 	 *      equally: false,
 	 *      padding: 10,
 	 *      item: {
+	 *          // will disable default interaction
+	 *          interaction: false,
+	 *
 	 *          onclick: function(id) { ... },
 	 *          onover: function(id) { ... },
 	 *          onout: function(id) { ... },
@@ -105,23 +112,24 @@ export default {
 	 *      usePoint: true
 	 *  }
 	 */
-	legend_show: true,
-	legend_hide: false,
 	legend_contents_bindto: <string|HTMLElement|undefined> undefined,
 	legend_contents_template: <string|(() => string)|undefined> "<span style='color:#fff;padding:5px;background-color:{=COLOR}'>{=TITLE}</span>",
-	legend_position: <"bottom"|"right"|"inset"> "bottom",
+	legend_equally: false,
+	legend_hide: false,
 	legend_inset_anchor: <"top-left"|"top-right"|"bottom-left"|"bottom-right"> "top-left",
 	legend_inset_x: 10,
 	legend_inset_y: 0,
 	legend_inset_step: <number|undefined> undefined,
+	legend_item_interaction: true,
 	legend_item_onclick: <Function|undefined> undefined,
 	legend_item_onover: <Function|undefined> undefined,
 	legend_item_onout: <Function|undefined> undefined,
-	legend_equally: false,
-	legend_padding: 0,
 	legend_item_tile_width: 10,
 	legend_item_tile_height: 10,
 	legend_item_tile_r: 5,
 	legend_item_tile_type: <"rectangle"|"circle"> "rectangle",
+	legend_padding: 0,
+	legend_position: <"bottom"|"right"|"inset"> "bottom",
+	legend_show: true,
 	legend_usePoint: false
 };

--- a/test/internals/legend-spec.ts
+++ b/test/internals/legend-spec.ts
@@ -15,7 +15,8 @@ describe("LEGEND", () => {
 	let args;
 
 	after(() => util.destroyAll());
-beforeEach(() => {
+
+	beforeEach(() => {
 		chart = util.generate(args);
 	});
 
@@ -638,7 +639,7 @@ beforeEach(() => {
 		});
 	});
 
-	describe("legend opacity onclcik", () => {
+	describe("legend opacity onclick", () => {
 		before(() => {
 			args = {
 				data: {
@@ -765,6 +766,89 @@ beforeEach(() => {
 			const legendItems = chart.$.legend.selectAll("line");
 
 			expect(legendItems.size()).to.be.equal(chart.data().length);
+		});
+	});
+
+	describe("legend item interaction", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 300, 350, 300],
+						["data2", 130, 100, 140]
+					],
+					type: "line"
+				},
+				legend: {
+					item: {
+						interaction: false
+					}
+				}
+			};
+		});
+
+		it("shouldn't be interacted", () => {
+			const {legend} = chart.$;
+
+			chart.data().forEach(({id}) => {
+				const item = legend.select(`.bb-legend-item-${id}`);
+
+				expect(item.on("click mouseover mouseout")).to.be.undefined;
+				expect(item.attr("style")).to.be.null;
+			});
+		});
+
+		it("set options: legend.item.onclick", () => {
+			args.legend.item.onclick = () => {};
+		});
+
+		it("should only 'click' event lister bound", () => {
+			const {legend} = chart.$;
+
+			chart.data().forEach(({id}) => {
+				const item = legend.select(`.bb-legend-item-${id}`);
+
+				expect(item.on("mouseover mouseout")).to.be.undefined;
+				expect(item.on("click")).to.not.be.undefined;
+
+				expect(item.style("cursor")).to.be.equal("pointer");
+			});
+		});
+
+		it("set options: legend.item.onover", () => {
+			delete args.legend.item.onclick;
+			args.legend.item.onover = () => {};
+		});
+
+		it("should only 'mouseover' event lister bound", () => {
+			const {legend} = chart.$;
+
+			chart.data().forEach(({id}) => {
+				const item = legend.select(`.bb-legend-item-${id}`);
+
+				expect(item.on("click mouseout")).to.be.undefined;
+				expect(item.on("mouseover")).to.not.be.undefined;
+
+				expect(item.style("cursor")).to.be.equal("pointer");
+			});
+		});
+
+		it("set options: legend.item.onout", () => {
+			delete args.legend.item.onover;
+			args.legend.item.onout = () => {};
+		});
+
+		it("should only 'mouseout' event lister bound", () => {
+			const {legend} = chart.$;
+
+			chart.data().forEach(({id}) => {
+				const item = legend.select(`.bb-legend-item-${id}`);
+
+				expect(item.on("click mouseover")).to.be.undefined;
+				expect(item.on("mouseout")).to.not.be.undefined;
+
+				expect(item.style("cursor")).to.be.equal("pointer");
+			});
 		});
 	});
 });

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -470,6 +470,15 @@ export interface LegendOptions {
 			 */
 			r?: number;
 		};
+
+		/**
+		 * Set legend item interaction.
+		 *  - **NOTE:**
+		 *    - This setting will not have effect on `.toggle()` method.
+	 	 *    - `legend.item.onXXX` listener options will work if set, regardless of this option value.
+		 */
+		interaction?: boolean;
+
 		/**
 		 * Set click event handler to the legend item.
 		 */


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#1598

## Details
<!-- Detailed description of the change/feature -->
This option can control default interaction of legend items

```js
legend: {
   item: {
      // will disable default interaction (mouse hover effect and click to hide clicked dataseries)
      interaction: false,

      // when set below callback option value, will work regardless of 'interaction=false' is set
      onclick: function(id) { ... },
      onover: function(id) { ... },
      onout: function(id) { ... }
   }
}
```