### PR TITLE
fix: Correct typo in BarOptions

### DIFF
--- a/types/options.shape.d.ts
+++ b/types/options.shape.d.ts
@@ -191,7 +191,7 @@ export interface BarOptions {
 	/**
 	 * Bars will be rendered at same position, which will be overlapped each other. (for non-grouped bars only)
 	 */
-	orverlap?: boolean;
+	overlap?: boolean;
 
 	/**
 	 * The padding pixel value between each bar.


### PR DESCRIPTION
## Issue
None

## Details
Hi, this fixes a small typo in the BarOptions type definition.  
Right now, TypeScript throws an error if you use the correct `overlap`.

