### PR TITLE
fix(zoom): Remove unused wheel listener

### DIFF
--- a/src/ChartInternal/interactions/zoom.ts
+++ b/src/ChartInternal/interactions/zoom.ts
@@ -332,10 +332,6 @@ export default {
 		const {config, $el: {eventRect}} = $$;
 		const behaviour = config.zoom_type === "drag" ? $$.zoomBehaviour : $$.zoom;
 
-		// Since Chrome 89, wheel zoom not works properly
-		// Applying the workaround: https://github.com/d3/d3-zoom/issues/231#issuecomment-802305692
-		$$.$el.svg.on("wheel", () => {});
-
 		eventRect?.call(behaviour)
 			.on("dblclick.zoom", null);
 	},

--- a/src/module/util.ts
+++ b/src/module/util.ts
@@ -835,7 +835,8 @@ function convertInputType(mouse: boolean, touch: boolean): "mouse" | "touch" | n
 	// Check if agent has mouse using any-hover, touch devices (e.g iPad) with external mouse will return true as long as mouse is connected
 	// https://css-tricks.com/interaction-media-features-and-their-potential-for-incorrect-assumptions/#aa-testing-the-capabilities-of-all-inputs
 	// Demo: https://patrickhlauke.github.io/touch/pointer-hover-any-pointer-any-hover/
-	const hasMouse = mouse && (matchMedia?.("any-hover:hover").matches || matchMedia?.("any-pointer:fine").matches);
+	const hasMouse = mouse &&
+		(matchMedia?.("any-hover:hover").matches || matchMedia?.("any-pointer:fine").matches);
 
 	// fallback to 'mouse' if no input type is detected.
 	return (hasMouse && "mouse") || (hasTouch && "touch") || "mouse";


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3791

## Details
<!-- Detailed description of the change/feature -->
- Remove unused mouse wheel event bind, where added as part of workaound for chrome
- Apply code format