### PR TITLE
fix(clip): Remove setting full domain url

### DIFF
--- a/src/ChartInternal/internals/clip.ts
+++ b/src/ChartInternal/internals/clip.ts
@@ -2,7 +2,6 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {document, window} from "../../module/browser";
 
 export default {
 	initClip(): void {
@@ -33,11 +32,7 @@ export default {
 			return null;
 		}
 
-		const isIE9 = window.navigator ?
-			window.navigator.appVersion
-				.toLowerCase().indexOf("msie 9.") >= 0 : false;
-
-		return `url(${(isIE9 ? "" : document.URL.split("#")[0])}#${id})`;
+		return `url(#${id})`;
 	},
 
 	appendClip(parent, id: string): void {

--- a/test/internals/core-spec.ts
+++ b/test/internals/core-spec.ts
@@ -337,9 +337,9 @@ describe("CORE", function() {
 		});
 
 		it("chart should have clip-path property", () => {
-			const main = chart.$.main.select(`.${$COMMON.chart}`);
+			const clipPath = chart.$.main.select(`.${$COMMON.chart}`)?.attr("clip-path");
 
-			expect(main.attr("clip-path")).to.not.be.null;
+			expect(/url\(#bb-\d+-clip\)/.test(clipPath)).to.be.true;
 		});
 
 		it("set option: axis.y2.show=true", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3684

## Details
<!-- Detailed description of the change/feature -->
Remove ie9 conditional and make setting clip-path's url() value to specify id value without setting full domain
