### PR TITLE
Add file extensions to types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "ES2015",
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"noImplicitAny": false,
 		"noImplicitThis": false,
 		"strictNullChecks": true,

--- a/types/axis.d.ts
+++ b/types/axis.d.ts
@@ -1,4 +1,4 @@
-import {Chart} from "./chart";
+import {Chart} from "./chart.js";
 
 /**
  * Copyright (c) 2017 ~ present NAVER Corp.

--- a/types/bb.d.ts
+++ b/types/bb.d.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Chart} from "./chart";
-import {ChartOptions} from "./options";
+import {Chart} from "./chart.js";
+import {ChartOptions} from "./options.js";
 
 export const bb: {
 	/**

--- a/types/chart.d.ts
+++ b/types/chart.d.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Data, RegionOptions} from "./options";
-import {ArrayOrString, d3Selection, DataArray, DataItem, PrimitiveArray, TargetIds} from "./types";
+import {Data, RegionOptions} from "./options.js";
+import {ArrayOrString, d3Selection, DataArray, DataItem, PrimitiveArray, TargetIds} from "./types.js";
 
 export interface Chart {
 	$: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {bb} from "./bb";
+import {bb} from "./bb.js";
 
 export default bb;
 export as namespace bb;
@@ -35,8 +35,8 @@ export {
 	selection,
 	subchart,
 	zoom
-} from "./bb";
-export * from "./axis";
-export * from "./chart";
-export * from "./options";
-export * from "./types";
+} from "./bb.js";
+export * from "./axis.js";
+export * from "./chart.js";
+export * from "./options.js";
+export * from "./types.js";

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -2,10 +2,10 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Axis} from "./axis";
-import {ChartTypes, d3Selection, DataItem, PrimitiveArray} from "./types";
-import {Chart} from "./chart";
-import {IArcData, IData, IDataPoint, IDataRow} from "../src/ChartInternal/data/IData";
+import {Axis} from "./axis.js";
+import {ChartTypes, d3Selection, DataItem, PrimitiveArray} from "./types.js";
+import {Chart} from "./chart.js";
+import {IArcData, IData, IDataPoint, IDataRow} from "../src/ChartInternal/data/IData.js";
 import {
 	ArcOptions,
 	AreaOptions,
@@ -23,7 +23,7 @@ import {
 	ScatterOptions,
 	SplineOptions,
 	TreemapOptions
-} from "./options.shape";
+} from "./options.shape.js";
 
 export type FormatFunction = (
 	this: Chart,

--- a/types/options.shape.d.ts
+++ b/types/options.shape.d.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {DataItem, GaugeTypes} from "./types";
-import {Chart} from "./chart";
+import {DataItem, GaugeTypes} from "./types.js";
+import {Chart} from "./chart.js";
 
 /**
  * Label line configuration for arc chart types (donut, pie, polar, gauge).

--- a/types/plugin/bubblecompare/index.d.ts
+++ b/types/plugin/bubblecompare/index.d.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Plugin} from "../plugin";
-import {BubblecompareOptions} from "./options";
+import {Plugin} from "../plugin.js";
+import {BubblecompareOptions} from "./options.js";
 
 export default class Bubblecompare extends Plugin {
 	/**

--- a/types/plugin/sparkline/index.d.ts
+++ b/types/plugin/sparkline/index.d.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Plugin} from "../plugin";
-import {SparklineOptions} from "./options";
+import {Plugin} from "../plugin.js";
+import {SparklineOptions} from "./options.js";
 
 export default class Sparkline extends Plugin {
 	/**

--- a/types/plugin/stanford/index.d.ts
+++ b/types/plugin/stanford/index.d.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Plugin} from "../plugin";
-import {StanfordOptions} from "./options";
+import {Plugin} from "../plugin.js";
+import {StanfordOptions} from "./options.js";
 
 export default class Stanford extends Plugin {
 	/**

--- a/types/plugin/tableview/index.d.ts
+++ b/types/plugin/tableview/index.d.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Plugin} from "../plugin";
-import {TableViewOptions} from "./options";
+import {Plugin} from "../plugin.js";
+import {TableViewOptions} from "./options.js";
 
 export default class TableView extends Plugin {
 	/**

--- a/types/plugin/textoverlap/index.d.ts
+++ b/types/plugin/textoverlap/index.d.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Plugin} from "../plugin";
-import {TextOverlapOptions} from "./options";
+import {Plugin} from "../plugin.js";
+import {TextOverlapOptions} from "./options.js";
 
 export default class TextOverlap extends Plugin {
 	/**


### PR DESCRIPTION
## Issue

https://github.com/naver/billboard.js/issues/3061

## Details

Adds file extenions to types, allowing this to compile when using bundler or node16 with typescript, where it would previously not find the right types:

```import type { ChartOptions } from "billboard.js"```

I've taken the liberty to change the moduleResolution to bundler, since all builds actually use rollup or webpack, and as such typescript should be configured to use the bundler moduleResolution.

Tests also run using vitest, which follows the bundler moduleResolution
