### PR TITLE
refactor(all): Optimize redraw with generation caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+billboard.js is a D3.js v6+ based JavaScript charting library (MIT). Written in TypeScript, it supports SVG rendering with modular ESM tree-shaking for chart types and interactions.
+
+## Common Commands
+
+```bash
+# Dev server
+npm start
+
+# Build (full: production + packaged + theme + plugin + esm + cjs)
+npm run build
+
+# Build dev only
+npm run build:dev
+
+# Lint
+npm run lint
+
+# Format
+npm run format
+
+# Run all tests (vitest + playwright/chromium, browser mode)
+npm test
+
+# Run a single test file
+npx vitest test/shape/bar-spec.ts
+
+# Run tests matching a pattern
+npx vitest -t "pattern"
+
+# Coverage
+npm run coverage
+```
+
+Package manager: `yarn@4.3.1` (corepack)
+
+## Architecture
+
+### Entry Points
+
+- `src/index.ts` — Full bundle: auto-registers all shape/interaction modules
+- `src/index.esm.ts` — ESM entry: exports individual shape types (`area`, `bar`, `line`, etc.) and interactions (`zoom`, `subchart`, `selection`) for tree-shaking
+- `src/core.ts` — `bb` namespace object with `generate()`, `defaults()`, `instance[]`
+
+### Core Classes
+
+- **`Chart`** (`src/Chart/Chart.ts`) — Public API class returned by `bb.generate()`. Methods split across `src/Chart/api/*.ts` files (data, load, export, tooltip, zoom, etc.)
+- **`ChartInternal`** (`src/ChartInternal/ChartInternal.ts`) — Internal implementation. Functionality mixed in via `extend()` from submodules:
+  - `data/` — data conversion, loading
+  - `interactions/` — drag, eventrect, flow, subchart, zoom
+  - `internals/` — redraw, scale, domain, size, color, legend, tooltip, format, text, title, style, type, class, category, transform
+  - `shape/` — rendering logic per chart type (arc, area, bar, bubble, candlestick, funnel, gauge, line, point, polar, radar, treemap)
+
+### Module Resolution System
+
+`src/config/resolver/shape.ts` and `interaction.ts` use a lazy self-replacing pattern: each exported function (e.g., `line()`, `bar()`) extends `ChartInternal.prototype` with the needed modules on first call, then replaces itself with a function returning the type constant. This enables tree-shaking — unused chart types are never loaded.
+
+### Configuration
+
+- `src/config/Options/` — Default option definitions organized by category (`axis/`, `common/`, `data/`, `interaction/`, `shape/`)
+- `src/config/Store/` — State management
+- `src/config/const.ts` — Chart type constants (`TYPE`)
+- `src/config/classes.ts` — CSS class name constants
+
+### Plugins
+
+`src/Plugin/` — Plugin base class and built-in plugins (bubblecompare, sparkline, stanford, tableview, textoverlap). Each plugin extends `Plugin.ts`.
+
+### Utilities
+
+`src/module/` — Shared utilities: `util.ts` (main helpers), `Cache.ts`, `browser.ts` (window/document refs), `generator.ts`, `sanitize.ts`
+
+### Styles
+
+`src/scss/` — SCSS sources for base theme and theme variants (dark, datalab, graph, insight, modern)
+
+## Test Structure
+
+Tests use **Vitest** with `@vitest/browser` (Playwright/Chromium). Test files: `test/**/*-spec.ts`
+
+Mirror structure: `test/shape/` for shape tests, `test/api/` for API tests, `test/interactions/` for interaction tests, `test/internals/` for internal logic tests.
+
+Test timeout: 3500ms. Hook timeout: 5000ms.
+
+## Commit Convention
+
+Follows [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+Ref #<issue>
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `skip`
+
+Scope is typically the module name (e.g., `Axis`, `tooltip`, `data`).

--- a/demo/benchmark/benchmark.js
+++ b/demo/benchmark/benchmark.js
@@ -133,25 +133,30 @@ window.bench = {
         this.chart.load({
             columns: this.getData(),
             done: function() {
+                ctx.perf(true, "Load");
                 ctx.timer = setTimeout(bench.load.bind(bench), 500);
             }
         });
-
-        this.perf(true, "Load");
     },
     resize: function() {
         this.stop();
-        
+        const duration = +this.$el.transition.value;
+
         this.timer = setInterval(() => {
             this.perf(false, "Resize");
-            
+
             bench.chart.resize({
                 width: this.getRandom(200, 600),
                 height: this.getRandom(200, 480)
             });
 
-            this.perf(true, "Resize");
-        }, 500);
+            if (duration > 0) {
+                // Wait for transition to complete before measuring
+                setTimeout(() => this.perf(true, "Resize"), duration + 50);
+            } else {
+                this.perf(true, "Resize");
+            }
+        }, Math.max(500, duration + 100));
     },
     stop: function() {
         this.play = false;

--- a/src/Chart/api/axis.ts
+++ b/src/Chart/api/axis.ts
@@ -39,6 +39,8 @@ function setMinMax($$, type: "min" | "max", value: AxisOption): void {
 			});
 		}
 
