### PR TITLE
fix(Domain): fix trimXDomain not trimming min

### DIFF
--- a/src/ChartInternal/internals/domain.ts
+++ b/src/ChartInternal/internals/domain.ts
@@ -355,8 +355,8 @@ export default {
 		const [min, max] = zoomDomain;
 
 		if (isInverted ? domain[0] >= min : domain[0] <= min) {
-			domain[0] = min;
 			domain[1] = +domain[1] + (min - domain[0]);
+			domain[0] = min;
 		}
 
 		if (isInverted ? domain[1] <= max : domain[1] >= max) {

--- a/test/internals/domain-spec.ts
+++ b/test/internals/domain-spec.ts
@@ -377,4 +377,36 @@ describe("DOMAIN", function() {
 			expect(y2.domain()).to.be.deep.equal(domain);
 		});
 	});
+
+	describe("trimXDomain", () => {
+		before(() => {
+			args = {
+				data: {
+					columns: [
+						["sample", 30, 200, 100, 400, 150, 250, 150, 200, 170, 240, 350, 150, 100, 400, 150],
+					],
+					type: "line",
+				},
+				zoom: {
+					enabled: true,
+				},
+			}
+		});
+
+		it("test pan left gets trimmed", () => {
+			const domain = chart.internal.scale.x.domain();
+			const trimmed = chart.internal.trimXDomain(domain.map((x: number) => x - 10));
+
+			expect(trimmed[0]).to.approximately(domain[0], 0.1);
+			expect(trimmed[1]).to.approximately(domain[1], 0.1);
+		});
+
+		it("test pan right gets trimmed", () => {
+			const domain = chart.internal.scale.x.domain();
+			const trimmed = chart.internal.trimXDomain(domain.map((x: number) => x + 5));
+
+			expect(trimmed[0]).to.approximately(domain[0], 0.1);
+			expect(trimmed[1]).to.approximately(domain[1], 0.1);
+		});
+	});
 });


### PR DESCRIPTION
## Details
When wheel zoom is enabled, panning too far to the left zooms in and then resets zoom when any other zoom input is given (another drag or scroll). This behavior does not occur when panning past the right side of the chart.

This seems to happen since e193c0f7 (3.8.0), where the order of assignment to `domain[0]` and `domain[1]` was reversed.

I'm not 100% sure that this change wasn't intentional, but changing it back doesn't seem to fail any additional tests.

![](https://i.imgur.com/WdS7HVs.gif)



## Steps to check or reproduce issue
1. Open zoom demo
2. Drag from left to right
3. Observe zoom level has changed
4. Perform any other zoom input (scroll in/out or drag left/right)
5. Observe zoom level has been reset

