### PR TITLE
fix(load): Update call sequence to be after data are unloaded

### DIFF
--- a/src/ChartInternal/data/load.ts
+++ b/src/ChartInternal/data/load.ts
@@ -156,13 +156,6 @@ export default {
 			return;
 		}
 
-		const targets = $el.svg.selectAll(targetIds.map(id => $$.selectorTarget(id)));
-
-		$T(targets)
-			.style("opacity", "0")
-			.remove()
-			.call(endall, done);
-
 		targetIds.forEach(id => {
 			const suffixId = $$.getTargetSelectorSuffix(id);
 
@@ -189,5 +182,12 @@ export default {
 
 		// Update current state chart type and elements list after redraw
 		$$.updateTypesElements();
+
+		const targets = $el.svg.selectAll(targetIds.map(id => $$.selectorTarget(id)));
+
+		$T(targets)
+			.style("opacity", "0")
+			.remove()
+			.call(endall, done);
 	}
 };


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4052

## Details
<!-- Detailed description of the change/feature -->
Unload callback should ran after data are unloaded