### PR TITLE
fix(axis): fix error when showing tick only

### DIFF
--- a/src/ChartInternal/Axis/AxisRendererHelper.ts
+++ b/src/ChartInternal/Axis/AxisRendererHelper.ts
@@ -40,8 +40,9 @@ export default class AxisRendererHelper {
 			w: 5.5,
 			h: 11.5
 		};
+		const text = node?.select("text");
 
-		!node.empty() && node.select("text")
+		!text.empty() && text
 			.text("0")
 			.call(el => {
 				try {

--- a/test/api/export-spec.ts
+++ b/test/api/export-spec.ts
@@ -201,9 +201,9 @@ describe("API export", () => {
 
 			// pattern for local: preserveFontStyle=true
 			[
-				"byuVSgeSACZuGnZIBBJFgAQwUbjZWVoQIAFMi6UoZ1gEhoeHzxORj7",
-				"gEMwIYvjgilxAsgoYFymZLtEoI4ACaBlzpB5Aqh4u1HAwik2LwOTAFo2",
-				"n3KPP7RFhvxMH97ZLyZpsgzMpjX2Qk8O3IUePj1WqYqk0kYkwz"
+				"i2iAoIcLvwVDzzAQUBmuodjmOmu+NeryqrOrq4jsyozKyLzy99vftNVcb343ou",
+				"JXSOKRvoLXeaeBnwyQ3q5TJIDtEMpaehdeQBLArBlL9P1Ni",
+				"iDzpkxgBoCd9qkExwC4O8qSCPVk3lyWshNuFqQAdJNm6rb+GVkH2CdOcenYIgj5Cy"
 			],
 			
 			// pattern for webdriverio

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -2281,6 +2281,45 @@ describe("AXIS", function() {
 				expect(axis.selectAll(".tick line").size()).to.be.equal(0);
 			});
 		});
+
+		it("set options", () => {
+			args = {
+				data: {
+					columns: [
+					  ["data1", 90, 100, 140, 200, 100]
+					],
+					type: "bar",
+				},
+				axis: {
+					x: {
+						tick: {
+							show: false,
+							text: {
+								show: false
+							}
+						}
+					},
+					y: {
+						tick: {
+							show: false,
+							text: {
+								show: false
+							}
+						}
+					}
+				}
+			};
+		});
+
+		it("should show tick without error", () => {
+			expect(
+				chart.config("axis.y.tick.show", true, true)
+			).to.not.throw;
+
+			expect(
+				chart.internal.$el.axis.y.selectAll(".tick").size() > 0
+			).to.be.true;
+		});
 	});
 
 	describe("axis text on 'binary floating point'", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3881

## Details
<!-- Detailed description of the change/feature -->
Do not call .getBBox() for empty node