### PR TITLE
fix(api): Fix to return indexed categories

### DIFF
--- a/src/Chart/api/category.ts
+++ b/src/Chart/api/category.ts
@@ -2,6 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
+import {isEmpty} from "../../module/util";
+
 export default {
 	/**
 	 * Set specified category name on category axis.
@@ -27,7 +29,7 @@ export default {
 	},
 
 	/**
-	 * Set category names on category axis.
+	 * Set or get category names on category axis.
 	 * @function categories
 	 * @instance
 	 * @memberof Chart
@@ -38,12 +40,14 @@ export default {
 	 *      "Category 1", "Category 2", ...
 	 * ]);
 	 */
-	categories(categories: string[]): string[] {
+	categories(categories?: string[]): string[] {
 		const $$ = this.internal;
 		const {config} = $$;
 
-		if (!arguments.length) {
-			return config.axis_x_categories;
+		if (!categories || !Array.isArray(categories)) {
+			const cat = config.axis_x_categories;
+
+			return isEmpty(cat) ? Object.values($$.data.xs)[0] : cat;
 		}
 
 		config.axis_x_categories = categories;

--- a/test/api/category-spec.ts
+++ b/test/api/category-spec.ts
@@ -120,4 +120,23 @@ describe("API category", () => {
 
 		expect(chart.$.tooltip.html()).to.be.empty;
 	});
+
+	it("set options", () => {
+		args = {
+			data: {
+				columns: [
+					["data1", 100, 99, 98]
+				],
+			},
+			axis: {
+				x: {
+					type: "category"
+				}
+			}
+		};
+	});
+
+	it("check for indexed categories", () => {
+		expect(chart.categories()).to.deep.equal([0,1,2]);
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3365

## Details
<!-- Detailed description of the change/feature -->
Fix to return indexed values when .categories() is called for indexed x axis type