### PR TITLE
fix(Axis): Correct x axis height calculation for autorotated x axis tick texts

### DIFF
--- a/src/ChartInternal/internals/size.axis.ts
+++ b/src/ChartInternal/internals/size.axis.ts
@@ -71,7 +71,11 @@ export default {
 
 		const maxtickSize = $$.axis.getMaxTickSize(id);
 
-		if (maxtickSize.height > defaultHeight) {
+		const isXAxisTickRotated = config.axis_x_tick_rotate > 0 && (
+			!config.axis_x_tick_autorotate || $$.needToRotateXAxisTickTexts()
+		);
+
+		if ((config.axis_x_tick_multiline || isXAxisTickRotated) && maxtickSize.height > defaultHeight) {
 			h += maxtickSize.height - defaultHeight;
 		}
 

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -1349,7 +1349,21 @@ describe("AXIS", function() {
 						expect(tspan.attr("dx")).to.be.equal("0");
 					});
 
-				compare(0, 18.8125, 48, 0);
+				compare(0, 18.8125, 30, 0);
+			});
+
+			it("should not use the height of the longest tick text when ticks are not rotated", () => {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function() {
+					const tick = d3Select(this);
+					const text = tick.select("text");
+					const tspan = text.select("tspan");
+
+					expect(text.attr("transform")).to.be.null;
+					expect(text.attr("y")).to.be.equal("9");
+					expect(tspan.attr("dx")).to.be.equal("0");
+				});
+
+				compare(0, 18.8125, 30, 0);
 			});
 
 			it("update args", () => {
@@ -1535,7 +1549,21 @@ describe("AXIS", function() {
 					expect(tspan.attr("dx")).to.be.equal("0");
 				});
 
-				compare(0, 18.8125, 55, 0);
+				compare(0, 18.8125, 30, 0);
+			});
+
+			it("should not use the height of the longest tick text when ticks are not rotated", () => {
+				chart.$.main.selectAll(`.${$AXIS.axisX} g.tick`).each(function() {
+					const tick = d3Select(this);
+					const text = tick.select("text");
+					const tspan = text.select("tspan");
+
+					expect(text.attr("transform")).to.be.null;
+					expect(text.attr("y")).to.be.equal("9");
+					expect(tspan.attr("dx")).to.be.equal("0");
+				});
+
+				compare(0, 18.8125, 30, 0);
 			});
 
 			it("update args", () => {


### PR DESCRIPTION
## Issue
#3584

## Details
The height of the rotated tick text was also added when the tick texts were not rotated due to the autorotate being enabled.
The `maxtickSize.height` is now only added if the tick texts are actually rotated or if multiline is enabled.
