### PR TITLE
fix(axis): Fix axis text position

### DIFF
--- a/src/ChartInternal/Axis/AxisRendererHelper.ts
+++ b/src/ChartInternal/Axis/AxisRendererHelper.ts
@@ -11,6 +11,7 @@ export default class AxisRendererHelper {
 	private owner;
 	private config;
 	private scale;
+	private charSize = {};
 
 	constructor(owner) {
 		const scale = getScale();
@@ -30,17 +31,23 @@ export default class AxisRendererHelper {
 
 	/**
 	 * Compute a character dimension
+	 * @param {string} orient Axis orientation
 	 * @param {d3.selection} text SVG text selection
 	 * @param {boolean} memoize memoize the calculated size
 	 * @returns {{w: number, h: number}}
 	 * @private
 	 */
-	static getSizeFor1Char(text: d3Selection, memoize = true): {w: number, h: number} {
+	getSizeFor1Char(orient: "top" | "bottom" | "left" | "right", text: d3Selection,
+		memoize = true): {w: number, h: number} {
 		// default size for one character
 		const size = {
 			w: 5.5,
 			h: 11.5
 		};
+
+		if (this.charSize[orient] && memoize) {
+			return this.charSize[orient];
+		}
 
 		!text.empty() && text
 			.text("0")
@@ -57,9 +64,7 @@ export default class AxisRendererHelper {
 				}
 			});
 
-		if (memoize) {
-			this.getSizeFor1Char = () => size;
-		}
+		this.charSize[orient] = size;
 
 		return size;
 	}

--- a/test/api/export-spec.ts
+++ b/test/api/export-spec.ts
@@ -201,9 +201,9 @@ describe("API export", () => {
 
 			// pattern for local: preserveFontStyle=true
 			[
-				"UwUQECoIlWYZu6qgABsKvys3LDFCAAGmYQNocKRKQAATAiIVlMehQgAKbHluxJ",
-				"bAOgeAH1QlUcTZOjJOFPV7zN3zDlq/tQUvMb1kYAjNcQLZROAGxBtNTf0oIXkACY",
-				"CZAACZAACZAABSCfARIgARIgARIgARLIMQIUgDkWcHaXBEiABEiABEiABCgA"
+				"BD7f3dolQSIIE6JjBYB3D9LAtz1h5CuB36FvSr0HWhgVj6PESehdq9fhvD",
+				"zPI9F/BFoRpBmbdjyc89MYSZDZHTWBmbtIJC1cdRp9xFmo93GKusODe44GcXn",
+				"7mj5wLZll4qBMfn4j3fMUMKCtHwIrdOT6uaNJu"
 			],
 			
 			// pattern for webdriverio

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -13,7 +13,7 @@ import util from "../assets/util";
 import {addCssRules, getBoundingRect} from "../assets/module/util";
 import bb from "../../src";
 import {$AXIS} from "../../src/config/classes";
-import AxisRendererHelper from "../../src/ChartInternal/Axis/AxisRendererHelper";
+// import AxisRendererHelper from "../../src/ChartInternal/Axis/AxisRendererHelper";
 //import getSizeFor1Char from "exports-loader?getSizeFor1Char!../../src/axis/bb.axis";
 
 describe("AXIS", function() {
@@ -133,10 +133,11 @@ describe("AXIS", function() {
 		});
 
 		it("should compute char dimension", () => {
-			const size = AxisRendererHelper.getSizeFor1Char(d3Select(".tick"));
+			const {helper} = chart.internal.axis.x;
+			const size = helper.getSizeFor1Char("bottom", d3Select(".tick"));
 
 			expect(size.w && size.h).to.be.ok;
-			expect(AxisRendererHelper.getSizeFor1Char()).to.be.equal(size);
+			expect(helper.getSizeFor1Char("bottom")).to.be.equal(size);
 		});
 
 		it("should have only 2 tick on y axis", () => {
@@ -1041,7 +1042,7 @@ describe("AXIS", function() {
 					const ticksText = chart.$.main.select(`.${$AXIS.axisX}`).selectAll("g.tick text");
 
 					ticksText.each(function() {
-						expect(util.ceil(+this.getAttribute("y"))).to.be.equal(37);
+						expect(util.ceil(+this.getAttribute("y"))).to.be.equal(38);
 					});
 				});
 			});
@@ -3870,8 +3871,8 @@ describe("AXIS", function() {
 				const tick = chart.internal.$el.axis.x.select(".tick").node();
 				const {width, height} = tick.getBoundingClientRect();
 
-				expect(width < 41).to.be.true;
-				// expect(height < 60).to.be.true;
+				// expect(width < 41).to.be.true;
+				expect(height < 60).to.be.true;
 
 				// reset font-size
 				text.style("font-size", null);
@@ -3919,5 +3920,53 @@ describe("AXIS", function() {
 				done(1);
 			}, 500);
 		}));
+
+		it("set options", () => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 50, 20, 10, 40, 15, 25]
+					]
+				},
+				axis: {
+					y2: {
+						show: true
+					}
+				},
+				bindto: {
+					element: "#chart",
+					classname: "bb eval-text-size"
+				}
+			};
+		});
+
+		it("check custom evaluator", () => {
+			const {$el: {axis}} = chart.internal;
+			const expectedY = {
+				y: 14,
+				y2: 11.5
+			};
+
+			["y", "y2"].forEach(id => {
+				expect(+axis[id].select(".tick text").attr("y")).to.be.closeTo(expectedY[id], 1);
+			});
+		});
+
+		it("set options: axis.rotated=true", () => {
+			args.axis.rotated = true;
+		});
+
+		it("check custom evaluator", () => {
+			const {$el: {axis}} = chart.internal;
+			const expectedY = {
+				y: 9,
+				y2: -26.5
+			};
+
+			["y", "y2"].forEach(id => {
+				expect(+axis[id].select(".tick text").attr("y")).to.be.closeTo(expectedY[id], 1);
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4017

## Details
<!-- Detailed description of the change/feature -->
Adjust tick text position based on the text font-size. As the nature of font's dimension can't be get accurately, texts position accuracy has limited.

- left: before / right: after
<img width="887" height="314" alt="image" src="https://github.com/user-attachments/assets/460b2bce-440e-4212-8cac-b69c736ca486" />
