### PR TITLE
fix(treemap): Fix generation w/non-exist node

### DIFF
--- a/demo/tomorrow.css
+++ b/demo/tomorrow.css
@@ -40,6 +40,12 @@ g > text.bb-title {
   font-weight: bold;
 }
 
+g > text.bb-title {
+  font-size: 1.3em;
+  stroke-width: 2px;
+  font-weight: bold;
+}
+
 @media (min-width: 1200px) {
   .example-grid:has(.chart_area div) {
     display: grid;

--- a/src/ChartInternal/shape/treemap.ts
+++ b/src/ChartInternal/shape/treemap.ts
@@ -63,6 +63,24 @@ function convertDataToTreemapData(data: IData[]): ITreemapData[] {
 	});
 }
 
+/**
+ * Get hierarchy data
+ * @param {object} data Data object
+ * @returns {Array} Array of hierarchy data
+ * @private
+ */
+function getHierachyData(data) {
+	const $$ = this;
+	const hierarchyData = d3Hierarchy(data).sum(d => d.value);
+	const sortFn = $$.getSortCompareFn(true);
+
+	return [
+		$$.treemap(
+			sortFn ? hierarchyData.sort(sortFn) : hierarchyData
+		)
+	];
+}
+
 export default {
 	initTreemap(): void {
 		const $$ = this;
@@ -79,15 +97,6 @@ export default {
 
 		$$.treemap = d3Treemap()
 			.tile($$.getTreemapTile());
-
-		$$.treemapFn = data => {
-			const hierarchyData = d3Hierarchy(data).sum(d => d.value);
-			const sortFn = $$.getSortCompareFn(true);
-
-			return $$.treemap(
-				sortFn ? hierarchyData.sort(sortFn) : hierarchyData
-			);
-		};
 
 		$el.defs
 			.append("clipPath")
@@ -198,10 +207,10 @@ export default {
 	updateTargetsForTreemap(targets: IData): void {
 		const $$ = this;
 		const {$el: {treemap}} = $$;
-		const treemapData = $$.treemapFn($$.getTreemapData(targets ?? $$.data.targets));
+		const treemapData = getHierachyData.call($$, $$.getTreemapData(targets ?? $$.data.targets));
 
 		// using $el.treemap reference can alter data, so select treemap <g> again
-		treemap.data([treemapData]);
+		treemap.data(treemapData);
 	},
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3777

## Details
<!-- Detailed description of the change/feature -->
when given bindto element doesn't exist, will append node internally, but generating treemap data will throw parent.ownerDocument error. Fix wraping treemap data in array.