### PR TITLE
feat(data): Intent to ship data.stack.normalize.perGroup

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3466,6 +3466,122 @@ var demos = {
 				}
 			}
 		],
+		DataStackNormalizedGroup: [
+			{
+				options: {
+					title: {
+						text: "Normalize per group - Multiple groups"
+					},
+					data: {
+						columns: [
+							["data1", 100, 200, 150, 300],
+							["data2", 200, 400, 350, 200],
+							["data3", 50, 100, 80, 120],
+							["data4", 150, 200, 220, 180]
+						],
+						type: "bar",
+						groups: [
+							["data1", "data2"],
+							["data3", "data4"]
+						],
+						stack: {
+							normalize: {
+								perGroup: true
+							}
+						}
+					},
+					axis: {
+						y: {
+							label: {
+								text: "Percentage (%)",
+								position: "outer-middle"
+							}
+						}
+					},
+					tooltip: {
+						format: {
+							title: function(x) { return "Index " + x; }
+						}
+					}
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "Normalize per group - With non-grouped data"
+					},
+					data: {
+						columns: [
+							["data1", 100, 200, 150, 300],
+							["data2", 200, 400, 350, 200],
+							["data3", 50, 100, 80, 120]
+						],
+						type: "bar", 
+						types: {
+							"data3": "line"
+						},
+						groups: [
+							["data1", "data2"]
+						],
+						stack: {
+							normalize: {
+								perGroup: true
+							}
+						},
+						axes: {
+							data3: "y2"
+						}
+					},
+					axis: {
+						y: {
+							label: {
+								text: "Grouped: % | Non-grouped: Absolute",
+								position: "outer-middle"
+							}
+						},
+						y2: {
+							show: true
+						}
+					},
+					tooltip: {
+						format: {
+							title: function(x) { return "Index " + x; }
+						}
+					}
+				}
+			},
+			{
+				options: {
+					title: {
+						text: "Normalize per group - Area chart"
+					},
+					data: {
+						columns: [
+							["data1", 30, 280, 951, 400, 150],
+							["data2", 130, 357, 751, 400, 150],
+							["data3", 50, 100, 200, 150, 80],
+							["data4", 100, 200, 300, 250, 120]
+						],
+						types: {
+							data1: "area",
+							data2: "area",
+							data3: "bar",
+							data4: "bar",
+						},
+						groups: [
+							["data1", "data2"],
+							["data3", "data4"]
+						],
+						stack: {
+							normalize: {
+								perGroup: true
+							}
+						}
+					},
+					clipPath: false
+				}
+			}
+		],
 		DataXSort: [
 			{
 				options: {

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -356,7 +356,7 @@ class Axis {
 		// Set tick
 		axis.tickFormat(
 			tickFormat || (
-				!isX && ($$.isStackNormalized() && (x => `${x}%`))
+				!isX && ($$.isStackNormalized() && $$.hasAxisGroupedData(id) && (x => `${x}%`))
 			)
 		);
 

--- a/src/ChartInternal/internals/domain.ts
+++ b/src/ChartInternal/internals/domain.ts
@@ -87,8 +87,20 @@ export default {
 		const {axis, config, scale} = $$;
 		const pfx = `axis_${axisId}`;
 
+		// Check if stack normalization should be applied for this axis
 		if ($$.isStackNormalized()) {
-			return [0, 100];
+			// Get all data IDs that belong to this axis
+			const axisDataIds = targets
+				.filter(t => axis.getId(t.id) === axisId)
+				.map(t => t.id);
+
+			// Check if any of the axis data IDs are in groups
+			const hasGroupedData = axisDataIds.some(id => $$.isGrouped(id));
+
+			// Apply normalization only if this axis has grouped data
+			if (hasGroupedData) {
+				return [0, 100];
+			}
 		}
 
 		const isLog = scale?.[axisId] && scale[axisId].type === "log";

--- a/src/config/Options/data/axis.ts
+++ b/src/config/Options/data/axis.ts
@@ -142,17 +142,42 @@ export default {
 	 *   - For stacking, '[data.groups](#.data%25E2%2580%25A4groups)' option should be set
 	 *   - y Axis will be set in percentage value (0 ~ 100%)
 	 *   - Must have postive values
+	 *   - Data not in any group will not be normalized when using perGroup option
 	 * @name data․stack․normalize
 	 * @memberof Options
-	 * @type {boolean}
+	 * @type {boolean|object}
 	 * @default false
-	 * @see [Demo](https://naver.github.io/billboard.js/demo/#Data.DataStackNormalized)
+	 * @see [Demo: Data Stack Normalized](https://naver.github.io/billboard.js/demo/#Data.DataStackNormalized)
+	 * @see [Demo: Data Stack Normalized per Group](https://naver.github.io/billboard.js/demo/#Data.DataStackNormalizedGroup)
 	 * @example
 	 * data: {
 	 *   stack: {
+	 *      // Normalize all grouped data together (all groups combined to 0-100%)
 	 *      normalize: true
+	 *
+	 *      // Normalize per group (each group independently becomes 0-100%)
+	 *      // Data not in any group will display with their original values.
+	 *      // If non-grouped data shares the same axis (e.g., y), it will be
+	 *      // displayed on the 0-100 absolute scale. To display original values,
+	 *      // assign them to a separate axis (e.g., y2).
+	 *      normalize: {
+	 *        perGroup: true
+	 *      }
+	 *   },
+	 *   groups: [
+	 *     ["data1", "data2"]  // This group will be normalized to 0-100%
+	 *   ],
+	 *   // data3 is not in any group, so it displays original values
+	 *   // Assign it to y2 axis to use a separate scale
+	 *   axes: {
+	 *     data3: "y2"
+	 *   }
+	 * },
+	 * axis: {
+	 *   y2: {
+	 *     show: true
 	 *   }
 	 * }
 	 */
-	data_stack_normalize: false
+	data_stack_normalize: <boolean | {perGroup?: boolean}>false
 };

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1456,8 +1456,21 @@ export interface Data {
 		 * - NOTE: For stacking, 'data.groups' option should be set
 		 *  - y Axis will be set in percentage value (0 ~ 100%)
 		 *  - Must have postive values
+		 *  - Data not in any group will not be normalized when using perGroup option
+		 * 
+		 * When boolean:
+		 *  - true: Normalize all grouped data together (all groups combined to 0-100%)
+		 * 
+		 * When object with perGroup:
+		 *  - perGroup: true - Normalize each group independently (each group becomes 0-100%)
+		 *    Data not in any group will display with their original values.
+		 *    If non-grouped data shares the same axis (e.g., y), it will be
+		 *    displayed on the 0-100 absolute scale. To display original values,
+		 *    assign them to a separate axis (e.g., y2).
 		 */
-		normalize?: boolean;
+		normalize?: boolean | {
+			perGroup?: boolean;
+		};
 	};
 
 	/**


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4060

## Details
<!-- Detailed description of the change/feature -->
Implement normalize per group option.
- Normalize per group (each group independently becomes 0-100%)
- Data not in any group will display with their original values.
   - If non-grouped data shares the same axis (e.g., y), it will be displayed on the 0-100 absolute scale. To display original values, assign them to a separate axis (e.g., y2).

```js
data: {
    stack: {
      normalize: {
        perGroup: true
      }
    }
}
```

<img width="610" height="681" alt="image" src="https://github.com/user-attachments/assets/ea05765e-b019-457a-9bd7-691daaea2c37" />
