### PR TITLE
refactor(color): Enhance data.color(s) option to take config value always

### DIFF
--- a/src/ChartInternal/internals/color.ts
+++ b/src/ChartInternal/internals/color.ts
@@ -89,8 +89,6 @@ export default {
 	generateColor(): Function {
 		const $$ = this;
 		const {$el, config} = $$;
-		const colors = config.data_colors;
-		const callback = config.data_color;
 		const ids: string[] = [];
 
 		let pattern = notEmpty(config.color_pattern) ?
@@ -115,6 +113,8 @@ export default {
 		}
 
 		return function(d: IDataRow | IArcData | string): string {
+			const colors = config.data_colors;
+			const callback = config.data_color;
 			const id: string = (d as IDataRow).id ||
 				(d as IArcData).data?.id ||
 				d as string;

--- a/test/api/chart-spec.ts
+++ b/test/api/chart-spec.ts
@@ -258,5 +258,24 @@ describe("API chart", () => {
 		it("should return generation options object.", () => {
 			expect(args).to.be.deep.equal(chart.config());
 		});
+
+		it("should data.color applied", () => new Promise(done => {
+			const color = "rgb(255, 0, 0)";
+
+			chart.config("data.color", function (c, d) {
+			      return {
+					data1: color
+				}[d.id];
+			}, true);
+
+			setTimeout(() => {
+				const {$: {legend, line: {lines}}} = chart;
+
+				expect(legend.select("line").style("stroke")).to.be.equal(color);
+				expect(lines.style("stroke")).to.be.equal(color);
+
+				done(1);
+			}, 350);
+		}));
 	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3984

## Details
<!-- Detailed description of the change/feature -->
Update data.color and data.colors options value to take from the config always. This will make runtime update to be applied at any time.

```js
const chart = bb.generate(args);

// when update `data.color` after the init, the new updated color value will be taken.
chart.config("data.color", function (color, d) {
      return {data: "blue"}[d.id];
}, true);
```