### PR TITLE
Missing tick.text.inner type added for xAxis

### DIFF
--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -326,6 +326,14 @@ export interface XTickConfiguration {
 		 * Show or hide tick text
 		 */
 		show?: boolean;
+
+		/**
+		 * Set the first/last axis tick text to be positioned inside the chart on non-rotated axis.
+		 */
+		inner?: boolean | {
+			first? : boolean;
+			last?: boolean;
+		};
 	};
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
<!-- Detailed description of the change/feature -->

`inner` type was missing from `tick.text.inner` which was causing a TS error when used.