### PR TITLE
fix(types): Export shape option types from main entry point

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,4 +39,5 @@ export {
 export * from "./axis.js";
 export * from "./chart.js";
 export * from "./options.js";
+export * from "./options.shape.js";
 export * from "./types.js";


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4104

## Details
<!-- Detailed description of the change/feature -->
Export all interfaces from options.shape.d.ts (BarOptions, LineOptions, etc.) so users can import them directly from "billboard.js".