### PR TITLE
feat(axis): Intent to ship axis' tick.culling.reverse

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2027,28 +2027,81 @@ var demos = {
 				}
 			}
 		},
-		XAxisTickCulling: {
-			options: {
-				data: {
-					columns: [
-						["sample", 30, 200, 100, 400, 150, 250, 30, 200, 100, 400, 150, 250, 30, 200, 100, 400, 150, 250, 200, 100, 400, 150, 250]
-					],
-					type: "line"
-				},
-				axis: {
-					x: {
-						type: "category",
-						tick: {
-							culling: {
-								max: 4 // the number of tick texts will be adjusted to less than this value
+		XAxisTickCulling: [
+			{
+				options: {
+					data: {
+						columns: [
+							["sample", 30, 200, 100, 400, 150, 250, 30, 200, 100, 400, 150, 250, 30, 200, 100, 400, 150, 250, 200, 100, 400, 150, 250]
+						],
+						type: "line"
+					},
+					axis: {
+						x: {
+							type: "category",
+							tick: {
+								culling: {
+									max: 4 // the number of tick texts will be adjusted to less than this value
+								}
+								// for normal axis, default on
+								// for category axis, default off
 							}
-							// for normal axis, default on
-							// for category axis, default off
+						}
+					}
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "Culling to start from the first tick",
+					},
+					data: {
+						x: 'periods',
+						type: "line",
+						columns: [
+							["periods", '1999', '2000', '2001', '2002', '2003','2004','2005', '2006', '2007', '2008', '2009', '2010', '2011', '2012', '2013', '2014', '2015','2016'],
+							["data1", 0, 70, 200, 100, 170, 150, 350, 320, 200, 100, 170, 150, 250, 30, 200, 100, 170, 390],
+						]
+					},
+					axis: {
+						x: {
+							tick: {
+								outer: false,
+								culling: {
+									max: 6
+								}
+							}
+						}
+					}
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "Culling to start from the last('reversed' way) tick",
+					},
+					data: {
+						x: 'periods',
+						type: "line",
+						columns: [
+							["periods", '1999', '2000', '2001', '2002', '2003','2004','2005', '2006', '2007', '2008', '2009', '2010', '2011', '2012', '2013', '2014', '2015','2016'],
+							["data1", 0, 70, 200, 100, 170, 150, 350, 320, 200, 100, 170, 150, 250, 30, 200, 100, 170, 390],
+						]
+					},
+					axis: {
+						x: {
+							tick: {
+								outer: false,
+								culling: {
+									max: 6,
+									reverse: true
+								}
+							}
 						}
 					}
 				}
 			}
-		},
+		],
 		XAxisTickFitting: {
 			options: {
 				data: {

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -1034,7 +1034,8 @@ class Axis {
 
 			if (axis && toCull) {
 				const tickNodes = axis.selectAll(".tick");
-				const tickValues = sortValue(tickNodes.data());
+				const tickValues = sortValue(tickNodes.data(),
+					!config[`${cullingOptionPrefix}_reverse`]);
 				const tickSize = tickValues.length;
 				const cullingMax = config[`${cullingOptionPrefix}_max`];
 				const lines = config[`${cullingOptionPrefix}_lines`];

--- a/src/config/Options/axis/x.ts
+++ b/src/config/Options/axis/x.ts
@@ -179,7 +179,7 @@ export default {
 	 * axis: {
 	 *   x: {
 	 *     tick: {
-	 *       culling: false
+	 *       culling: false,
 	 *     }
 	 *   }
 	 * }
@@ -223,6 +223,27 @@ export default {
 	 * }
 	 */
 	axis_x_tick_culling_lines: true,
+
+	/**
+	 * Control culling start point to be reversed. If set to true, the culling will be started from the end to start.
+	 * - **NOTE:** This option is only available when `axis.x.tick.culling` is set to truthy value.
+	 * @name axis․x․tick․culling․reverse
+	 * @memberof Options
+	 * @type {boolean}
+	 * @default false
+	 * @see [Demo](https://naver.github.io/billboard.js/demo/#Axis.XAxisTickCulling)
+	 * @example
+	 * axis: {
+	 *   x: {
+	 *     tick: {
+	 *       culling: {
+	 *           reverse: true,
+	 *       }
+	 *     }
+	 *   }
+	 * }
+	 */
+	axis_x_tick_culling_reverse: false,
 
 	/**
 	 * The number of x axis ticks to show.<br><br>

--- a/src/config/Options/axis/y.ts
+++ b/src/config/Options/axis/y.ts
@@ -247,6 +247,26 @@ export default {
 	axis_y_tick_culling_lines: true,
 
 	/**
+	 * Control culling start point to be reversed. If set to true, the culling will be started from the end to start.
+	 * - **NOTE:** This option is only available when `axis.y.tick.culling` is set to truthy value.
+	 * @name axis․y․tick․culling․reverse
+	 * @memberof Options
+	 * @type {boolean}
+	 * @default false
+	 * @example
+	 * axis: {
+	 *   y: {
+	 *     tick: {
+	 *       culling: {
+	 *           reverse: true,
+	 *       }
+	 *     }
+	 *   }
+	 * }
+	 */
+	axis_y_tick_culling_reverse: false,
+
+	/**
 	 * Show y axis outer tick.
 	 * @name axis․y․tick․outer
 	 * @memberof Options

--- a/src/config/Options/axis/y2.ts
+++ b/src/config/Options/axis/y2.ts
@@ -233,6 +233,26 @@ export default {
 	axis_y2_tick_culling_lines: true,
 
 	/**
+	 * Control culling start point to be reversed. If set to true, the culling will be started from the end to start.
+	 * - **NOTE:** This option is only available when `axis.y2.tick.culling` is set to truthy value.
+	 * @name axis․y2․tick․culling․reverse
+	 * @memberof Options
+	 * @type {boolean}
+	 * @default false
+	 * @example
+	 * axis: {
+	 *   y2: {
+	 *     tick: {
+	 *       culling: {
+	 *           reverse: true,
+	 *       }
+	 *     }
+	 *   }
+	 * }
+	 */
+	axis_y2_tick_culling_reverse: false,
+
+	/**
 	 * Show or hide y2 axis outer tick.
 	 * @name axis․y2․tick․outer
 	 * @memberof Options

--- a/src/config/Options/common/main.ts
+++ b/src/config/Options/common/main.ts
@@ -197,7 +197,7 @@ export default {
 	 *  }
 	 */
 	resize_auto: <boolean | "parent" | "viewBox">true,
-	resize_timer: true,
+	resize_timer: false,
 
 	/**
 	 * Set a callback to execute when the chart is clicked.

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -3028,6 +3028,58 @@ describe("AXIS", function() {
 				done(1);
 			});
 		}));
+
+		it("set options", () => {
+			args = {
+				data: {
+					x: 'periods',
+					type: "line",
+					columns: [
+						["periods", '1999', '2000', '2001', '2002', '2003','2004','2005', '2006', '2007', '2008', '2009', '2010', '2011', '2012', '2013', '2014', '2015','2016'],
+						["data1", 0, 70, 200, 100, 170, 150, 350, 320, 200, 100, 170, 150, 250, 30, 200, 100, 170, 390],
+					]
+				},
+				axis: {
+					x: {
+						tick: {
+							outer: false,
+							culling: {
+								max: 6,
+								reverse: true
+							}
+						}
+					}
+				}
+			};
+		});
+
+		it("should reverse the x-axis tick text culling.", () => {
+			const tickText = chart.internal.$el.axis.x
+				.selectAll(".tick text")
+				.filter(function() {
+					return this.style.display !== "none";
+				})
+				.nodes().map(v => v.textContent);
+
+
+			expect(tickText).to.be.deep.equal(['2000', '2004', '2008', '2012', '2016']);
+		});
+
+		it("set options: axis.rotated=true", () => {
+			args.axis.rotated = true;
+		});
+
+		it("should x axis' tick text culling to be reversed on rotated axis.", () => {
+			const tickText = chart.internal.$el.axis.x
+				.selectAll(".tick text")
+				.filter(function() {
+					return this.style.display !== "none";
+				})
+				.nodes().map(v => v.textContent);
+
+
+			expect(tickText).to.be.deep.equal(['2000', '2004', '2008', '2012', '2016']);
+		});
 	});
 	
 	describe("Axes tick padding", () => {

--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -251,6 +251,12 @@ export interface XTickConfiguration {
 		 * Control visibility of tick lines within culling option, along with tick text.
 		 */
 		lines?: boolean;
+
+		/**	
+		 * Control culling start point to be reversed. If set to true, the culling will be started from the end to start.
+	     * - **NOTE:** This option is only available when `axis.x.tick.culling` is set to truthy value.
+		 */
+		reverse?: boolean;
 	};
 
 	/**
@@ -404,6 +410,12 @@ export interface YTickConfiguration {
 		 * Control visibility of tick lines within culling option, along with tick text.
 		 */
 		lines?: boolean;
+
+		/**	
+		 * Control culling start point to be reversed. If set to true, the culling will be started from the end to start.
+	     * - **NOTE:** This option is only available when `axis.x.tick.culling` is set to truthy value.
+		 */
+		reverse?: boolean;
 	};
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3967

## Details
<!-- Detailed description of the change/feature -->
Implement new reverse option where culling to start from the last tick

```js
axis: {
  [x | y | y2]: {
    tick: {
      outer: false,
      culling: {
        max: 6,
        reverse: true
      }
    }
  }
}
```

<img width="563" alt="image" src="https://github.com/user-attachments/assets/9db67cff-e943-4c31-96ce-731b0c974462" />
