### PR TITLE
fix(point): Fix data.onclick not called when point.senstivity is radius

### DIFF
--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -619,13 +619,14 @@ export default {
 
 		const mouse = getPointer(state.event, this);
 		const closest = $$.findClosestFromTargets(targetsToShow, mouse);
+		const sensitivity = config.point_sensitivity === "radius" ? closest.r : config.point_sensitivity;
 
 		if (!closest) {
 			return;
 		}
 
 		// select if selection enabled
-		if ($$.isBarType(closest.id) || $$.dist(closest, mouse) < config.point_sensitivity) {
+		if ($$.isBarType(closest.id) || $$.dist(closest, mouse) < sensitivity) {
 			$$.$el.main.selectAll(`.${$SHAPE.shapes}${$$.getTargetSelectorSuffix(closest.id)}`)
 				.selectAll(`.${$SHAPE.shape}-${closest.index}`)
 				.each(function() {

--- a/src/ChartInternal/shape/point.ts
+++ b/src/ChartInternal/shape/point.ts
@@ -371,9 +371,11 @@ export default {
 	},
 
 	isWithinCircle(node: SVGElement, r?: number): boolean {
-		const mouse = getPointer(this.state.event, node);
+		const {config, state} = this;
+		const mouse = getPointer(state.event, node);
 		const element = d3Select(node);
 		const prefix = this.isCirclePoint(node) ? "c" : "";
+		const sensitivity = config.point_sensitivity === "radius" ? node.getAttribute("r") : config.point_sensitivity;
 		let cx = +element.attr(`${prefix}x`);
 		let cy = +element.attr(`${prefix}y`);
 
@@ -387,7 +389,7 @@ export default {
 
 		return Math.sqrt(
 			Math.pow(cx - mouse[0], 2) + Math.pow(cy - mouse[1], 2)
-		) < (r || this.config.point_sensitivity);
+		) < (r || sensitivity);
 	},
 
 	/**

--- a/test/interactions/interaction-spec.ts
+++ b/test/interactions/interaction-spec.ts
@@ -632,6 +632,26 @@ describe("INTERACTION", () => {
 				expect(clicked).to.be.true;
 				expect(data.value).to.be.equal(10);
 			});
+			
+			it("set option point.sensitivity='radius'", () => {
+				args.point.sensitivity = "radius";
+			});
+
+			it("check for data click for line: when point.senstivity='radius'", () => {
+				const main = chart.$.main;
+				const {eventRect} = chart.internal.$el;
+				const circle = util.getBBox(main.select(`.${$CIRCLE.circles}-data1 circle`));
+
+				util.fireEvent(eventRect.node(), "click", {
+					clientX: circle.x,
+					clientY: circle.y
+				}, chart);
+
+				expect(clicked).to.be.true;
+				expect(data.value).to.be.equal(10);
+
+				delete args.point.sensitivity;
+			});
 
 			it("set option point.type='rectangle'", () => {
 				args.point.pattern = ["rectangle"];


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3466

## Details
<!-- Detailed description of the change/feature -->
when point.senstivity='radius' is set, the conditional checking distance not work. When the value is 'radius' make conditional to work with node's radius value instead.