### PR TITLE
fix(interaction): Fix data.onover call in touch event

### DIFF
--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -477,7 +477,13 @@ export default {
 		if ($$.isBarType(closest.id) || dist < $$.getPointSensitivity(closest)) {
 			$$.$el.svg.select(`.${$EVENT.eventRect}`).style("cursor", "pointer");
 
-			if (triggerEvent && !state.mouseover) {
+			if (
+				triggerEvent && (
+					!state.mouseover ||
+					state.mouseover.x !== closest.x ||
+					state.mouseover.id !== closest.id
+				)
+			) {
 				config.data_onover.call($$.api, closest);
 				state.mouseover = closest;
 			}


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4076

## Details
<!-- Detailed description of the change/feature -->
Update conditional to trigger onover event.
The state.mouseover value is released in onout for desktop, but in touch "onout" doesn't exist, so add conditional to handle trigger point.