### PR TITLE
fix(boost): Reuse Worker and Object URL to prevent memory leak

### DIFF
--- a/src/module/worker.ts
+++ b/src/module/worker.ts
@@ -4,24 +4,26 @@
  */
 import {window} from "./browser";
 
-// Store blob in memory
-const blob = {};
+// Store worker cache in memory
+const cache: {[key: string]: {src: string, worker: Worker | null}} = {};
 
 /**
- * Get Object URL
+ * Get or create cached worker resources (Object URL, Worker)
  * @param {function} fn Function to be executed in worker
  * @param {Array} depsFn Dependency functions to run given function(fn).
- * @returns {string}
+ * @returns {{key: string, src: string}} Cache key and Object URL
  * @private
  */
-function getObjectURL(fn: Function, depsFn?: Function[]): string {
+function getOrCreateWorkerResources(fn: Function, depsFn?: Function[]): {key: string, src: string} {
 	const fnString = fn.toString();
-	const key = fnString.replace(/(function|[\s\W\n])/g, "").substring(0, 15);
+	// Include depsFn in cache key to handle different dependencies
+	const depsString = depsFn?.map(String).join(";") ?? "";
+	const key = (fnString + depsString).replace(/(function|[\s\W\n])/g, "").substring(0, 30);
 
-	if (!(key in blob)) {
-		// Web Worker body
-		blob[key] = new window.Blob([
-			`${depsFn?.map(String).join(";") ?? ""}
+	if (!(key in cache)) {
+		// Create Blob and Object URL for Web Worker
+		const blob = new window.Blob([
+			`${depsString}
 
 			self.onmessage=function({data}) {
 				const result = (${fnString}).apply(null, data);
@@ -30,27 +32,44 @@ function getObjectURL(fn: Function, depsFn?: Function[]): string {
 		], {
 			type: "text/javascript"
 		});
+
+		cache[key] = {
+			src: window.URL.createObjectURL(blob),
+			worker: null
+		};
 	}
 
-	return window.URL.createObjectURL(blob[key]);
+	return {key, src: cache[key].src};
 }
 
 /**
- * Get WebWorker instance
+ * Get or create cached WebWorker instance
+ * @param {string} key Cache key
  * @param {string} src URL object as string
- * @returns {object} WebWorker instance
+ * @returns {Worker} WebWorker instance
  * @private
  */
-export function getWorker(src) {
-	const worker = new window.Worker(src);
+export function getWorker(key: string, src: string): Worker | null {
+	const cached = cache[key];
 
-	// handle error
-	worker.onerror = function(e) {
-		// eslint-disable-next-line no-console
-		console.error ? console.error(e) : console.log(e);
-	};
+	// Return null if cache entry doesn't exist
+	if (!cached) {
+		return null;
+	}
 
-	return worker;
+	if (!cached.worker) {
+		cached.worker = new window.Worker(src);
+
+		// handle error
+		if (cached.worker) {
+			cached.worker.onerror = function(e: ErrorEvent) {
+				// eslint-disable-next-line no-console
+				console.error ? console.error(e) : console.log(e);
+			};
+		}
+	}
+
+	return cached.worker;
 }
 
 /**
@@ -59,7 +78,7 @@ export function getWorker(src) {
  * @param {function} fn Function to be executed in worker
  * @param {function} callback Callback function to receive result from worker
  * @param {Array} depsFn Dependency functions to run given function(fn).
- * @returns {object}
+ * @returns {function}
  * @example
  * 	const worker = runWorker(function(arg) {
  * 		  // do some tasks...
@@ -82,34 +101,49 @@ export function runWorker(
 	callback: Function,
 	depsFn?: Function[]
 ): Function {
-	let runFn = function(...args) {
+	let runFn = function(...args: unknown[]) {
 		const res = fn(...args);
 
 		callback(res);
 	};
 
 	if (window.Worker && useWorker) {
-		const src = getObjectURL(fn, depsFn);
-		const worker = getWorker(src);
+		const {key, src} = getOrCreateWorkerResources(fn, depsFn);
+		const worker = getWorker(key, src);
 
-		runFn = function(...args) {
-			// trigger worker
-			worker.postMessage(args);
+		runFn = function(...args: unknown[]) {
+			if (worker) {
+				// trigger worker
+				worker.postMessage(args);
 
-			// listen worker
-			worker.onmessage = function(e) {
-				// release object URL from memory
-				window.URL.revokeObjectURL(src);
-
-				return callback(e.data);
-			};
-
-			// return new Promise((resolve, reject) => {
-			// 	worker.onmessage = ({data}) => resolve(data);
-			// 	worker.onerror = reject;
-			// });
+				// listen worker
+				worker.onmessage = function(e: MessageEvent) {
+					// Object URL and Worker are cached and reused
+					return callback(e.data);
+				};
+			}
 		};
 	}
 
 	return runFn;
+}
+
+/**
+ * Clean-up all cached workers and release resources
+ * @private
+ */
+export function cleanupWorkers(): void {
+	for (const key in cache) {
+		const cached = cache[key];
+
+		if (cached.worker) {
+			cached.worker.terminate();
+		}
+
+		if (cached.src) {
+			window.URL.revokeObjectURL(cached.src);
+		}
+
+		delete cache[key];
+	}
 }

--- a/test/module/module-spec.ts
+++ b/test/module/module-spec.ts
@@ -9,7 +9,7 @@ import sinon from "sinon";
 import util from "../assets/util";
 import {getFallback, window} from "../../src/module/browser";
 // import {getGlobal, getFallback, window} from "../../src/module/browser";
-import {getWorker, runWorker} from "../../src/module/worker";
+import {runWorker} from "../../src/module/worker";
 
 describe("MODULE", function() {
     let chart;
@@ -20,7 +20,7 @@ describe("MODULE", function() {
 	});
 
     afterEach(() => {
-        chart.destroy();
+        chart?.destroy();
     });
 
     describe("Cache", () => {
@@ -122,29 +122,17 @@ describe("MODULE", function() {
         }));
     });
 
-    describe("Worker", () => { 
-        it("check worker onerror handler call.", () => {
-            const worker = getWorker("test");
-            const errorStub = sinon.stub(console, "error");
+    describe("Worker", () => {
+        it("check runWorker sync execution", () => {
+            let result = null;
 
-            worker.onerror({e: {message: "ERR MSG"}});
+            runWorker(
+                false,
+                function(val: number) { return val * 2; },
+                function(res: number) { result = res; }
+            )(5);
 
-            expect(errorStub.called).to.be.true;
-
-            errorStub.restore();
-            
-            const error = console.error;
-
-            // @ts-ignore
-            console.error = null;
-            const logStub = sinon.stub(console, "log");
-
-            worker.onerror({e: {message: "ERR MSG"}});
-
-            expect(logStub.called).to.be.true;
-
-            logStub.restore();
-            console.error = error;
+            expect(result).to.be.equal(10);
         });
 
         it("check with dependency function", () => new Promise(done => {
@@ -155,7 +143,7 @@ describe("MODULE", function() {
             runWorker(
                 true,
                 function() { return depsFn(); },
-                function(res) {
+                function(res: number) {
                     expect(res).to.be.equal(1234);
                     done(1);
                 },


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3720

## Details
<!-- Detailed description of the change/feature -->
- Cache Worker instance and Object URL for reuse instead of creating new ones on every call
- Add defensive check for undefined cache entry in getWorker()
- Add cleanupWorkers() function for resource cleanup
- Include depsFn in cache key to handle different dependencies
- Update tests for new Worker caching implementation