### PR TITLE
fix(radar): Fix axes texts exclusion on resize

### DIFF
--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -4,6 +4,7 @@
  */
 import {document} from "../../module/browser";
 import {$AXIS, $SUBCHART} from "../../config/classes";
+import {KEY} from "../../module/Cache";
 import {ceil10, capitalize, isNumber, isEmpty, isString, isUndefined} from "../../module/util";
 
 export default {
@@ -389,8 +390,9 @@ export default {
 		if ($$.hasArcType()) {
 			const hasGauge = $$.hasType("gauge");
 			const isLegendRight = config.legend_show && state.isLegendRight;
+			const textWidth = (state.hasRadar && $$.cache.get(KEY.radarTextWidth)) ?? 0;
 
-			state.arcWidth = state.width - (isLegendRight ? currLegend.width + 10 : 0);
+			state.arcWidth = state.width - (isLegendRight ? currLegend.width + 10 : 0) - textWidth;
 			state.arcHeight = state.height - (isLegendRight && !hasGauge ? 0 : 10);
 
 			if (hasGauge && !config.gauge_fullCircle) {

--- a/src/ChartInternal/internals/transform.ts
+++ b/src/ChartInternal/internals/transform.ts
@@ -48,10 +48,10 @@ export default {
 			x = state.arcWidth / 2;
 			y = state.arcHeight / 2;
 		} else if (target === "radar") {
-			const [width] = $$.getRadarSize();
+			const [width, height] = $$.getRadarSize();
 
 			x = state.width / 2 - width;
-			y = asHalfPixel(state.margin.top);
+			y = state.height / 2 - height;
 		}
 
 		return `translate(${x}, ${y})`;

--- a/src/module/Cache.ts
+++ b/src/module/Cache.ts
@@ -18,6 +18,7 @@ export const KEY = {
 	dataTotalPerIndex: "$totalPerIndex",
 	legendItemTextBox: "legendItemTextBox",
 	radarPoints: "$radarPoints",
+	radarTextWidth: "$radarTextWidth",
 	setOverOut: "setOverOut",
 	callOverOutForTouch: "callOverOutForTouch",
 	textRect: "textRect"

--- a/test/shape/radar-spec.ts
+++ b/test/shape/radar-spec.ts
@@ -389,4 +389,36 @@ describe("SHAPE RADAR", () => {
 			}).size()).to.be.equal(chart.data().length);
 		});
 	});
+
+	describe("size & position", () => {
+		before(() => {
+			args = {
+				data: {
+					x: "x",
+					columns: [
+						["x", "Data A", "Data B", "Data C", "Data D", "Data E"],
+						["data1", 330, 350, 200, 380, 150],
+						["data2", 130, 100, null, 200, 80],
+						["data3", 230, 153, 85, 300, 250]
+					],
+					type: "radar"
+				}
+			};
+		});
+
+		it("should resize with axes texts", done => {
+			const {$el: {radar}, state} = chart.internal;
+			const yPos = util.parseNum(radar.attr("transform").replace(/[^,]+/, ""));
+
+			// when
+			chart.resize({width: 300});
+
+			setTimeout(() => {
+				expect(util.parseNum(radar.attr("transform").replace(/[^,]+/, ""))).to.be.greaterThan(yPos);
+				expect(radar.node().getBoundingClientRect().width).to.be.below(state.width);
+
+				done();
+			}, 300);
+		});
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3126

## Details
<!-- Detailed description of the change/feature -->
- Make radar dimension to be calculating axes texts
- Make radar vertically aligned at the middle

Before | After the fix
:---: | :---:
<img src=https://github.com/naver/billboard.js/assets/2178435/e0a1bef5-ef5e-4c35-afec-698b22c40e96 height=250> | <img src=https://github.com/naver/billboard.js/assets/2178435/413bf9a5-780e-4cf3-b64f-90bfb5bbe5d5  height=250>


