### PR TITLE
refactor(all): make rect called from single source 

### DIFF
--- a/src/Chart/api/export.ts
+++ b/src/Chart/api/export.ts
@@ -4,7 +4,14 @@
  */
 import {namespaces as d3Namespaces} from "d3-selection";
 import {document, window} from "../../module/browser";
-import {getCssRules, isFunction, mergeObj, toArray} from "../../module/util";
+import {
+	getBBox,
+	getBoundingRect,
+	getCssRules,
+	isFunction,
+	mergeObj,
+	toArray
+} from "../../module/util";
 
 type TExportOption = TSize & {
 	preserveAspectRatio: boolean,
@@ -98,9 +105,9 @@ function nodeToSvgDataUrl(node, option: TExportOption, orgSize: TSize) {
  */
 function getCoords(elem, svgOffset): TSize {
 	const {top, left} = svgOffset;
-	const {x, y} = elem.getBBox();
+	const {x, y} = getBBox(elem, true);
 	const {a, b, c, d, e, f} = elem.getScreenCTM();
-	const {width, height} = elem.getBoundingClientRect();
+	const {width, height} = getBoundingRect(elem, true);
 
 	return {
 		x: (a * x) + (c * y) + e - left,
@@ -117,7 +124,7 @@ function getCoords(elem, svgOffset): TSize {
  * @private
  */
 function getGlyph(svg: SVGElement): TTextGlyph[] {
-	const {left, top} = svg.getBoundingClientRect();
+	const {left, top} = getBoundingRect(svg);
 	const filterFn = t => t.textContent || t.childElementCount;
 	const glyph: TTextGlyph[] = [];
 

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -12,6 +12,7 @@ import type {AxisType} from "../../../types/types";
 import {$AXIS, $COMMON} from "../../config/classes";
 import {
 	capitalize,
+	getBoundingRect,
 	isArray,
 	isEmpty,
 	isFunction,
@@ -699,7 +700,7 @@ class Axis {
 							width: this.textContent.length * sizeFor1Char.w,
 							height: sizeFor1Char.h
 						} :
-						this.getBoundingClientRect();
+						getBoundingRect(this, true);
 
 					max.width = Math.max(max.width, width);
 					max.height = Math.max(max.height, height);

--- a/src/ChartInternal/Axis/AxisRendererHelper.ts
+++ b/src/ChartInternal/Axis/AxisRendererHelper.ts
@@ -4,7 +4,7 @@
  * @ignore
  */
 import type {d3Selection} from "../../../types/types";
-import {isDefined, isNumber, isString, isValue} from "../../module/util";
+import {getBBox, isDefined, isNumber, isString, isValue} from "../../module/util";
 import {getScale} from "../internals/scale";
 
 export default class AxisRendererHelper {
@@ -46,7 +46,7 @@ export default class AxisRendererHelper {
 			.text("0")
 			.call((el: d3Selection) => {
 				try {
-					const {width, height} = el.node().getBBox();
+					const {width, height} = getBBox(el.node(), true);
 
 					if (width && height) {
 						size.w = width;

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -7,6 +7,7 @@ import {$BAR, $CANDLESTICK, $COMMON} from "../../config/classes";
 import {KEY} from "../../module/Cache";
 import {
 	findIndex,
+	getBoundingRect,
 	getScrollPosition,
 	getTransformCTM,
 	getUnique,
@@ -754,7 +755,7 @@ export default {
 		return index;
 	},
 
-	getDataLabelLength(min, max, key) {
+	getDataLabelLength(min: number, max: number, key: string): number[] {
 		const $$ = this;
 		const lengths = [0, 0];
 		const paddingCoef = 1.3;
@@ -765,7 +766,7 @@ export default {
 			.append("text")
 			.text(d => $$.dataLabelFormat(d.id)(d))
 			.each(function(d, i) {
-				lengths[i] = this.getBoundingClientRect()[key] * paddingCoef;
+				lengths[i] = getBoundingRect(this, true)[key] * paddingCoef;
 			})
 			.remove();
 

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -4,7 +4,13 @@
  */
 import type {d3Selection} from "../../../types";
 import {$COMMON, $EVENT, $SHAPE} from "../../config/classes";
-import {getPointer, getScrollPosition, isBoolean, isFunction} from "../../module/util";
+import {
+	getBoundingRect,
+	getPointer,
+	getScrollPosition,
+	isBoolean,
+	isFunction
+} from "../../module/util";
 
 export default {
 	/**
@@ -205,8 +211,7 @@ export default {
 			if (eventReceiver) {
 				const scrollPos = getScrollPosition($el.chart.node());
 
-				eventReceiver.rect = rectElement.node()
-					.getBoundingClientRect()
+				eventReceiver.rect = getBoundingRect(rectElement.node(), true)
 					.toJSON();
 
 				eventReceiver.rect.top += scrollPos.y;

--- a/src/ChartInternal/interactions/interaction.ts
+++ b/src/ChartInternal/interactions/interaction.ts
@@ -8,6 +8,7 @@ import {$ARC, $AXIS, $COMMON, $SHAPE} from "../../config/classes";
 import {KEY} from "../../module/Cache";
 import {
 	emulateEvent,
+	getBoundingRect,
 	getPointer,
 	getTransformCTM,
 	hasViewBox,
@@ -202,7 +203,7 @@ export default {
 		if (element) {
 			const isMultipleX = $$.isMultipleX();
 			const isRotated = config.axis_rotated;
-			let {width, left, top} = element.getBoundingClientRect();
+			let {width, left, top} = getBoundingRect(element);
 
 			if (hasAxis && !hasRadar && !isMultipleX) {
 				const coords = eventReceiver.coords[index];

--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -5,7 +5,15 @@
 import {$AXIS, $SUBCHART} from "../../config/classes";
 import {document} from "../../module/browser";
 import {KEY} from "../../module/Cache";
-import {capitalize, ceil10, isEmpty, isNumber, isString, isUndefined} from "../../module/util";
+import {
+	capitalize,
+	ceil10,
+	getBoundingRect,
+	isEmpty,
+	isNumber,
+	isString,
+	isUndefined
+} from "../../module/util";
 
 export default {
 	/**
@@ -47,7 +55,7 @@ export default {
 
 		while (v < 30 && parent && parent.tagName !== "BODY") {
 			try {
-				v = parent.getBoundingClientRect()[key];
+				v = getBoundingRect(parent, true)[key];
 			} catch {
 				if (offsetName in parent) {
 					// In IE in certain cases getBoundingClientRect
@@ -103,12 +111,15 @@ export default {
 			const label = $el.main.select(`.${leftAxisClass}-label`);
 
 			if (!label.empty()) {
-				labelWidth = label.node().getBoundingClientRect().left;
+				labelWidth = getBoundingRect(label.node()).left;
 			}
 		}
 
-		const svgRect = leftAxis && hasLeftAxisRect ? leftAxis.getBoundingClientRect() : {right: 0};
-		const chartRectLeft = $el.chart.node().getBoundingClientRect().left + labelWidth;
+		const svgRect = leftAxis && hasLeftAxisRect ?
+			getBoundingRect(leftAxis, !withoutRecompute) :
+			{right: 0};
+		const chartRectLeft = getBoundingRect($el.chart.node(), !withoutRecompute).left +
+			labelWidth;
 		const hasArc = $$.hasArcType();
 		const svgLeft = svgRect.right - chartRectLeft -
 			(hasArc ? 0 : $$.getCurrentPaddingByDirection("left", withoutRecompute));

--- a/src/ChartInternal/internals/tooltip.ts
+++ b/src/ChartInternal/internals/tooltip.ts
@@ -7,6 +7,7 @@ import {$ARC, $TOOLTIP} from "../../config/classes";
 import {document} from "../../module/browser";
 import {
 	callFn,
+	getBoundingRect,
 	getPointer,
 	getTransformCTM,
 	hasViewBox,
@@ -387,7 +388,7 @@ export default {
 
 		// currPos value based on SVG coordinate
 		const ctm = getTransformCTM(target, x, y, false);
-		const rect = target.getBoundingClientRect();
+		const rect = getBoundingRect(target);
 		const size = getTransformCTM(target, 20, 0, false).x;
 
 		let top = ctm.y;

--- a/src/ChartInternal/shape/point.ts
+++ b/src/ChartInternal/shape/point.ts
@@ -6,6 +6,7 @@ import {select as d3Select} from "d3-selection";
 import type {d3Selection} from "../../../types/types";
 import {$CIRCLE, $COMMON, $SELECT} from "../../config/classes";
 import {
+	getBBox,
 	getBoundingRect,
 	getPointer,
 	getRandom,
@@ -301,7 +302,7 @@ export default {
 				if (this.tagName === "circle") {
 					point.attr("r", r);
 				} else {
-					const {width, height} = this.getBBox();
+					const {width, height} = getBBox(this);
 					const x = ratio * (+point.attr("x") + width / 2);
 					const y = ratio * (+point.attr("y") + height / 2);
 
@@ -487,7 +488,7 @@ export default {
 
 		update(element, xPosFn, yPosFn, fillStyleFn, withTransition, flow, selectedCircles) {
 			const $$ = this;
-			const {width, height} = element.node().getBBox();
+			const {width, height} = getBBox(element.node());
 
 			const xPosFn2 = d => (isValue(d.value) ? xPosFn(d) - width / 2 : 0);
 			const yPosFn2 = d => (isValue(d.value) ? yPosFn(d) - height / 2 : 0);

--- a/src/ChartInternal/shape/radar.ts
+++ b/src/ChartInternal/shape/radar.ts
@@ -6,6 +6,7 @@ import {select as d3Select} from "d3-selection";
 import {$AXIS, $COMMON, $LEVEL, $RADAR, $SHAPE, $TEXT} from "../../config/classes";
 import {KEY} from "../../module/Cache";
 import {
+	getBoundingRect,
 	getMinMax,
 	getPathBox,
 	getRange,
@@ -293,7 +294,7 @@ export default {
 				.attr("transform", function(d) {
 					if (isUndefined(this.width)) {
 						// cache evaluated axis text width
-						this.width = this.getBoundingClientRect().width / 2;
+						this.width = getBoundingRect(this, true).width / 2;
 					}
 
 					let posX = $$.getRadarPosition("x", d.index, undefined, 1);

--- a/src/ChartInternal/shape/shape.ts
+++ b/src/ChartInternal/shape/shape.ts
@@ -27,6 +27,7 @@ import type {d3Selection} from "../../../types/types";
 import CLASS from "../../config/classes";
 import {
 	capitalize,
+	getBBox,
 	getPointer,
 	getRectSegList,
 	getUnique,
@@ -590,7 +591,7 @@ export default {
 		const x = Math.min(seg0.x, seg1.x);
 		const y = Math.min(seg0.y, seg1.y);
 		const offset = this.config.bar_sensitivity;
-		const {width, height} = that.getBBox();
+		const {width, height} = getBBox(that, true);
 		const sx = x - offset;
 		const ex = x + width + offset;
 		const sy = y + height + offset;

--- a/src/config/Options/common/main.ts
+++ b/src/config/Options/common/main.ts
@@ -168,7 +168,7 @@ export default {
 	 *   - false: Disables automatic resize.
 	 *   - "parent": Enables automatic resize when the parent node is resized.
 	 *   - "viewBox": Enables automatic resize, and size will be fixed based on the viewbox.
-	 * @property {boolean|number} [resize.timer=false] Set resize timer option.
+	 * @property {boolean|number} [resize.timer=true] Set resize timer option.
 	 * - **NOTE:** Available options
 	 *   - The resize function will be called using:
 	 *     - true: `setTimeout()`
@@ -197,7 +197,7 @@ export default {
 	 *  }
 	 */
 	resize_auto: <boolean | "parent" | "viewBox">true,
-	resize_timer: false,
+	resize_timer: true,
 
 	/**
 	 * Set a callback to execute when the chart is clicked.

--- a/test/assets/module/util.ts
+++ b/test/assets/module/util.ts
@@ -23,6 +23,7 @@ export const {
 	findIndex,
 	getBrushSelection,
 	getBoundingRect,
+	getBBox,
 	getCssRules,
 	getMinMax,
 	getOption,


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
- Update the call of .getBoundingClientRect() and .getBBox() to use internal single function
- revert resize.timer=true as default