### PR TITLE
fix(arc): Fix shape rendering when data id equivalent of color string

### DIFF
--- a/test/shape/arc-spec.ts
+++ b/test/shape/arc-spec.ts
@@ -879,5 +879,31 @@ describe("SHAPE ARC", () => {
 				i++;
 			}, 15);
 		});
+
+		it("when colorish string value is used as data name", done => {
+			const chart = util.generate({
+				data: {
+					columns: [
+						["data1", 30],
+						["red", 120]
+					],
+					type: "donut"
+				},
+				onafterinit: function() {
+					setTimeout(() => {
+						this.focus("red");
+					}, 300);
+			
+					setTimeout(() => {
+						const d = this.$.arc.select(".bb-arc-red").attr("d");
+			
+						// shape shouldn't be an empty path
+						expect(d).to.not.be.equal("M 0 0");
+
+						done();
+					}, 500);
+				}
+			});			
+		});
 	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3321

## Details
<!-- Detailed description of the change/feature -->
For interpolation, make sure to be applied only necessary values.
Issue happened because colorish string were interpolated, which transformed
id values as interpolated color string.

![donut](https://github.com/naver/billboard.js/assets/2178435/91be9fe2-eec4-4a12-8063-39690033a540)
