### PR TITLE
refactor(axis,text): enhance getMaxTickSize to account for resizing

### DIFF
--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -617,7 +617,7 @@ class Axis {
 	 */
 	getMaxTickSize(id: AxisType, withoutRecompute?: boolean): {width: number, height: number} {
 		const $$ = this.owner;
-		const {config, state: {current}, $el: {svg, chart}} = $$;
+		const {config, state: {current, resizing}, $el: {svg, chart}} = $$;
 		const currentTickMax = current.maxTickSize[id];
 		const configPrefix = `axis_${id}`;
 		const max = {
@@ -626,7 +626,7 @@ class Axis {
 		};
 
 		if (
-			withoutRecompute || !config[`${configPrefix}_show`] || (
+			resizing || withoutRecompute || !config[`${configPrefix}_show`] || (
 				currentTickMax.width > 0 && $$.filterTargetsToShow().length === 0
 			)
 		) {

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -7,7 +7,6 @@ import {$BAR, $CANDLESTICK, $COMMON} from "../../config/classes";
 import {KEY} from "../../module/Cache";
 import {
 	findIndex,
-	getBoundingRect,
 	getScrollPosition,
 	getTransformCTM,
 	getUnique,
@@ -755,22 +754,13 @@ export default {
 		return index;
 	},
 
-	getDataLabelLength(min: number, max: number, key: string): number[] {
+	getDataLabelLength(min: number, max: number, key: "width" | "height"): number[] {
 		const $$ = this;
-		const lengths = [0, 0];
 		const paddingCoef = 1.3;
 
-		$$.$el.chart.select("svg").selectAll(".dummy")
-			.data([min, max])
-			.enter()
-			.append("text")
-			.text(d => $$.dataLabelFormat(d.id)(d))
-			.each(function(d, i) {
-				lengths[i] = getBoundingRect(this, true)[key] * paddingCoef;
-			})
-			.remove();
-
-		return lengths;
+		return $$.getTextRect(
+			[min, max].map(v => $$.dataLabelFormat()(v))
+		)?.map((rect: DOMRect) => rect[key] * paddingCoef) || [0, 0];
 	},
 
 	isNoneArc(d) {

--- a/src/ChartInternal/internals/domain.ts
+++ b/src/ChartInternal/internals/domain.ts
@@ -82,7 +82,7 @@ export default {
 			.some(v => $$.axis.getId(v) === id);
 	},
 
-	getYDomain(targets, axisId: string, xDomain) {
+	getYDomain(targets: IData[], axisId: "y" | "y2", xDomain: TDomainRange) {
 		const $$ = this;
 		const {axis, config, scale} = $$;
 		const pfx = `axis_${axisId}`;

--- a/src/ChartInternal/internals/grid.ts
+++ b/src/ChartInternal/internals/grid.ts
@@ -371,7 +371,7 @@ export default {
 		const $$ = this;
 
 		$$.$el.main.selectAll(
-			`line.bb-axis-tooltip-x, line.bb-axis-tooltip-y`
+			`line.${$AXIS.axisTooltipX}, line.${$AXIS.axisTooltipY}`
 		).style("visibility", "hidden");
 
 		Object.values($$.$el.axisTooltip)

--- a/src/config/classes.ts
+++ b/src/config/classes.ts
@@ -43,7 +43,9 @@ export const $AXIS = {
 	axisYLabel: "bb-axis-y-label",
 	axisXTooltip: "bb-axis-x-tooltip",
 	axisYTooltip: "bb-axis-y-tooltip",
-	axisY2Tooltip: "bb-axis-y2-tooltip"
+	axisY2Tooltip: "bb-axis-y2-tooltip",
+	axisTooltipX: "bb-axis-tooltip-x",
+	axisTooltipY: "bb-axis-tooltip-y"
 };
 
 export const $BAR = {


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
- Include resizing state in the getMaxTickSize method to improve tick size calculations.
- Update data label visibility to hidden for better initial rendering.
- Specify parameter types in getYDomain for clarity and type safety.
- Update getTextRect to be used getting text element's rect boudning.