### PR TITLE
fix(zoom): Prevent error for out of range

### DIFF
--- a/src/ChartInternal/Axis/AxisRendererHelper.ts
+++ b/src/ChartInternal/Axis/AxisRendererHelper.ts
@@ -77,9 +77,11 @@ export default class AxisRendererHelper {
 			value => `translate(0,${value})`;
 
 		return (selection, scale) => {
-			selection.attr("transform", d => (
-				isValue(d) ? fn(Math.ceil(scale(d))) : null
-			));
+			selection.attr("transform", d => {
+				const x = scale(d);
+
+				return isValue(d) ? fn(Math.ceil(x)) : null;
+			});
 		};
 	}
 

--- a/test/api/zoom-spec.ts
+++ b/test/api/zoom-spec.ts
@@ -632,4 +632,81 @@ describe("API zoom", function() {
 			expect($$.scale.zoom).to.be.null;		  	
 		});
 	});
+
+	describe("zoom extent", () => {
+		beforeAll(() => {
+			chart = util.generate({
+				data: {
+					json: [
+						{"date":"2023-09-30 00:00:00","ek_house":0},
+						{"date":"2023-10-14 00:00:00","ek_house":0},
+						{"date":"2023-10-21 00:00:00","ek_house":0},
+						{"date":"2023-10-28 00:00:00","ek_house":0},
+						{"date":"2023-11-04 00:00:00","ek_house":0},
+					],
+					keys: {
+						x: "date",
+						value: ["ek_house"],
+					},
+				},
+				axis: {
+					x: {
+						type: "timeseries",
+						tick: {
+							format: "%Y-%m-%d"
+						},
+					},
+					y: {
+						show: false
+					}
+				},
+				zoom: {
+					enabled: true
+				}
+			});
+		});
+
+		it("shouldn't throw error for timeseries x axis, when is given out of range.", () => new Promise(done => {
+			chart.zoom([1697701666380, 1697702008724]);
+			
+			setTimeout(() => {
+				chart.$.circles.each(function() {
+					expect(this.getAttribute("cx") !== "NaN").to.be.true;
+				});
+
+				done(1);
+			}, 300);
+		}));
+
+		it("shouldn't throw error for indexed x axis, when is given out of range.", () => new Promise(done => {
+			chart = util.generate({
+				data: {
+					columns: [
+						["data2", 130, 100, 140, 200, 150, 50, 120, 100, 80, 90]
+					],
+				},
+				zoom: {
+					enabled: true
+				},
+				axis: {
+					y: {
+						show: false
+					}
+				}
+			});
+
+			chart.zoom([
+				4.908784864317814,
+				4.908812566017803
+			]);
+
+			setTimeout(() => {
+				chart.$.circles.each(function() {
+					expect(this.getAttribute("cx") !== "NaN").to.be.true;
+				});
+
+				done(1);
+			}, 300);
+		}));
+	});
 });

--- a/test/internals/bb-spec.ts
+++ b/test/internals/bb-spec.ts
@@ -536,7 +536,7 @@ describe("Interface & initialization", () => {
 		}));
 
 		it("check lazy rendering on callbacks", () => new Promise(done => {
-			const el = <HTMLDivElement>document.body.querySelector("#chart");
+			const el = document.body.querySelector("#chart") as HTMLDivElement;
 
 			// hide to lazy render
 			el.style.display = "none";


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3895

## Details
<!-- Detailed description of the change/feature -->
- When given zoom-in range isn't handled, do not perform next steps
- Initialize drag zoom related event binding when only 'drag' type is specified