### PR TITLE
fix(regions): Mitigate broken dashed lines rendering

### DIFF
--- a/src/ChartInternal/internals/scale.ts
+++ b/src/ChartInternal/internals/scale.ts
@@ -99,7 +99,15 @@ export default {
 		const $$ = this;
 		const offset = offsetValue || (() => $$.axis.x.tickOffset());
 		const isInverted = $$.config.axis_x_inverted;
-		const scale = function(d, raw) {
+
+		/**
+		 * Get scaled value
+		 * @param {object} d Data object
+		 * @param {boolean} raw Get the raw value
+		 * @returns {number}
+		 * @private
+		 */
+		const scale = function(d: IDataRow, raw?: boolean): number {
 			const v = scaleValue(d) + offset();
 
 			return raw ? v : Math.ceil(v);

--- a/src/config/Options/shape/bar.ts
+++ b/src/config/Options/shape/bar.ts
@@ -37,7 +37,7 @@ export default {
 	 * @property {number} [bar.width.max] The maximum width value for ratio.
 	 * @property {number} [bar.width.dataname] Change the width of bar for indicated dataset only.
 	 * @property {number} [bar.width.dataname.ratio=0.6] Change the width of bar chart by ratio.
-	 *  - **NOTE:** 
+	 *  - **NOTE:**
 	 *   - Works only for non-stacked bar
 	 * @property {number} [bar.width.dataname.max] The maximum width value for ratio.
 	 * @property {boolean} [bar.zerobased=true] Set if min or max value will be 0 on bar chart.

--- a/test/internals/rergions-spec.ts
+++ b/test/internals/rergions-spec.ts
@@ -180,7 +180,7 @@ describe("REGIONS", function() {
 		});
 	});
 
-	describe("regions", () => {
+	describe("regions with dasharray", () => {
 		before(() => {
 			args = {
 				data: {
@@ -214,6 +214,95 @@ describe("REGIONS", function() {
 			const lCnt = chart.$.line.lines.attr("d").split("L").length;
 
 			expect(lCnt).to.be.above(30);
+		});
+
+		it("set options", () => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400 , 150, 250, 30]
+					],
+					type: "line",
+					regions: {
+						data1: [
+							{
+								start: 1,
+								end: 2,
+								style: {
+									dasharray: "5 3"
+								}
+							},
+							{
+								start: 3,
+								end: 4,
+								style: {
+									dasharray: "10 5"
+								}
+							}
+						]
+					}
+				},
+				axis: {
+					y: {
+						show: false
+					}
+				},
+				point: {
+					show: false
+				}
+			};
+		});
+
+		it("shouldn't have any overflowed dashed lines.", () => {
+			const path = chart.$.line.lines.attr("d").split("M").map(v => {
+				return v && v.split("L").map(v2 => +v2.replace(/,.*/,""))
+			}).filter(Boolean);
+
+			const hasOverflow = path.some((v, i, arr) => {
+				if (v.length > 2) {
+					return arr[i - 1][1] > v[0];
+				}
+
+				return false;
+			});
+
+			expect(hasOverflow).to.be.false;
+		});
+
+		it("set options", () => {
+			args.axis.rotated = true;
+			args.data.regions.data1 = [
+				{
+					start: 1,
+					end: 2,
+					style: {
+						dasharray: "10 2"
+					}
+				},
+				{
+					start: 3,
+					end: 4,
+					style: {
+						dasharray: "9 2"
+					}
+				}
+			];
+		});
+
+		it("shouldn't have any overflowed dashed lines on rotated axis.", () => {
+			const path = chart.$.line.lines.attr("d").split("M").map(v => {
+				return v && v.split("L").map(v2 => +v2.replace(/,.*/,""))
+			}).filter(Boolean);
+
+			const hasOverflow = path.some((v, i, arr) => {
+				if (v.length > 2) {
+					return v[0] > arr[i-1][1];
+				}
+
+				return false;
+			});
+
+			expect(hasOverflow).to.be.false;
 		});
 	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3790

## Details
<!-- Detailed description of the change/feature -->
Prevent dashed lines coordinates to overflow

Before | After the fix
:---: | :---:
<img width="641" alt="image" src="https://github.com/naver/billboard.js/assets/2178435/275fb321-5725-40de-b7c3-1973a567085a"> | <img width="643" alt="image" src="https://github.com/naver/billboard.js/assets/2178435/d893b73c-8d92-47de-842c-945067d6b4b9">


```js
// generation option used for screenshot example
bb.generate({
	size: {
		width: 640,
		height: 480
	},
	data: {
    	columns: [
	    ["data1", 30, 200, 100, 400 , 150, 250, 30]
        ],
        type: "line",
        regions: {
	        data1: [
		  {
			  start: 1,
			  end: 2,
			  style: {
				  dasharray: "5 3"
			  }
		  },
		  {
			  start: 3,
			  end: 4,
			  style: {
				  dasharray: "10 5"
			  }
		  }
	        ]
        }
    },
	axis: {
		y: {
			show: false
		}
	},
	point: {
		show: false
	},
	zoom: {
		enabled: true
	}
});
```