+		$$.state.dirty.data = true;
+
 		$$.redraw({
 			withUpdateOrgXDomain: true,
 			withUpdateXDomain: true

--- a/src/Chart/api/category.ts
+++ b/src/Chart/api/category.ts
@@ -22,6 +22,7 @@ export default {
 
 		if (arguments.length > 1) {
 			config.axis_x_categories[i] = category;
+			$$.state.dirty.data = true;
 			$$.redraw();
 		}
 
@@ -51,6 +52,7 @@ export default {
 		}
 
 		config.axis_x_categories = categories;
+		$$.state.dirty.data = true;
 		$$.redraw();
 
 		return config.axis_x_categories;

--- a/src/Chart/api/chart.ts
+++ b/src/Chart/api/chart.ts
@@ -30,6 +30,7 @@ export default {
 			config.size_height = size ? size.height : null;
 
 			state.resizing = true;
+			state.dirty.size = true;
 
 			this.flush(false);
 			$$.resizeFunction();
@@ -72,6 +73,9 @@ export default {
 			}
 
 			$$.scale.zoom = null;
+
+			// Ensure shapes are fully updated on flush
+			state.dirty.data = true;
 
 			soft ?
 				$$.redraw({
@@ -117,6 +121,9 @@ export default {
 
 		if (notEmpty($$)) {
 			$$.callPluginHook("$willDestroy");
+
+			// clear interaction caches that hold DOM references
+			$$.cache?.remove(["setOverOut", "callOverOutForTouch"]);
 
 			$$.charts.splice($$.charts.indexOf(this), 1);
 

--- a/src/Chart/api/flow.ts
+++ b/src/Chart/api/flow.ts
@@ -199,6 +199,8 @@ export default {
 
 			// Set targets
 			$$.updateTargets($$.data.targets);
+			$$.state.dirty.data = true;
+			$$.state._eventRectFingerprint = null;
 
 			// Redraw with new targets
 			$$.redraw({

--- a/src/Chart/api/group.ts
+++ b/src/Chart/api/group.ts
@@ -27,6 +27,7 @@ export default {
 		}
 
 		config.data_groups = groups;
+		$$.state.dirty.data = true;
 		$$.redraw();
 
 		return config.data_groups;

--- a/src/Chart/api/load.ts
+++ b/src/Chart/api/load.ts
@@ -147,6 +147,9 @@ export default {
 		const $$ = this.internal;
 		const {config} = $$;
 
+		$$.state.dirty.data = true;
+		$$.state._eventRectFingerprint = null;
+
 		// update xs if specified
 		args.xs && $$.addXs(args.xs);
 
@@ -225,6 +228,9 @@ export default {
 		}
 
 		const ids = $$.mapToTargetIds(args.ids);
+
+		$$.state.dirty.data = true;
+		$$.state._eventRectFingerprint = null;
 
 		$$.unload(ids, () => {
 			$$.redraw({

--- a/src/Chart/api/show.ts
+++ b/src/Chart/api/show.ts
@@ -9,9 +9,11 @@ import {callFn, endall} from "../../module/util";
  * @param {boolean} show Show or hide
  * @param {Array} targetIdsValue Target id values
  * @param {object} options Options
+ * @param {boolean} [options.withLegend=false] whether or not display legend
+ * @param {boolean} [skipRedraw=false] whether or not skip redraw after show/hide
  * @private
  */
-function showHide(show: boolean, targetIdsValue: string[], options: any): void {
+function showHide(show: boolean, targetIdsValue: string[], options: any, skipRedraw = false): void {
 	const $$ = this.internal;
 	const targetIds = $$.mapToTargetIds(targetIdsValue);
 	const hiddenIds = $$.state.hiddenTargetIds
@@ -19,6 +21,7 @@ function showHide(show: boolean, targetIdsValue: string[], options: any): void {
 		.filter(Boolean);
 
 	$$.state.toggling = true;
+	$$.state.dirty.visibility = true;
 
 	$$[`${show ? "remove" : "add"}HiddenTargetIds`](targetIds);
 
@@ -44,11 +47,13 @@ function showHide(show: boolean, targetIdsValue: string[], options: any): void {
 
 	options.withLegend && $$[`${show ? "show" : "hide"}Legend`](targetIds);
 
-	$$.redraw({
-		withUpdateOrgXDomain: true,
-		withUpdateXDomain: true,
-		withLegend: true
-	});
+	if (!skipRedraw) {
+		$$.redraw({
+			withUpdateOrgXDomain: true,
+			withUpdateXDomain: true,
+			withLegend: true
+		});
+	}
 
 	$$.state.toggling = false;
 }
@@ -127,9 +132,15 @@ export default {
 		$$.mapToTargetIds(targetIds)
 			.forEach((id: string) => targets[$$.isTargetToShow(id) ? "hide" : "show"].push(id));
 
-		// perform show & hide task separately
-		// https://github.com/naver/billboard.js/issues/454
-		targets.show.length && this.show(targets.show, options);
-		targets.hide.length && setTimeout(() => this.hide(targets.hide, options), 0);
+		if (targets.show.length && targets.hide.length) {
+			// Batch both operations with a single redraw
+			showHide.call(this, true, targets.show, options, true);
+			showHide.call(this, false, targets.hide, options);
+		} else {
+			// perform show & hide task separately
+			// https://github.com/naver/billboard.js/issues/454
+			targets.show.length && this.show(targets.show, options);
+			targets.hide.length && this.hide(targets.hide, options);
+		}
 	}
 };

--- a/src/Chart/api/x.ts
+++ b/src/Chart/api/x.ts
@@ -29,6 +29,7 @@ export default {
 				this.categories(x);
 			} else {
 				$$.updateTargetX(data.targets, x);
+				$$.state.dirty.data = true;
 
 				$$.redraw({
 					withUpdateOrgXDomain: true,
@@ -62,6 +63,7 @@ export default {
 
 		if (isObject(xs)) {
 			$$.updateTargetXs($$.data.targets, xs);
+			$$.state.dirty.data = true;
 
 			$$.redraw({
 				withUpdateOrgXDomain: true,

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -10,6 +10,7 @@ import {
 } from "d3-axis";
 import type {AxisType} from "../../../types/types";
 import {$AXIS, $COMMON} from "../../config/classes";
+import {KEY} from "../../module/Cache";
 import {
 	capitalize,
 	getBoundingRect,
@@ -617,7 +618,17 @@ class Axis {
 	 */
 	getMaxTickSize(id: AxisType, withoutRecompute?: boolean): {width: number, height: number} {
 		const $$ = this.owner;
-		const {config, state: {current, resizing}, $el: {svg, chart}} = $$;
+		const {config, state, $el: {svg, chart}} = $$;
+		const {current, resizing} = state;
+
+		// Generation-based cache: skip redundant measurements within same redraw cycle
+		const cacheKey = `${KEY.maxTickSize}_${id}_${!!withoutRecompute}`;
+		const cached = $$.cache.get(cacheKey);
+
+		if (cached && cached.generation === state.tickSizeGeneration) {
+			return cached.value;
+		}
+
 		const currentTickMax = current.maxTickSize[id];
 		const configPrefix = `axis_${id}`;
 		const max = {
@@ -635,7 +646,7 @@ class Axis {
 
 		if (svg) {
 			const isYAxis = /^y2?$/.test(id);
-			const targetsToShow = $$.filterTargetsToShow($$.data.targets);
+			const targetsToShow = state._targetsToShow || $$.filterTargetsToShow($$.data.targets);
 			const scale = $$.scale[id].copy().domain(
 				$$[`get${isYAxis ? "Y" : "X"}Domain`](targetsToShow, id)
 			);
@@ -736,6 +747,9 @@ class Axis {
 				currentTickMax[key] = max[key];
 			}
 		});
+
+		// Cache result for this redraw generation
+		$$.cache.add(cacheKey, {generation: state.tickSizeGeneration, value: currentTickMax});
 
 		return currentTickMax;
 	}

--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -788,6 +788,19 @@ export default class ChartInternal {
 
 		if (/^(true|parent)$/.test(resize_auto)) {
 			list.push(() => {
+				// Skip resize if dimensions haven't changed
+				const prevWidth = state.current.width;
+				const prevHeight = state.current.height;
+
+				$$.setContainerSize();
+
+				if (
+					prevWidth === state.current.width &&
+					prevHeight === state.current.height
+				) {
+					return;
+				}
+
 				state.resizing = true;
 
 				// https://github.com/naver/billboard.js/issues/2650

--- a/src/ChartInternal/data/convert.ts
+++ b/src/ChartInternal/data/convert.ts
@@ -172,6 +172,12 @@ export default {
 		// save x for update data by load when custom x and bb.x API
 		_setXS.bind($$)(ids, data, params);
 
+		// Build a Map for O(1) category-to-index lookups
+		const categoryIndexMap =
+			(params.customX && params.categorized && config.axis_x_categories.length) ?
+				new Map<string, number>(config.axis_x_categories.map((cat, i) => [cat, i])) :
+				null;
+
 		// convert to target
 		const targets = ids.map((id, index) => {
 			const convertedId = config.data_idConverter.bind($$.api)(id);
@@ -203,13 +209,20 @@ export default {
 					if ((isCategory || state.hasRadar) && index === 0 && !isUndefined(rawX)) {
 						if (!hasCategory && index === 0 && i === 0 && !isDataAppend) {
 							config.axis_x_categories = [];
+
+							if (categoryIndexMap) {
+								categoryIndexMap.clear();
+							}
 						}
 
-						x = config.axis_x_categories.indexOf(rawX);
+						const rawXStr = String(rawX);
+
+						x = categoryIndexMap?.get(rawXStr) ?? -1;
 
 						if (x === -1) {
 							x = config.axis_x_categories.length;
 							config.axis_x_categories.push(rawX);
+							categoryIndexMap?.set(rawXStr, x);
 						}
 					} else {
 						x = $$.generateTargetX(rawX, id, xIndex + i);

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -533,7 +533,7 @@ export default {
 		if (!targets) {
 			const {cache, data, state} = $$;
 			const cacheKey = KEY.filteredTargets;
-			const visibilityChecksum = state.hiddenTargetIds.join(",");
+			const visibilityChecksum = state._visibilityChecksum ?? "";
 			const storedChecksum = cache.get(KEY.visibilityChecksum);
 
 			// Invalidate cache if visibility changed
@@ -609,10 +609,12 @@ export default {
 
 	addHiddenTargetIds(targetIds: string[]): void {
 		this.addTargetIds("hiddenTargetIds", targetIds);
+		this.state._visibilityChecksum = this.state.hiddenTargetIds.join(",");
 	},
 
 	removeHiddenTargetIds(targetIds: string[]): void {
 		this.removeTargetIds("hiddenTargetIds", targetIds);
+		this.state._visibilityChecksum = this.state.hiddenTargetIds.join(",");
 	},
 
 	addHiddenLegendIds(targetIds: string[]): void {

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -269,6 +269,18 @@ export default {
 		const xScale = scale.zoom || scale.x;
 		const isRotated = config.axis_rotated;
 		const isMultipleX = $$.isMultipleX();
+
+		// Skip recalculation if scale domain hasn't changed
+		const xDomain = xScale?.domain();
+		const fingerprint = xDomain ?
+			`${xDomain[0]}_${xDomain[1]}_${$$.data.targets.length}` :
+			null;
+
+		if (fingerprint && fingerprint === state._eventRectFingerprint) {
+			return;
+		}
+
+		state._eventRectFingerprint = fingerprint;
 		let x;
 		let y;
 		let w;
@@ -498,6 +510,7 @@ export default {
 		const $$ = this;
 		const {$el: {circle, tooltip}} = $$;
 
+		$$.state._lastTooltipMouse = null;
 		$$.$el.svg.select(`.${$EVENT.eventRect}`).style("cursor", null);
 		$$.hideGridFocus();
 
@@ -587,7 +600,20 @@ export default {
 
 					// do nothing while dragging/flowing
 					if (state.dragging || state.flowing || $$.hasArcType() || eventOnSameIdx) {
-						config.tooltip_show && eventOnSameIdx && $$.setTooltipPosition();
+						// Throttle tooltip position updates: skip if mouse hasn't moved enough
+						if (config.tooltip_show && eventOnSameIdx) {
+							const [mx, my] = getPointer(event, this);
+							const last = state._lastTooltipMouse;
+
+							if (
+								!last ||
+								(mx - last[0]) ** 2 + (my - last[1]) ** 2 >= 9
+							) {
+								state._lastTooltipMouse = [mx, my];
+								$$.setTooltipPosition();
+							}
+						}
+
 						return;
 					}
 

--- a/src/ChartInternal/internals/domain.ts
+++ b/src/ChartInternal/internals/domain.ts
@@ -20,58 +20,96 @@ import {
 import type {IData, TDomainRange} from "../data/IData";
 
 export default {
-	getYDomainMinMax(targets, type: "min" | "max"): number | Date | undefined {
+	/**
+	 * Get both min and max Y domain values in a single pass.
+	 * Avoids calling getValuesAsIdKeyed twice.
+	 * @param {Array} targets Target data
+	 * @returns {[number|Date|undefined, number|Date|undefined]} [min, max]
+	 * @private
+	 */
+	getYDomainMinMaxBoth(targets): [number | Date | undefined, number | Date | undefined] {
 		const $$ = this;
 		const {axis, config} = $$;
-		const isMin = type === "min";
-
 		const dataGroups = config.data_groups;
 		const ids = $$.mapToIds(targets);
-		const idsSet = toSet(ids); // O(1) lookup instead of O(n) indexOf
-		const ys = $$.getValuesAsIdKeyed(targets);
+		const idsSet = toSet(ids);
+		const rawYs = $$.getValuesAsIdKeyed(targets);
 
 		if (dataGroups.length > 0) {
-			const hasValue = $$[`has${isMin ? "Negative" : "Positive"}ValueInTargets`](targets);
-
-			// Pre-compute axis IDs for O(1) lookup instead of repeated axis.getId() calls
+			const hasNegative = $$.hasNegativeValueInTargets(targets);
+			const hasPositive = $$.hasPositiveValueInTargets(targets);
 			const axisIdMap = new Map(ids.map(id => [id, axis.getId(id)]));
 
+			// Clone ys into separate min/max copies since grouped calculation mutates values
+			const ysMin = {};
+			const ysMax = {};
+
+			for (const key in rawYs) {
+				ysMin[key] = rawYs[key].slice();
+				ysMax[key] = rawYs[key].slice();
+			}
+
 			dataGroups.forEach(groupIds => {
-				// Determine baseId
-				const idsInGroup = groupIds
-					.filter(v => idsSet.has(v));
+				const idsInGroup = groupIds.filter(v => idsSet.has(v));
 
 				if (idsInGroup.length) {
 					const baseId = idsInGroup[0];
 					const baseAxisId = axisIdMap.get(baseId);
 
-					// Initialize base value. Set to 0 if not match with the condition
-					if (hasValue && ys[baseId]) {
-						ys[baseId] = ys[baseId]
-							.map(v => ((isMin ? v < 0 : v > 0) ? v : 0));
+					// Initialize base values for min (negative) and max (positive)
+					if (ysMin[baseId] && hasNegative) {
+						ysMin[baseId] = ysMin[baseId].map(v => (v < 0 ? v : 0));
+					}
+
+					if (ysMax[baseId] && hasPositive) {
+						ysMax[baseId] = ysMax[baseId].map(v => (v > 0 ? v : 0));
 					}
 
 					idsInGroup
 						.filter((v, i) => i > 0)
 						.forEach(id => {
-							if (ys[id]) {
+							if (ysMin[id]) {
 								const axisId = axisIdMap.get(id);
 
-								ys[id].forEach((v, i) => {
+								ysMin[id].forEach((v, i) => {
 									const val = +v;
-									const meetCondition = isMin ? val > 0 : val < 0;
 
-									if (axisId === baseAxisId && !(hasValue && meetCondition)) {
-										ys[baseId][i] += val;
+									// min pass: skip positive values when hasNegative
+									if (axisId === baseAxisId && !(hasNegative && val > 0)) {
+										ysMin[baseId][i] += val;
+									}
+								});
+							}
+
+							if (ysMax[id]) {
+								const axisId = axisIdMap.get(id);
+
+								ysMax[id].forEach((v, i) => {
+									const val = +v;
+
+									// max pass: skip negative values when hasPositive
+									if (axisId === baseAxisId && !(hasPositive && val < 0)) {
+										ysMax[baseId][i] += val;
 									}
 								});
 							}
 						});
 				}
 			});
+
+			return [
+				getMinMax("min", Object.keys(ysMin).map(key => getMinMax("min", ysMin[key]))),
+				getMinMax("max", Object.keys(ysMax).map(key => getMinMax("max", ysMax[key])))
+			];
 		}
 
-		return getMinMax(type, Object.keys(ys).map(key => getMinMax(type, ys[key])));
+		// No groups — compute min/max directly from rawYs without cloning
+		const keys = Object.keys(rawYs);
+
+		return [
+			getMinMax("min", keys.map(key => getMinMax("min", rawYs[key]))),
+			getMinMax("max", keys.map(key => getMinMax("max", rawYs[key])))
+		];
 	},
 
 	/**
@@ -130,8 +168,9 @@ export default {
 		const showHorizontalDataLabel = $$.hasDataLabel() && config.axis_rotated;
 		const showVerticalDataLabel = $$.hasDataLabel() && !config.axis_rotated;
 
-		let yDomainMin = $$.getYDomainMinMax(yTargets, "min");
-		let yDomainMax = $$.getYDomainMinMax(yTargets, "max");
+		const [yDomainMinVal, yDomainMaxVal] = $$.getYDomainMinMaxBoth(yTargets);
+		let yDomainMin = yDomainMinVal;
+		let yDomainMax = yDomainMaxVal;
 
 		let isZeroBased = [TYPE.BAR, TYPE.BUBBLE, TYPE.SCATTER, ...TYPE_BY_CATEGORY.Line]
 			.some(v => {

--- a/src/ChartInternal/internals/grid.ts
+++ b/src/ChartInternal/internals/grid.ts
@@ -385,11 +385,15 @@ export default {
 	 */
 	showGridFocus(data?): void {
 		const $$ = this;
-		const {config, state: {width, height}} = $$;
+		const {config, state, state: {width, height}} = $$;
 		const isRotated = config.axis_rotated;
-		const focusEl = $$.$el.main.selectAll(
-			`line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`
-		);
+
+		// Cache grid focus selection to avoid repeated DOM queries on mousemove
+		const focusEl = state._gridFocusEl?.size() ?
+			state._gridFocusEl :
+			(state._gridFocusEl = $$.$el.main.selectAll(
+				`line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`
+			));
 
 		const dataToShow = (data || [focusEl.datum()]).filter(d =>
 			d && isValue($$.getBaseValue(d))
@@ -461,12 +465,16 @@ export default {
 
 	hideGridFocus(): void {
 		const $$ = this;
-		const {state: {inputType, resizing}, $el: {main}} = $$;
+		const {state, state: {inputType, resizing}, $el: {main}} = $$;
 
 		if (inputType === "mouse" || !resizing) {
-			main.selectAll(`line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`)
-				.style("visibility", "hidden");
+			const focusEl = state._gridFocusEl?.size() ?
+				state._gridFocusEl :
+				(state._gridFocusEl = main.selectAll(
+					`line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`
+				));
 
+			focusEl.style("visibility", "hidden");
 			$$.hideCircleFocus?.();
 		}
 	},

--- a/src/ChartInternal/internals/redraw.ts
+++ b/src/ChartInternal/internals/redraw.ts
@@ -4,6 +4,7 @@
  */
 import {transition as d3Transition} from "d3-transition";
 import {$COMMON, $SELECT, $TEXT} from "../../config/classes";
+import {KEY} from "../../module/Cache";
 import {generateWait} from "../../module/generator";
 import {callFn, capitalize, getOption, isTabVisible, notEmpty} from "../../module/util";
 
@@ -15,7 +16,31 @@ export default {
 
 		state.redrawing = true;
 
+		// Increment generation counter for per-redraw caching (e.g. getMaxTickSize)
+		state.tickSizeGeneration = (state.tickSizeGeneration || 0) + 1;
+
+		// Invalidate per-redraw caches (only when size changed or initializing)
+		if (options.initializing || state.dirty.size || state.dirty.data || !state.rendered) {
+			$$.cache.remove([KEY.svgLeft]);
+		}
+
 		const targetsToShow = $$.filterTargetsToShow($$.data.targets);
+
+		// Cache for reuse by sub-methods within this redraw cycle
+		state._targetsToShow = targetsToShow;
+
+		// Capture and reset dirty flags immediately to avoid race conditions
+		// (async afterRedraw could wipe flags set by a subsequent redraw)
+		const dirtySnapshot = {
+			data: state.dirty.data,
+			visibility: state.dirty.visibility,
+			size: state.dirty.size
+		};
+
+		state.dirty.data = false;
+		state.dirty.visibility = false;
+		state.dirty.size = false;
+
 		const {flow, initializing} = options;
 		const wth = $$.getWithOption(options);
 		const duration = wth.Transition ? config.transition_duration : 0;
@@ -45,6 +70,11 @@ export default {
 		// title - position early so other elements can calculate correct padding
 		$$.redrawTitle?.();
 
+		// Shape DOM updates (D3 data join: enter/update/exit) are only needed when data or
+		// visibility changes. Zoom/brush only need redraw*() (position recalculation via
+		// getRedrawList), not update*(). New APIs that modify data must set dirty flags.
+		const needShapeUpdate = dirtySnapshot.data || dirtySnapshot.visibility || initializing;
+
 		// update axis
 		if (state.hasAxis) {
 			// @TODO: Make 'init' state to be accessible everywhere not passing as argument.
@@ -60,7 +90,9 @@ export default {
 				const name = capitalize(v);
 
 				if ((/^(line|area)$/.test(v) && $$.hasTypeOf(name)) || $$.hasType(v)) {
-					$$[`update${name}`](wth.TransitionForExit);
+					if (needShapeUpdate) {
+						$$[`update${name}`](wth.TransitionForExit);
+					}
 				}
 			});
 
@@ -93,13 +125,19 @@ export default {
 		}
 
 		if (!state.resizing && !treemap && ($$.hasPointType() || state.hasRadar)) {
-			$$.updateCircle();
+			if (needShapeUpdate) {
+				$$.updateCircle();
+			}
 		} else if ($$.hasLegendDefsPoint?.()) {
 			$$.data.targets.forEach($$.point("create", this));
 		}
 
 		// text
-		$$.hasDataLabel() && !$$.hasArcType(null, ["radar"]) && $$.updateText();
+		if ($$.hasDataLabel() && !$$.hasArcType(null, ["radar"])) {
+			if (needShapeUpdate) {
+				$$.updateText();
+			}
+		}
 
 		initializing && $$.updateTypesElements();
 
@@ -145,6 +183,8 @@ export default {
 			flowFn && flowFn();
 
 			state.redrawing = false;
+			state._targetsToShow = null;
+
 			callFn(config.onrendered, $$.api);
 		};
 
@@ -158,7 +198,7 @@ export default {
 				d3Transition().duration(duration)
 					.each(() => {
 						redrawList
-							.reduce((acc, t1) => acc.concat(t1), [])
+							.flatMap(t1 => t1)
 							.forEach(t => waitForDraw.add(t));
 					})
 					.call(waitForDraw, afterRedraw);

--- a/src/ChartInternal/internals/scale.ts
+++ b/src/ChartInternal/internals/scale.ts
@@ -62,12 +62,23 @@ export default {
 	 * @param {number} min Min value
 	 * @param {number} max Max value
 	 * @param {Array} domain Domain value
+	 * @param {object} [existing] Existing scale function to be updated
 	 * @returns {function} Scale function
 	 * @private
 	 */
-	getYScale(id: "y" | "y2", min: number, max: number, domain: number[]): Function {
+	getYScale(id: "y" | "y2", min: number, max: number, domain: number[], existing?): Function {
 		const $$ = this;
-		const scale = getScale($$.axis.getAxisType(id), min, max);
+		const type = $$.axis.getAxisType(id);
+
+		// Reuse existing scale if type hasn't changed — just update range
+		if (existing && existing.type === type) {
+			existing.range([min, max]);
+			domain && existing.domain(domain);
+
+			return existing;
+		}
+
+		const scale = getScale(type, min, max);
 
 		domain && scale.domain(domain);
 
@@ -195,12 +206,13 @@ export default {
 
 			// y Axis
 			scale.y = $$.getYScale("y", min.y, max.y,
-				scale.y ? scale.y.domain() : config.axis_y_default);
+				scale.y ? scale.y.domain() : config.axis_y_default, scale.y);
 			scale.subY = $$.getYScale(
 				"y",
 				min.subY,
 				max.subY,
-				scale.subY ? scale.subY.domain() : config.axis_y_default
+				scale.subY ? scale.subY.domain() : config.axis_y_default,
+				scale.subY
 			);
 
 			axis.setAxis("y", scale.y, config.axis_y_tick_outer, isInit);
@@ -208,12 +220,13 @@ export default {
 			// y2 Axis
 			if (config.axis_y2_show) {
 				scale.y2 = $$.getYScale("y2", min.y, max.y,
-					scale.y2 ? scale.y2.domain() : config.axis_y2_default);
+					scale.y2 ? scale.y2.domain() : config.axis_y2_default, scale.y2);
 				scale.subY2 = $$.getYScale(
 					"y2",
 					min.subY,
 					max.subY,
-					scale.subY2 ? scale.subY2.domain() : config.axis_y2_default
+					scale.subY2 ? scale.subY2.domain() : config.axis_y2_default,
+					scale.subY2
 				);
 
 				axis.setAxis("y2", scale.y2, config.axis_y2_tick_outer, isInit);

--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -93,7 +93,17 @@ export default {
 
 	getSvgLeft(withoutRecompute?: boolean): number {
 		const $$ = this;
-		const {config, state: {hasAxis}, $el} = $$;
+		const {cache, config, state: {hasAxis}, $el} = $$;
+
+		// Return cached value when recompute is not forced
+		if (withoutRecompute) {
+			const cached = cache.get(KEY.svgLeft);
+
+			if (cached !== null) {
+				return cached;
+			}
+		}
+
 		const isRotated = config.axis_rotated;
 		const hasLeftAxisRect = isRotated || (!isRotated && !config.axis_y_inner);
 		const leftAxisClass = isRotated ? $AXIS.axisX : $AXIS.axisY;
@@ -122,7 +132,11 @@ export default {
 		const svgLeft = svgRect.right - chartRectLeft -
 			(hasArc ? 0 : $$.getCurrentPaddingByDirection("left", withoutRecompute));
 
-		return svgLeft > 0 ? svgLeft : 0;
+		const result = svgLeft > 0 ? svgLeft : 0;
+
+		cache.add(KEY.svgLeft, result);
+
+		return result;
 	},
 
 	updateDimension(withoutAxis?: boolean): void {
@@ -328,9 +342,12 @@ export default {
 
 		!isInit && $$.setContainerSize();
 
+		// Cache legend dimensions to avoid redundant calls
+		const legendWidth = legend ? $$.getLegendWidth() : 0;
+		const legendHeight = legend ? $$.getLegendHeight() : 0;
 		const currLegend = {
-			width: legend ? $$.getLegendWidth() : 0,
-			height: legend ? $$.getLegendHeight() : 0
+			width: legendWidth,
+			height: legendHeight
 		};
 
 		if (!isNonAxis && config.axis_x_show && config.axis_x_tick_autorotate) {
@@ -339,11 +356,11 @@ export default {
 
 		const legendSize = {
 			right: config.legend_show && state.isLegendRight ?
-				$$.getLegendWidth() + (isFitPadding ? 0 : 20) :
+				legendWidth + (isFitPadding ? 0 : 20) :
 				0,
 			bottom: !config.legend_show || state.isLegendRight || state.isLegendInset ?
 				0 :
-				currLegend.height
+				legendHeight
 		};
 
 		const xAxisHeight = isRotated || isNonAxis ? 0 : $$.getHorizontalAxisHeight("x");

--- a/src/config/Store/State.ts
+++ b/src/config/Store/State.ts
@@ -172,7 +172,27 @@ export default class State {
 
 			// RAF batching for zoom/drag interactions
 			pendingRaf: <number | null>null,
-			rafBatchQueue: <Array<() => void>>[]
+			rafBatchQueue: <Array<() => void>>[],
+
+			// Dirty flags for selective redraw
+			dirty: {
+				data: false, // data changed (load/unload)
+				visibility: false, // show/hide toggled
+				size: false // dimensions changed
+			},
+
+			// Performance: per-redraw generation counter for tick size caching
+			tickSizeGeneration: 0,
+
+			// Performance: cached targets for reuse within redraw cycle
+			_targetsToShow: <any[] | null>null,
+			_eventRectFingerprint: <string | null>null,
+
+			// Performance: throttle tooltip position updates on mousemove
+			_lastTooltipMouse: <number[] | null>null,
+
+			// Performance: cached grid focus D3 selection
+			_gridFocusEl: <any>null
 		};
 	}
 }

--- a/src/module/Cache.ts
+++ b/src/module/Cache.ts
@@ -19,6 +19,7 @@ export const KEY = {
 	domainMinMax: "$domainMinMax",
 	filteredTargets: "$filteredTargets",
 	filteredNullish: "$filteredNullish",
+	svgLeft: "$svgLeft",
 	visibilityChecksum: "visibilityChecksum",
 	legendItemTextBox: "legendItemTextBox",
 	legendItemMap: "$legendItemMap",
@@ -27,7 +28,8 @@ export const KEY = {
 	setOverOut: "setOverOut",
 	callOverOutForTouch: "callOverOutForTouch",
 	textRect: "textRect",
-	shapeOffset: "$shapeOffset"
+	shapeOffset: "$shapeOffset",
+	maxTickSize: "$maxTickSize"
 };
 
 export default class Cache {
@@ -70,7 +72,7 @@ export default class Cache {
 
 			for (let i = 0, id; (id = key[i]); i++) {
 				if (id in this.cache) {
-					targets.push(this.cloneTarget(this.cache[id]));
+					targets.push(this.cache[id]);
 				}
 			}
 
@@ -89,7 +91,7 @@ export default class Cache {
 	 * @private
 	 */
 	has(key: string): boolean {
-		return key in this.cache && this.cache[key] !== null;
+		return key in this.cache;
 	}
 
 	/**
@@ -112,7 +114,7 @@ export default class Cache {
 		for (const x in $$.cache) {
 			// reset the prefixed '$' key(which is internal use data) only.
 			if (all || /^\$/.test(x)) {
-				$$.cache[x] = null;
+				delete $$.cache[x];
 			}
 		}
 	}


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
- Generation-based caching for getMaxTickSize() to avoid redundant DOM measurements within same redraw cycle
- Skip D3 enter/merge when data/visibility unchanged via dirty flags
- Scale fingerprinting in updateEventRectData() to skip O(n) recalculation when domain is unchanged
- Batch filterTargetsToShow() in state for reuse by sub-methods during redraw
- Set dirty flags across all data-mutating APIs

### Benchmark
> Condition: Bar type, 5×1000 data 

 | Metric | 3.18.0 | this update | Improvement |                                         
  |---|---|---|---|                                                              
  | **Load** (avg) | 95.2 ms | 66.8 ms | **-29.8%** |                                 
  | **Resize** (avg) | 51.8 ms | 31.1 ms | **-40.0%** |
  | **CPU (Load)** | ~31% | ~19% | **-38.7%** |                                       
  | **CPU (Resize)** | ~24.1% | ~14% | **-41.9%** |                                   
  | **Memory (Load)** | 78.4 MB | 78.1 MB | Same |                                    
  | **Memory (Resize)** | 72.2 MB | 77.3 MB | +7.1% |   

  Load ~30% faster, Resize ~40% faster. CPU usage reduced by nearly 40% overall.