### PR TITLE
fix(core): Fix potential security vulnerability

### DIFF
--- a/src/Chart/api/export.ts
+++ b/src/Chart/api/export.ts
@@ -257,7 +257,7 @@ export default {
 		const $$ = this.internal;
 		const {state, $el: {chart, svg}} = $$;
 		const {width, height} = state.current;
-		const opt = mergeObj({
+		const opt = mergeObj(Object.create(null), {
 			width,
 			height,
 			preserveAspectRatio: true,

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,7 +5,7 @@
 import Chart from "./Chart/Chart";
 import {isObject, mergeObj} from "./module/util";
 
-let defaults = {};
+let defaults = Object.create(null);
 
 /**
  * @namespace bb
@@ -92,7 +92,7 @@ const bb = {
 	 * });
 	 */
 	generate(config) {
-		const options = mergeObj({}, defaults, config);
+		const options = mergeObj(Object.create(null), defaults, config);
 		const inst = new Chart(options);
 
 		inst.internal.charts = this.instance;

--- a/src/module/util.ts
+++ b/src/module/util.ts
@@ -620,13 +620,15 @@ function mergeObj(target: object, ...objectN): any {
 
 	if (isObject(target) && isObject(source)) {
 		Object.keys(source).forEach(key => {
-			const value = source[key];
+			if (!/^(__proto__|constructor|prototype)$/i.test(key)) {
+				const value = source[key];
 
-			if (isObject(value)) {
-				!target[key] && (target[key] = {});
-				target[key] = mergeObj(target[key], value);
-			} else {
-				target[key] = isArray(value) ? value.concat() : value;
+				if (isObject(value)) {
+					!target[key] && (target[key] = {});
+					target[key] = mergeObj(target[key], value);
+				} else {
+					target[key] = isArray(value) ? value.concat() : value;
+				}
 			}
 		});
 	}

--- a/test/api/show-spec.ts
+++ b/test/api/show-spec.ts
@@ -130,7 +130,7 @@ describe("API show", () => {
 				expect(+internal.$el.svg.selectAll(`.${$LEGEND.legendItemHidden}`).size()).to.be.equal(1);
 
 				done(1);
-			}, 300);
+			}, 400);
 		}));
 
 		it("Show all data", () => new Promise(done => {

--- a/test/internals/core-spec.ts
+++ b/test/internals/core-spec.ts
@@ -344,4 +344,14 @@ describe("CORE", function() {
 			expect(d3Select(previous).classed($GRID.grid)).to.be.true;
 		});
 	});
+
+	describe("security prevention", () => {
+		it("should not allow pollution of the prototype", () => {
+			const chart = util.generate(JSON.parse(`{"data":{"columns":[["data1",30,200,100,400,150,250],["data2",130,100,140,200,150,50]],"type":"bar"},"bar":{"width":{"ratio":0.5}},"bindto":"#chart","__proto__":{"pollutedKey":"pollutedValue"}}`));
+
+			// @ts-ignore
+			expect(({}.__proto__).pollutedKey).to.be.undefined;
+		});
+	});
+
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3975

## Details
<!-- Detailed description of the change/feature -->
Add prevention for prototype pollution, by enforcing options objects to not extend nor chaining Object.prototype