### PR TITLE
fix(worker): Exclude empty data ran on Worker thread

### DIFF
--- a/src/ChartInternal/data/convert.ts
+++ b/src/ChartInternal/data/convert.ts
@@ -112,14 +112,14 @@ export default {
 			url(data.url, data.mimeType, data.headers, getDataKeyForJson(data.keys, config),
 				callback);
 		} else if (data.json) {
-			runWorker(useWorker, json, callback, [columns, rows])(
+			runWorker(data.json.length ? useWorker : false, json, callback, [columns, rows])(
 				data.json,
 				getDataKeyForJson(data.keys, config)
 			);
 		} else if (data.rows) {
-			runWorker(useWorker, rows, callback)(data.rows);
+			runWorker(data.rows.length ? useWorker : false, rows, callback)(data.rows);
 		} else if (data.columns) {
-			runWorker(useWorker, columns, callback)(data.columns);
+			runWorker(data.columns.length ? useWorker : false, columns, callback)(data.columns);
 		} else if (args.bindto) {
 			throw Error("url or json or rows or columns is required.");
 		}

--- a/src/config/Options/common/boost.ts
+++ b/src/config/Options/common/boost.ts
@@ -20,6 +20,7 @@ export default {
 	 * - **NOTE:**
 	 *   - For now, only applies for data conversion at the initial time.
 	 *   - As of Web Worker's async nature, handling chart instance synchrously is not recommended.
+	 *   - When given data is empty, useWorker will be ignored.
 	 * @example
 	 *  boost: {
 	 *      useCssRule: true,

--- a/test/internals/boost-spec.ts
+++ b/test/internals/boost-spec.ts
@@ -70,6 +70,152 @@ describe("BOOST", () => {
 	});
 
 	describe("useWorker", function() {
+		beforeEach(() => {
+			args = {
+				boost: {
+					useWorker: true
+				},
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 50, 150, 150, 150, 50, 150]
+					],
+					type: "line"
+				}
+			};
+		});
+
+		it("should enable Web Worker option when boost.useWorker is true", () => {
+			chart = util.generate(args);
+			const {config} = chart.internal;
+			
+			expect(config.boost_useWorker).to.be.true;
+		});
+
+		it("should disable Web Worker option when boost.useWorker is false", () => {
+			args.boost.useWorker = false;
+			chart = util.generate(args);
+			const {config} = chart.internal;
+			
+			expect(config.boost_useWorker).to.be.false;
+		});
+
+		it("should process JSON data correctly (fallback to sync when Worker not available)", () => {
+			const jsonData = [
+				{x: 1, value1: 10, value2: 20},
+				{x: 2, value1: 15, value2: 25},
+				{x: 3, value1: 20, value2: 30}
+			];
+
+			// Use sync processing to ensure reliable test
+			args.boost.useWorker = false;
+			args.data = {
+				json: jsonData,
+				keys: {x: "x", value: ["value1", "value2"]}
+			};
+
+			chart = util.generate(args);
+			const data = chart.data();
+			
+			expect(data.length).to.be.equal(2);
+			expect(data[0].id).to.be.equal("value1");
+			expect(data[1].id).to.be.equal("value2");
+		});
+
+		it("should process rows data correctly (fallback to sync when Worker not available)", () => {
+			const rowsData = [
+				["data1", "data2"],
+				[10, 20],
+				[15, 25],
+				[20, 30]
+			];
+
+			// Use sync processing to ensure reliable test
+			args.boost.useWorker = false;
+			args.data = {
+				rows: rowsData
+			};
+
+			chart = util.generate(args);
+			const data = chart.data();
+			
+			expect(data.length).to.be.equal(2);
+			expect(data[0].id).to.be.equal("data1");
+			expect(data[1].id).to.be.equal("data2");
+		});
+
+		it("should process columns data correctly (fallback to sync when Worker not available)", () => {
+			const columnsData = [
+				["data1", 30, 200, 100, 400, 150, 250],
+				["data2", 50, 150, 150, 150, 50, 150]
+			];
+
+			// Use sync processing to ensure reliable test
+			args.boost.useWorker = false;
+			args.data = {
+				columns: columnsData
+			};
+
+			chart = util.generate(args);
+			const data = chart.data();
+			
+			expect(data.length).to.be.equal(2);
+			expect(data[0].id).to.be.equal("data1");
+			expect(data[1].id).to.be.equal("data2");
+		});
+
+		it("should not use Web Worker when data is empty", () => {
+			args.data = {
+				columns: []
+			};
+
+			chart = util.generate(args);
+			const {config} = chart.internal;
+			
+			// useWorker should be enabled in config but shouldn't be used for empty data
+			expect(config.boost_useWorker).to.be.true;
+		});
+
+		it("should work with synchronous processing when useWorker is disabled", () => {
+			args.boost.useWorker = false;
+			
+			chart = util.generate(args);
+			const data = chart.data();
+			
+			expect(data.length).to.be.equal(2);
+			expect(data[0].id).to.be.equal("data1");
+			expect(data[1].id).to.be.equal("data2");
+		});
+
+		it("should have boost_useWorker config when enabled", () => {
+			args.boost.useWorker = true;
+			chart = util.generate(args);
+			
+			expect(chart.internal.config.boost_useWorker).to.be.true;
+		});
+
+		it("should handle data conversion logic in convert.ts with runWorker", () => {
+			// Test that boost config is properly set and integration works
+			args.boost.useWorker = true;
+			args.data = {
+				columns: [
+					["data1", 30, 200, 100],
+					["data2", 50, 150, 150]
+				]
+			};
+			
+			chart = util.generate(args);
+			
+			// Verify config is set properly
+			expect(chart.internal.config.boost_useWorker).to.be.true;
+			
+			// Verify chart exists and has basic functionality
+			expect(chart).to.not.be.undefined;
+			expect(chart.internal).to.not.be.undefined;
+		});
+	});
+
+	describe("runWorker function tests", function() {
 		it("check if given function run without WebWorker", () => {
 			return new Promise((resolve) => {
 				runWorker(false, function test_for_worker(p) {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4041

## Details
<!-- Detailed description of the change/feature -->
for SSR env, it usually initializes with empty data array. Hence, for empty data avoid to ran conversion in Worker thread.
