### PR TITLE
fix(tooltip): Fix tooltip.format.value arg for bar range data

### DIFF
--- a/src/ChartInternal/internals/format.ts
+++ b/src/ChartInternal/internals/format.ts
@@ -50,8 +50,8 @@ export default {
 		};
 	},
 
-	defaultValueFormat(v): number|string {
-		return isValue(v) ? +v : "";
+	defaultValueFormat(v: number|number[]): number|string {
+		return isArray(v) ? v.join("~") : (isValue(v) ? +v : "");
 	},
 
 	defaultArcValueFormat(v, ratio): string {

--- a/src/ChartInternal/internals/tooltip.ts
+++ b/src/ChartInternal/internals/tooltip.ts
@@ -198,9 +198,9 @@ export default {
 
 				value = `<b>Open:</b> ${open} <b>High:</b> ${high} <b>Low:</b> ${low} <b>Close:</b> ${close}${volume ? ` <b>Volume:</b> ${volume}` : ""}`;
 			} else if ($$.isBarRangeType(row)) {
-				const {value: [start, end], id, index} = row;
+				const {value: rangeValue, id, index} = row;
 
-				value = `${valueFormat(start, undefined, id, index)} ~ ${valueFormat(end, undefined, id, index)}`;
+				value = `${valueFormat(rangeValue, undefined, id, index)}`;
 			} else {
 				value = valueFormat(getRowValue(row), ...param);
 			}

--- a/test/internals/tooltip-spec.ts
+++ b/test/internals/tooltip-spec.ts
@@ -1953,7 +1953,7 @@ describe("TOOLTIP", function() {
 			util.hoverChart(chart, "mousemove", {clientX: 180, clientY: 130});
 
 			expect(chart.$.tooltip.select(".value").html())
-				.to.be.equal("1300 ~ 1339");
+				.to.be.equal("1300~1339");
 		});
 	});
 
@@ -2080,13 +2080,12 @@ describe("TOOLTIP", function() {
 			// when
 			chart.tooltip.show({x: 1});
 
-			expect(spy.callCount).to.be.equal(2);
-
+			expect(spy.callCount).to.be.equal(1);
 			expect(spy.args.every(v => v.length === 4)).to.be.true;
 			expect(spy.args.every(v => {
 				const [value, ratio, id, index]= v;
 
-				return isNumber(value) && isUndefined(ratio) && isString(id) && isNumber(index);
+				return Array.isArray(value) && isUndefined(ratio) && isString(id) && isNumber(index);
 			})).to.be.true;
 
 			spy.resetHistory();


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3507

## Details
<!-- Detailed description of the change/feature -->
- Make format function called once for range(array) data type
- Update on defaultValueFormat to handle array type value also.

```js
bb.generate({
  data: {
    columns: [
      ["data1", [100, 250], 30]
    ],
    type: "bar"
  },
  tooltip: {
    format: {
      value: function (value, ratio, id, index) {
        // when value is ranged type, "value" argument will be an array
        // x0: value => [100, 250]
        // x1: value => 30
      }
    }
  }
});
```