### PR TITLE
fix(axis): Fix x axis tick text overlap with legend

### DIFF
--- a/src/ChartInternal/internals/clip.ts
+++ b/src/ChartInternal/internals/clip.ts
@@ -123,16 +123,16 @@ export default {
 
 	setXAxisTickClipWidth(): void {
 		const $$ = this;
-		const {config, state: {current: {maxTickWidths}}} = $$;
+		const {config, state: {current: {maxTickSize}}} = $$;
 
 		const xAxisTickRotate = $$.getAxisTickRotate("x");
 
 		if (!config.axis_x_tick_multiline && xAxisTickRotate) {
 			const sinRotation = Math.sin(Math.PI / 180 * Math.abs(xAxisTickRotate));
 
-			maxTickWidths.x.clipPath = ($$.getHorizontalAxisHeight("x") - 20) / sinRotation;
+			maxTickSize.x.clipPath = ($$.getHorizontalAxisHeight("x") - 20) / sinRotation;
 		} else {
-			maxTickWidths.x.clipPath = null;
+			maxTickSize.x.clipPath = null;
 		}
 	},
 
@@ -142,7 +142,7 @@ export default {
 
 		if (svg) {
 			svg.select(`#${clip.idXAxisTickTexts} rect`)
-				.attr("width", current.maxTickWidths.x.clipPath)
+				.attr("width", current.maxTickSize.x.clipPath)
 				.attr("height", 30);
 		}
 	}

--- a/src/ChartInternal/internals/size.axis.ts
+++ b/src/ChartInternal/internals/size.axis.ts
@@ -26,7 +26,7 @@ export default {
 
 		if ($$.axis) {
 			const position = $$.axis?.getLabelPositionById(id);
-			const width = $$.axis.getMaxTickWidth(id, withoutRecompute);
+			const {width} = $$.axis.getMaxTickSize(id, withoutRecompute);
 			const gap = width === 0 ? 0.5 : 0;
 
 			return width + (
@@ -47,7 +47,9 @@ export default {
 		const isFitPadding = config.padding?.mode === "fit";
 		const isInner = config[`axis_${id}_inner`];
 		const hasLabelText = config[`axis_${id}_label`].text;
+		const defaultHeight = 13;
 		let h = config.padding?.mode === "fit" ? (isInner && !hasLabelText ? (id === "y" ? 1 : 0) : 20) : 30;
+
 
 		if (id === "x" && !config.axis_x_show) {
 			return 8;
@@ -67,14 +69,14 @@ export default {
 			return isFitPadding ? 0 : rotatedPadding.top;
 		}
 
+		const maxtickSize = $$.axis.getMaxTickSize(id);
 		const rotate = $$.getAxisTickRotate(id);
 
 		// Calculate x/y axis height when tick rotated
 		if (
 			((id === "x" && !isRotated) || (/y2?/.test(id) && isRotated)) && rotate
 		) {
-			h = 30 +
-				$$.axis.getMaxTickWidth(id) *
+			h += maxtickSize.width *
 				Math.cos(Math.PI * (90 - Math.abs(rotate)) / 180);
 
 			if (!config.axis_x_tick_multiline && current.height) {
@@ -82,6 +84,8 @@ export default {
 					h = current.height / 2;
 				}
 			}
+		} else if (maxtickSize.height > defaultHeight && config.legend_show) {
+			h += maxtickSize.height - defaultHeight;
 		}
 
 		return h +
@@ -114,7 +118,7 @@ export default {
 
 			if (config.axis_x_tick_fit && allowedXAxisTypes) {
 				const xTickCount = config.axis_x_tick_count;
-				const currentXTicksLength = state.current.maxTickWidths.x.ticks.length;
+				const currentXTicksLength = state.current.maxTickSize.x.ticks.length;
 				let tickCount = 0;
 
 				if (xTickCount) {
@@ -163,9 +167,9 @@ export default {
 		const tickCountWithPadding = axis.x.tickCount +
 			axis.x.padding.left + axis.x.padding.right;
 
-		const maxTickWidth = $$.axis.getMaxTickWidth("x");
+		const {width} = $$.axis.getMaxTickSize("x");
 		const tickLength = tickCountWithPadding ? xAxisLength / tickCountWithPadding : 0;
 
-		return maxTickWidth > tickLength;
+		return width > tickLength;
 	}
 };

--- a/src/config/Store/State.ts
+++ b/src/config/Store/State.ts
@@ -54,10 +54,10 @@ export default class State {
 				height: 0,
 				dataMax: 0,
 
-				maxTickWidths: {
-					x: {size: 0, ticks: <number[]> [], clipPath: 0, domain: ""},
-					y: {size: 0, domain: ""},
-					y2: {size: 0, domain: ""}
+				maxTickSize: {
+					x: {width: 0, height: 0, ticks: <number[]> [], clipPath: 0, domain: ""},
+					y: {width: 0, height: 0, domain: ""},
+					y2: {width: 0, height: 0, domain: ""}
 				},
 
 				// current used chart type list

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -1061,6 +1061,81 @@ describe("AXIS", function() {
 		});
 	});
 
+	describe("axis x height", () => {
+		before(() => {
+			args = {
+				data: {
+					x: "x",
+					xFormat: "%Y",
+					columns: [
+						["x", "2010", "2011", "2012", "2013", "2014", "2015"],
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 130, 340, 200, 500, 250, 350]
+					],
+					type: "line"
+				  },
+				  axis: {
+					x: {
+					  type: "timeseries",
+					  localtime: false,
+					  tick: {
+						format: "%Y-%m-%d %H:%M:%S"
+					  }
+					}
+				}
+			}
+		});
+
+		it("shouldn't overlap x Axis tick text with legend", () => {
+			const {axis: {x}, legend} = chart.internal.$el;
+
+			const xBottom = x.node().getBoundingClientRect().bottom;
+			const legendTop = legend.node().getBoundingClientRect().top;
+
+			expect(legendTop > xBottom).to.be.true;			
+		});
+
+		it("set option: legend.show=false", () => {
+			args.legend = {
+				show: false
+			};
+		});
+
+		it("x Axis tick text should stay within container", () => {
+			const {$el: {axis: {x}}, state} = chart.internal;
+			const xBottom = x.node().getBoundingClientRect().bottom;
+
+			expect(xBottom).to.be.closeTo(state.current.height, 5);
+		});
+
+		it("set option: legend.show=false", () => {
+			args = {
+				data: {
+					x: "x",
+					columns: [
+						["x", "First Q\n2018", "Second\nQ 2018", "3Q\nYear\n2018", "Forth\nQuarter\n2018"],
+						["data", 30, 100, 400, 150]
+					],
+					type: "line"
+				},
+				axis: {
+					x: {
+						type: "category"
+					}
+				}
+			};
+		});
+
+		it("shouldn't overlap x Axis tick text with legend", () => {
+			const {axis: {x}, legend} = chart.internal.$el;
+
+			const xBottom = x.node().getBoundingClientRect().bottom;
+			const legendTop = legend.node().getBoundingClientRect().top;
+
+			expect(legendTop > xBottom).to.be.true;			
+		});
+	});
+
 	describe("axis.x.tick.tooltip", () => {
 		before(() => {
 			args = {
@@ -3188,12 +3263,12 @@ describe("AXIS", function() {
 		});
 
 		it("x Axis tick width should be evaluated correctly", () => {
-			const {state: {current}} = chart.internal;
+			const {state: {current: {maxTickSize}}} = chart.internal;
 
-			const maxTickWidth = current.maxTickWidths.x.size;
+			const {width} = maxTickSize.x;
 			const tickWdith = chart.$.main.select(`.${$AXIS.axisX} tspan`).node().getBoundingClientRect().width;
 
-			expect(maxTickWidth).to.be.equal(tickWdith);
+			expect(width).to.be.equal(tickWdith);
 		});
 	});
 

--- a/test/plugin/stanford/stanford-elements-spec.ts
+++ b/test/plugin/stanford/stanford-elements-spec.ts
@@ -157,7 +157,7 @@ describe("PLUGIN: STANFORD ELEMENTS", () => {
 				expect(line.size()).to.be.equal(1);
 
 				pos.forEach((v, i) => {
-					expect(v).to.be.closeTo(expected[i], 3);
+					expect(v).to.be.closeTo(expected[i], 10);
 				});
 
 				done();


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3485

## Details
<!-- Detailed description of the change/feature -->
Compute tick text's height and applies when is greater than the default height value.

<img width="564" alt="image" src="https://github.com/naver/billboard.js/assets/2178435/c2a6cce2-1919-48f0-84ce-425a217e7961">
<img width="560" alt="image" src="https://github.com/naver/billboard.js/assets/2178435/d6aa5dcf-7c48-40d8-98d5-6feb9fee7bcd">
