### PR TITLE
fix(line): Fix step line path rendering on Windows

### DIFF
--- a/src/ChartInternal/shape/line.ts
+++ b/src/ChartInternal/shape/line.ts
@@ -81,7 +81,6 @@ export default {
 			.style("stroke", $$.color)
 			.merge(line)
 			.style("opacity", $$.initialOpacity.bind($$))
-			.style("shape-rendering", d => ($$.isStepType(d) ? "crispEdges" : ""))
 			.attr("transform", null);
 	},
 

--- a/test/shape/line-spec.ts
+++ b/test/shape/line-spec.ts
@@ -65,11 +65,11 @@ describe("SHAPE LINE", () => {
 			args.line.step.type = "step-after";
 		});
 
-		it("should have shape-rendering = crispedges when it's step chart", () => {
+		it("should 'shape-rendering' shouldn't be set 'crispedges' when it's step chart", () => {
 			chart.$.main.selectAll(`.${$LINE.line}`).each(function() {
 				const style = d3Select(this).style("shape-rendering").toLowerCase();
 
-				expect(style).to.be.equal("crispedges");
+				expect(style).to.be.equal("auto");
 			});
 		});
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3295

## Details
<!-- Detailed description of the change/feature -->
Remove 'shape-rendering:crispEdges' for step line to remove rendering issue on Windows