### PR TITLE
feat(regions): Enhance regions rendering

### DIFF
--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -684,9 +684,20 @@ export default {
 	},
 
 	/**
+	 * Determine if has null value
+	 * @param {Array} targets Data array to be evaluated
+	 * @returns {boolean}
+	 * @private
+	 */
+	hasNullDataValue(targets: IDataRow[]): boolean {
+		return targets.some(({value}) => value === null);
+	},
+
+	/**
 	 * Get data index from the event coodinates
 	 * @param {Event} event Event object
 	 * @returns {number}
+	 * @private
 	 */
 	getDataIndexFromEvent(event): number {
 		const $$ = this;

--- a/src/ChartInternal/internals/scale.ts
+++ b/src/ChartInternal/internals/scale.ts
@@ -15,12 +15,12 @@ import type {IDataRow, IGridData} from "../data/IData";
 /**
  * Get scale
  * @param {string} [type='linear'] Scale type
- * @param {number} [min] Min range
- * @param {number} [max] Max range
+ * @param {number|Date} [min] Min range
+ * @param {number|Date} [max] Max range
  * @returns {d3.scaleLinear|d3.scaleTime} scale
  * @private
  */
-export function getScale(type = "linear", min = 0, max = 1): any {
+export function getScale(type = "linear", min, max): any {
 	const scale = ({
 		linear: d3ScaleLinear,
 		log: d3ScaleSymlog,
@@ -32,7 +32,7 @@ export function getScale(type = "linear", min = 0, max = 1): any {
 	scale.type = type;
 	/_?log/.test(type) && scale.clamp(true);
 
-	return scale.range([min, max]);
+	return scale.range([min ?? 0, max ?? 1]);
 }
 
 export default {

--- a/src/ChartInternal/shape/line.ts
+++ b/src/ChartInternal/shape/line.ts
@@ -13,7 +13,71 @@ import {
 	isValue,
 	parseDate
 } from "../../module/util";
+import type {IDataRow} from "../data/IData";
 import {getScale} from "../internals/scale";
+
+/**
+ * Get stroke dasharray style value
+ * @param {number} start Start position in path length
+ * @param {number} end End position in path length
+ * @param {Array} pattern Dash array pattern
+ * @param {boolean} isLastX Weather is last x tick
+ * @returns {object} Stroke dasharray style value and its length
+ * @private
+ */
+function getStrokeDashArray(start: number, end: number, pattern: [number, number],
+	isLastX = false): {dash: string, length: number} {
+	const dash = start ? [start, 0] : pattern;
+
+	for (let i = start ? start : pattern.reduce((a, c) => a + c); i <= end;) {
+		pattern.forEach(v => {
+			if (i + v <= end) {
+				dash.push(v);
+			}
+
+			i += v;
+		});
+	}
+
+	// make sure to have even length
+	dash.length % 2 !== 0 && dash.push(isLastX ? pattern[1] : 0);
+
+	return {
+		dash: dash.join(" "),
+		length: dash.reduce((a, b) => a + b, 0)
+	};
+}
+
+/**
+ * Get regions data
+ * @param {Array} d Data object
+ * @param {object} _regions regions to be set
+ * @param {boolean} isTimeSeries whether is time series
+ * @returns {object} Regions data
+ * @private
+ */
+function getRegions(d, _regions, isTimeSeries) {
+	const $$ = this;
+	const regions: {start: number | string, end: number | string, style: string}[] = [];
+	const dasharray = "2 2"; // default value
+
+	// Check start/end of regions
+	if (isDefined(_regions)) {
+		const getValue = (v: Date | any, def: number | Date): Date | any => (
+			isUndefined(v) ? def : (isTimeSeries ? parseDate.call($$, v) : v)
+		);
+
+		for (let i = 0, reg; (reg = _regions[i]); i++) {
+			const start = getValue(reg.start, d[0].x);
+			const end = getValue(reg.end, d[d.length - 1].x);
+			const style = reg.style || {dasharray};
+
+			regions[i] = {start, end, style};
+		}
+	}
+
+	return regions;
+}
 
 export default {
 	initLine(): void {
@@ -211,33 +275,30 @@ export default {
 		};
 	},
 
-	lineWithRegions(d, x, y, _regions): string {
+	/**
+	 * Set regions dasharray and get path
+	 * @param {Array} d Data object
+	 * @param {Function} x x scale function
+	 * @param {Function} y y scale function
+	 * @param {object} _regions regions to be set
+	 * @returns {stirng} Path string
+	 * @private
+	 */
+	lineWithRegions(d: IDataRow[], x, y, _regions): string {
 		const $$ = this;
 		const {config} = $$;
 		const isRotated = config.axis_rotated;
 		const isTimeSeries = $$.axis.isTimeSeries();
-		const regions: any[] = [];
 		const dasharray = "2 2"; // default value
+		const regions = getRegions.bind($$)(d, _regions, isTimeSeries);
+
+		// when contains null data, can't apply style dashed
+		const hasNullDataValue = $$.hasNullDataValue(d);
 
 		let xp;
 		let yp;
 		let diff;
 		let diffx2;
-
-		// Check start/end of regions
-		if (isDefined(_regions)) {
-			const getValue = (v: Date | any, def: number): Date | any => (
-				isUndefined(v) ? def : (isTimeSeries ? parseDate.call($$, v) : v)
-			);
-
-			for (let i = 0, reg; (reg = _regions[i]); i++) {
-				const start = getValue(reg.start, d[0].x);
-				const end = getValue(reg.end, d[d.length - 1].x);
-				const style = reg.style || {dasharray};
-
-				regions[i] = {start, end, style};
-			}
-		}
 
 		// Set scales
 		const xValue = isRotated ? dt => y(dt.value) : dt => x(dt.x);
@@ -279,15 +340,12 @@ export default {
 					yDiff = y0;
 				}
 
-				const points = isRotated ?
-					[
-						[yValue, xValue],
-						[yDiff, xDiff]
-					] :
-					[
-						[xValue, yValue],
-						[xDiff, yDiff]
-					];
+				const points = [
+					[xValue, yValue],
+					[xDiff, yDiff]
+				];
+
+				isRotated && points.forEach(v => v.reverse());
 
 				return generateM(points);
 			};
@@ -295,6 +353,16 @@ export default {
 		// Generate
 		const axisType = {x: $$.axis.getAxisType("x"), y: $$.axis.getAxisType("y")};
 		let path = "";
+
+		// clone the line path to be used to get length value
+		const target = $$.$el.line.filter(({id}) => id === d[0].id);
+		const tempNode = target.clone().style("display", "none");
+		const getLength = (node, path) => node.attr("d", path).node().getTotalLength();
+		const dashArray = {
+			dash: <string[]>[],
+			lastLength: 0
+		};
+		let isLastX = false;
 
 		for (let i = 0, data; (data = d[i]); i++) {
 			const prevData = d[i - 1];
@@ -316,22 +384,67 @@ export default {
 				xp = getScale(axisType.x, prevData.x, data.x);
 				yp = getScale(axisType.y, prevData.value, data.value);
 
-				const dx = x(data.x) - x(prevData.x);
-				const dy = y(data.value) - y(prevData.value);
-				const dd = Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2));
+				// when it contains null data, dash can't be applied with style
+				if (hasNullDataValue) {
+					const dx = x(data.x) - x(prevData.x);
+					const dy = y(data.value) - y(prevData.value);
+					const dd = Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2));
 
-				diff = style[0] / dd; // dash
-				diffx2 = diff * style[1]; // gap
+					diff = style[0] / dd; // dash
+					diffx2 = diff * style[1]; // gap
 
-				for (let j = diff; j <= 1; j += diffx2) {
-					path += sWithRegion(prevData, data, j, diff);
+					for (let j = diff; j <= 1; j += diffx2) {
+						path += sWithRegion(prevData, data, j, diff);
 
-					// to make sure correct line drawing
-					if (j + diffx2 >= 1) {
-						path += sWithRegion(prevData, data, 1, 0);
+						// to make sure correct line drawing
+						if (j + diffx2 >= 1) {
+							path += sWithRegion(prevData, data, 1, 0);
+						}
 					}
+				} else {
+					let points = <number[][]>[];
+					isLastX = data.x === d[d.length - 1].x;
+
+					if (isTimeSeries) {
+						const x0 = +prevData.x;
+						const xv0 = new Date(x0);
+						const xv1 = new Date(x0 + (+data.x - x0));
+
+						points = [
+							[x(xv0), y(yp(0))], // M
+							[x(xv1), y(yp(1))] // L
+						];
+					} else {
+						points = [
+							[x(xp(0)), y(yp(0))], // M
+							[x(xp(1)), y(yp(1))] // L
+						];
+					}
+
+					isRotated && points.forEach(v => v.reverse());
+
+					const startLength = getLength(tempNode, path);
+					const endLength = getLength(tempNode, path += `L${points[1].join(",")}`);
+
+					const strokeDashArray = getStrokeDashArray(
+						startLength - dashArray.lastLength,
+						endLength - dashArray.lastLength,
+						style,
+						isLastX
+					);
+
+					dashArray.lastLength += strokeDashArray.length;
+					dashArray.dash.push(strokeDashArray.dash);
 				}
 			}
+		}
+
+		if (dashArray.dash.length) {
+			// if not last x tick, then should draw rest of path that is not drawed yet
+			!isLastX && dashArray.dash.push(getLength(tempNode, path));
+
+			tempNode.remove();
+			target.attr("stroke-dasharray", dashArray.dash.join(" "));
 		}
 
 		return path;

--- a/src/config/Options/data/axis.ts
+++ b/src/config/Options/data/axis.ts
@@ -108,8 +108,12 @@ export default {
 	 * - The object type should be as:
 	 *   - start {number}: Start data point number. If not set, the start will be the first data point.
 	 *   - [end] {number}: End data point number. If not set, the end will be the last data point.
-	 *   - [style.dasharray="2 2"] {object}: The first number specifies a distance for the filled area, and the second a distance for the unfilled area.
-	 * - **NOTE:** Currently this option supports only line chart and dashed style. If this option specified, the line will be dashed only in the regions.
+	 *   - [style.dasharray="2 2"] {string}: The first number specifies a distance for the filled area, and the second a distance for the unfilled area.
+	 * - **NOTE:**
+	 *   - Supports only line type.
+	 *   - `start` and `end` values should be in the exact x value range.
+	 *   - Dashes will be applied using `stroke-dasharray` css property when data doesn't contain nullish value(or nullish value with `line.connectNull=true` set).
+	 *   - Dashes will be applied via path command when data contains nullish value.
 	 * @name data․regions
 	 * @memberof Options
 	 * @type {object}

--- a/test/internals/rergions-spec.ts
+++ b/test/internals/rergions-spec.ts
@@ -186,8 +186,8 @@ describe("REGIONS", function() {
 				data: {
 					x: "x",
 					columns: [
-						["x", "2023-08-25", "2023-08-26", "2023-08-27"],
-						["data1", 50, 20, 10]
+						["x", "2023-08-25", "2023-08-26", "2023-08-27", "2023-08-28", "2023-08-29"],
+						["data1", 50, 20, 10, null, 20, 30]
 					],
 					regions: {
 						data1: [{
@@ -213,14 +213,14 @@ describe("REGIONS", function() {
 		it("should regions applied for timeseries chart.", () => {
 			const lCnt = chart.$.line.lines.attr("d").split("L").length;
 
-			expect(lCnt).to.be.above(30);
+			expect(lCnt).to.be.above(19);
 		});
 
 		it("set options", () => {
 			args = {
 				data: {
 					columns: [
-						["data1", 30, 200, 100, 400 , 150, 250, 30]
+						["data1", null, 200, 100, 152, 150, 250, 30]
 					],
 					type: "line",
 					regions: {


### PR DESCRIPTION

Ref 

## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3830 #3790

## Details
<!-- Detailed description of the change/feature -->
Improve dashed line rendering using css instead path command. Will render same way for nullish value.

Multiple path command | Single path command
:---: | :---:
<img src=https://github.com/user-attachments/assets/89642088-e3d3-43ea-be71-cbcc7a3aa63f height=300> | <img src=https://github.com/user-attachments/assets/25ee9d78-f19a-4f63-a993-da27d22a6ad0 height=300>

```sh
## Multiple path command
M5,232.59188034188037L95,136.3311965811966M99.1850983903491,139.55194620927864L104.28196148658054,142.77269583736071M109.37882458281199,145.99344546544276L114.47568767904343,149.21419509352484M119.57255077527489,152.4349447216069L124.66941387150631,155.65569434968896M129.76627696773778,158.87644397777103L134.8631400639692,162.0971936058531M139.96000316020064,165.31794323393515L145.0568662564321,168.53869286201723M150.15372935266356,171.75944249009927L155.250592448895,174.98019211818138M160.34745554512645,178.20094174626342L165.44431864135788,181.4216913743455M170.5411817375893,184.64244100242755L175.63804483382077,187.86319063050962M180.73490793005217,191.0839402585917L185.83177102628363,194.30468988667374M183.69607843137257,192.9551282051282L183.69607843137257,192.9551282051282L274,23.083333333333343M274.3757024302515,24.776501143752657L275.44748329187564,26.469668954172M277.5910450151239,29.85600457501063L278.66282587674795,31.549172385429976M280.8063875999962,34.935508006268634L281.8781684616203,36.628675816687924M284.0217301848685,40.01501143752664L285.0935110464926,41.70817924794595M287.2370727697408,45.094514868784586L288.30885363136485,46.787682679203954M290.4524153546131,50.17401830004259L291.52419621623727,51.86718611046193M293.66775793948545,55.253521731300594L294.7395388011096,56.94668954171988M296.88310052435776,60.33302516255856L297.9548813859818,62.02619297297788M300.09844310923006,65.41252859381653L301.1702239708542,67.10569640423589M303.3137856941024,70.49203202507452L304.3855665557265,72.18519983549385M306.52912827897467,75.57153545633248L307.6009091405988,77.2647032667518M309.74447086384697,80.65103888759049L310.8162517254711,82.34420669800981M312.9598134487193,85.73054231884846L314.0315943103434,87.4237101292678M316.17515603359163,90.81004575010644L317.24693689521575,92.50321356052578M319.39049861846394,95.88954918136443L320.462279480088,97.58271699178376M322.60584120333624,100.96905261262242L323.67762206496036,102.66222042304173M325.82118378820854,106.04855604388037L326.8929646498326,107.74172385429969M329.03652637308085,111.12805947513836L330.10830723470497,112.82122728555771M332.25186895795315,116.20756290639633L333.32364981957727,117.90073071681566M335.46721154282545,121.28706633765431L336.5389924044496,122.98023414807365M338.68255412769776,126.36656976891229L339.7543349893219,128.05973757933162M341.8978967125701,131.44607320017028L342.96967757419424,133.1392410105896M345.1132392974424,136.52557663142824L346.1850201590665,138.21874444184758M348.32858188231467,141.60508006268623L349.4003627439388,143.29824787310557M351.543924467187,146.6845834939442L352.6157053288111,148.3777513043635M354.75926705205933,151.76408692520218L355.83104791368345,153.4572547356215M357.9746096369316,156.8435903564601L359.04639049855575,158.53675816687948M361.18995222180394,161.92309378771813L362.26173308342806,163.61626159813744M362.9117647058824,164.6431623931624L362.9117647058824,164.6431623931624M364.59721655730294,163.57811153322723L366.28266840872357,162.51306067329205M369.6535721115648,160.38295895342168L371.33902396298544,159.3179080934865M374.7099276658266,157.18780637361616L376.3953795172473,156.122755513681M379.7662832200885,153.99265379381063L381.45173507150906,152.92760293387545M384.82263877435037,150.7975012140051L386.50809062577093,149.73245035406993M389.8789943286122,147.60234863419956L391.5644461800328,146.53729777426437M394.935349882874,144.407196054394L396.6208017342947,143.34214519445888M399.99170543713586,141.21204347458848L401.67715728855654,140.14699261465333M405.04806099139785,138.01689089478296L406.73351284281836,136.95184003484778M410.10441654565955,134.82173831497744L411.7898683970802,133.75668745504225M415.16077209992136,131.6265857351719L416.84622395134204,130.5615348752367M420.21712765418323,128.43143315536636L421.9025795056039,127.3663822954312M425.2734832084451,125.23628057556083L426.9589350598657,124.17122971562564M430.3298387627069,122.04112799575532L432.0152906141275,120.97607713582012M435.3861943169688,118.8459754159498L437.07164616838935,117.78092455601458M440.44254987123065,115.65082283614423L442.1280017226512,114.58577197620906M445.4989054254925,112.4556702563387L447.18435727691303,111.39061939640354M450.5552609797542,109.26051767653317L452.24071283117496,108.19546681659801M452.5196078431373,108.01923076923076L452.5196078431373,108.01923076923076

## Single path command
M4,232.59188034188037L71,136.3311965811966L139,192.9551282051282L206,23.083333333333343L274,164.6431623931624L341,108.01923076923076
```

## Region with zoom interaction
![0a710ba9-9023-1fb8-8190-e346363f7a0e](https://github.com/user-attachments/assets/ed6aff59-c3f3-4fbb-8059-9e15f30270c0)

## Profile
Before | After
:---: | :---:
<img src=https://github.com/user-attachments/assets/2a0518de-a7a5-4f8e-ad86-1c6bf36a1caf width=500> | <img src=https://github.com/user-attachments/assets/1220c51c-c8d4-4577-8e38-48880aec1f03 width=400>

Task duration:
- 84ms &rarr; 5ms `94%`