### PR TITLE
feat(bar): Enhance bar width to adjust from callback

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -5157,24 +5157,49 @@ d3.select(".chart_area")
 				}
 			},
 		],
-		BarWidth: {
-			options: {
-				data: {
-					columns: [
-						["data1", 30, 200, 100, 400, 150, 250],
-						["data2", 130, 100, 140, 200, 150, 50],
-						["data3", 130, 100, 140, 200, 150, 50]
-					],
-					type: "bar"
-				},
-				bar: {
-					width: {
-						ratio: 0.9,
-						max: 30
+		BarWidth: [
+			{
+				options: {
+					title: {
+						text: "set width in ratio with max limit"
+					},
+					data: {
+						columns: [
+							["data1", 30, 200, 100, 400, 150, 250],
+							["data2", 130, 100, 140, 200, 150, 50],
+							["data3", 130, 100, 140, 200, 150, 50]
+						],
+						type: "bar"
+					},
+					bar: {
+						width: {
+							ratio: 0.9,
+							max: 30
+						}
+					}
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "set width in callback"
+					},
+					data: {
+						columns: [
+							["data1", 30, 200, 100, 400, 150, 250],
+							["data2", 130, 100, 140, 200, 150, 50],
+							["data3", 130, 100, 140, 200, 150, 50]
+						],
+						type: "bar"
+					},
+					bar: {
+						width: function(width, targetsNum, maxDataCount) {
+						return width / (targetsNum * maxDataCount);
+						}
 					}
 				}
 			}
-		},
+		],
 		BarWidthVariant: {
 			options: {
 				data: {

--- a/src/ChartInternal/shape/shape.ts
+++ b/src/ChartInternal/shape/shape.ts
@@ -30,6 +30,7 @@ import {
 	getPointer,
 	getRectSegList,
 	getUnique,
+	isFunction,
 	isNumber,
 	isObjectType,
 	isUndefined,
@@ -441,7 +442,7 @@ export default {
 
 	getBarW(type, axis, targetsNum: number): number | IOffset {
 		const $$ = this;
-		const {config, org, scale} = $$;
+		const {config, org, scale, state} = $$;
 		const maxDataCount = $$.getMaxDataCount();
 		const isGrouped = type === "bar" && config.data_groups?.length;
 		const configName = `${type}_width`;
@@ -467,9 +468,11 @@ export default {
 			const width = id ? config[configName][id] : config[configName];
 			const ratio = id ? width.ratio : config[`${configName}_ratio`];
 			const max = id ? width.max : config[`${configName}_max`];
-			const w = isNumber(width) ?
-				width :
-				(targetsNum ? (tickInterval * ratio) / targetsNum : 0);
+			const w = isNumber(width) ? width : (
+				isFunction(width) ?
+					width.call($$, state.width, targetsNum, maxDataCount) :
+					(targetsNum ? (tickInterval * ratio) / targetsNum : 0)
+			);
 
 			return max && w > max ? max : w;
 		};

--- a/src/config/Options/shape/bar.ts
+++ b/src/config/Options/shape/bar.ts
@@ -26,7 +26,7 @@ export default {
 	 * @property {number} [bar.radius] Set the radius of bar edge in pixel.
 	 * @property {number} [bar.radius.ratio] Set the radius ratio of bar edge in relative the bar's width.
 	 * @property {number} [bar.sensitivity=2] The senstivity offset value for interaction boundary.
-	 * @property {number} [bar.width] Change the width of bar chart.
+	 * @property {number|Function|object} [bar.width] Change the width of bar chart.
 	 * @property {number} [bar.width.ratio=0.6] Change the width of bar chart by ratio.
 	 * - **NOTE:** Criteria for ratio.
 	 *   - When x ticks count is same with the data count, the baseline for ratio is the minimum interval value of x ticks.
@@ -106,7 +106,15 @@ export default {
 	 *
 	 *      width: 10,
 	 *
-	 *      // or
+	 *      // or specify width callback. The callback will receive width, targetsNum, maxDataCount as arguments.
+	 *      // - width: chart area width
+	 *      // - targetsNum: number of targets
+	 *      // - maxDataCount: maximum data count among targets
+	 *      width: function(width, targetsNum, maxDataCount) {
+	 *            return width / (targetsNum * maxDataCount);
+	 *      }
+	 *
+	 *      // or specify ratio & max
 	 *      width: {
 	 *          ratio: 0.2,
 	 *          max: 20
@@ -137,7 +145,10 @@ export default {
 	bar_radius: <number | {ratio: number} | undefined>undefined,
 	bar_radius_ratio: <number | undefined>undefined,
 	bar_sensitivity: 2,
-	bar_width: <number | {ratio?: number, max?: number} | undefined>undefined,
+	bar_width: <number | ((width: number, targetsNum: number, maxDataCount: number) => number) | {
+		ratio?: number,
+		max?: number
+	} | undefined>undefined,
 	bar_width_ratio: 0.6,
 	bar_width_max: undefined,
 	bar_zerobased: true

--- a/test/shape/bar-spec.ts
+++ b/test/shape/bar-spec.ts
@@ -806,6 +806,45 @@ describe("SHAPE BAR", () => {
 			expect(bars.previousSibling.classList.contains($LINE.chartLines)).to.be.true;
 			expect(bars.nextSibling.classList.contains($EVENT.eventRects)).to.be.true;
 		});
+
+		it("set options", () => {
+			args = {
+				data: {
+					columns: [ 
+						["data1", 30, 200, 100],
+						["data2", 130, 100, 140]
+					],
+					type: "bar"
+				},
+				bar: {
+					width: function(width, targetsNum, maxDataCount) {
+						return width / (targetsNum * maxDataCount)
+					}
+				}
+			}
+		});
+
+		it("should bar width size adjust from width callback", () => {
+			const getTargetWidth = () => {
+				const chartWidth = chart.internal.state.width;
+				const data = chart.data();
+				const targetsNum = data.length;
+				const maxDataCount = data[0].values.length;
+				
+				return args.bar.width(chartWidth, targetsNum, maxDataCount);
+			}
+
+			chart.$.bar.bars.each(function() {
+				expect(this.getBoundingClientRect().width).to.be.closeTo(getTargetWidth(), 1);
+			});
+
+			// when
+			chart.resize({width: 500});
+
+			chart.$.bar.bars.each(function() {
+				expect(this.getBoundingClientRect().width).to.be.closeTo(getTargetWidth(), 1);
+			});
+		});
 	});
 
 	describe("bar indices", () => {

--- a/types/options.shape.d.ts
+++ b/types/options.shape.d.ts
@@ -217,7 +217,16 @@ export interface BarOptions {
 	/**
 	 * Change the width of bar chart. If ratio is specified, change the width of bar chart by ratio.
 	 */
-	width?: number | {
+	width?: number | (
+		/**
+		 * Specify width callback
+		 * The callback will receive width, targetsNum, maxDataCount as arguments.
+	 	 * - width: chart area width
+	 	 * - targetsNum: number of targets
+	 	 * - maxDataCount: maximum data count among targets
+		 */
+		(width: number, targetsNum: number, maxDataCount: number) => number
+	) | {
 		/**
 		 * Set the width of each bar by ratio
 		 */


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3820

## Details
<!-- Detailed description of the change/feature -->
Implement bar.width to accept function where can adjust bar's width

```js
// or specify width callback. The callback will receive width, targetsNum, maxDataCount as arguments.
// - width: chart area width
// - targetsNum: number of targets
// - maxDataCount: maximum data count among targets
width: function(width, targetsNum, maxDataCount) {
      return width / (targetsNum * maxDataCount);
}
```