### PR TITLE
fix(treemap): Fix generation w/non-exist node

### DIFF
--- a/src/ChartInternal/shape/treemap.ts
+++ b/src/ChartInternal/shape/treemap.ts
@@ -201,7 +201,7 @@ export default {
 		const treemapData = $$.treemapFn($$.getTreemapData(targets ?? $$.data.targets));
 
 		// using $el.treemap reference can alter data, so select treemap <g> again
-		treemap.data(treemapData);
+		treemap.data([treemapData]);
 	},
 
 	/**

--- a/test/assets/util.ts
+++ b/test/assets/util.ts
@@ -44,25 +44,28 @@ function initDom(idValue) {
 /**
  * Generate chart
  * @param {Object} args chart options
+ * @param {boolean} raw Generate with only given options
  * @return {bb} billboard.js instance
  */
-function generate(args) {
+function generate(args, raw = false) {
 	let chart;
 	let inputType = "mouse";
 
 	if (args) {
-		if (!args.bindto) {
-			args.bindto = "#chart";
+		if (!raw) {
+			if (!args.bindto) {
+				args.bindto = "#chart";
+			}
+
+			initDom(args.bindto);
+
+			// when touch param is set, make to be 'touch' input mode
+			if (args.interaction?.inputType?.touch) {
+				inputType = "touch";
+			}
+
+			window.$$TEST$$.convertInputType = inputType;
 		}
-
-		initDom(args.bindto);
-
-		// when touch param is set, make to be 'touch' input mode
-		if (args.interaction?.inputType?.touch) {
-			inputType = "touch";
-		}
-
-		window.$$TEST$$.convertInputType = inputType;
 
 		chart = bb.generate(args);
 	}

--- a/test/shape/treemap-spec.ts
+++ b/test/shape/treemap-spec.ts
@@ -190,6 +190,25 @@ describe("TREEMAP", () => {
 
 			treemap.destroy();
 		});
+
+		it("should generate w/o error", () => {
+			const param = {
+				data: {
+					columns: [
+						["data1", 1300],
+					],
+					type: "treemap"
+				  },
+				  bindto: "#chart25"
+			};
+
+			// generate with only given argument
+			const treemap = util.generate(param, true)
+
+			treemap.destroy();
+
+			expect(true).to.be.ok;
+		});
 	});
 
 	describe("label options", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3777

## Details
<!-- Detailed description of the change/feature -->
when given bindto element doesn't exist, will append node internally, but generating treemap data will throw `parent.ownerDocument` error. Fix waraping treemap data in array.