### PR TITLE
chore(packages): add types field to exports

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,6 +7,7 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"types": "./dist/types/index.d.ts",
 			"import": "./dist/billboardjs-react.js",
 			"require": "./dist/billboardjs-react.cjs"
 		}


### PR DESCRIPTION
## Issue

https://github.com/naver/billboard.js/issues/3540

## Details

Add types field exports in package.json to support TypeScript's `"moduleResolution":"bundler"`.