### PR TITLE
chore(build): Rename plugin packaged file name

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -14,7 +14,8 @@ module.exports = function(api) {
 				},
 				"modules": false,
 				"loose": true,
-				"useBuiltIns": false
+				"useBuiltIns": false,
+				exclude: ["@babel/plugin-transform-block-scoping"]
 			}
 		]
 	];

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -51,7 +51,8 @@ module.exports = function(config) {
 						test: /(\.[jt]s)$/,
 						loader: "babel-loader",
 						exclude: {
-							and: [/node_modules/]
+							and: [/node_modules/],
+							not: [/(d3\-.*)$/, /internmap/]
 						}
 					}
 				]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"build:theme": "cross-env NODE_ENV=theme webpack",
 		"build:production:analyzer": "cross-env ANALYZER=true npm run build:production",
 		"build:packaged:analyzer": "cross-env ANALYZER=true npm run build:packaged",
-		"build:plugin": "cross-env NODE_ENV=plugin webpack && cross-env NODE_ENV=plugin MODE=min webpack && cross-env NODE_ENV=plugin MODE=pkgd webpack",
+		"build:plugin": "cross-env NODE_ENV=plugin webpack && cross-env NODE_ENV=plugin MODE=min webpack && cross-env NODE_ENV=plugin MODE=pkgd webpack && cross-env NODE_ENV=plugin MODE=pkgd-min webpack",
 		"build:plugin:types": "node ./config/type.d-plugin.js",
 		"release": "semantic-release",
 		"lint": "npm run lint:types && eslint src --ext .ts",


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3334

## Details
<!-- Detailed description of the change/feature -->
- Set plugin dist files name to contain 'pkgd' as postfix.
- Remove '@babel/plugin-transform-block-scoping' plugin wich transpiles incorrectly