### PR TITLE
fix(axis): adjust tick generation logic for rotated axes

### DIFF
--- a/src/ChartInternal/Axis/AxisRenderer.ts
+++ b/src/ChartInternal/Axis/AxisRenderer.ts
@@ -113,7 +113,8 @@ export default class AxisRenderer {
 
 			if (tickShow.tick || tickShow.text) {
 				// count of tick data in array
-				const ticks = config.tickValues || helper.generateTicks(scale1, isLeftRight);
+				const ticks = config.tickValues ||
+					helper.generateTicks(scale1, isLeftRight || params.config.axis_rotated);
 
 				// set generated ticks
 				ctx.generatedTicks = ticks;

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -286,6 +286,48 @@ describe("AXIS", function() {
 				expect(this.textContent % 1).to.be.equal(0);
 			});
 		});
+
+		it("set options", () => {
+			args = {
+				  data: {
+					columns: [
+						["data1", 3, 10, 11, 12]
+					],
+					type: "bar"
+				},
+				axis: {
+					rotated: true,
+					y: {
+						max: 100,
+						min: 0,
+						tick: {
+							stepSize: 2,
+						}
+					}
+				}
+			};
+		});
+
+		it("should stepSize works on rotated axis.", () => {
+			const {stepSize} = args.axis.y.tick;
+			let {$el: {axis: {y}}} = chart.internal;			
+			let temp;
+
+			y = y.selectAll(".tick tspan");
+
+			expect(y.size()).to.be.equal(61);
+
+			y.each(function() {
+				const value = +this.textContent;
+
+				if (!temp) {
+					temp = value;
+				} else {
+					expect(temp + stepSize).to.be.equal(value);
+					temp = value;
+				}
+			});
+		});
 	});
 
 	describe("axis label #1", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3991

## Details
<!-- Detailed description of the change/feature -->
Make axis rotated state is passed to tick generation method