### PR TITLE
refactor(state): abstract _targetsToShow cache and fix stale state bugs

### DIFF
--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -678,7 +678,7 @@ class Axis {
 
 		if (svg) {
 			const isYAxis = /^y2?$/.test(id);
-			const targetsToShow = state._targetsToShow || $$.filterTargetsToShow($$.data.targets);
+			const targetsToShow = $$.getTargetsToShow();
 			const scale = $$.scale[id].copy().domain(
 				$$[`get${isYAxis ? "Y" : "X"}Domain`](targetsToShow, id)
 			);
@@ -859,7 +859,7 @@ class Axis {
 			maxOverflow = Math.max(maxOverflow, overflow);
 		}
 
-		const filteredTargets = $$.filterTargetsToShow($$.data.targets);
+		const filteredTargets = $$.getTargetsToShow();
 		let tickOffset = 0;
 
 		if (

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -562,6 +562,12 @@ export default {
 		return this.state.hiddenLegendIds.indexOf(targetId) < 0;
 	},
 
+	getTargetsToShow(): any[] {
+		const {state} = this;
+
+		return state._targetsToShow ?? this.filterTargetsToShow();
+	},
+
 	filterTargetsToShow(targets?) {
 		const $$ = this;
 

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -270,10 +270,12 @@ export default {
 		const isRotated = config.axis_rotated;
 		const isMultipleX = $$.isMultipleX();
 
-		// Skip recalculation if scale domain hasn't changed
+		// Skip recalculation if scale domain or visibility hasn't changed
 		const xDomain = xScale?.domain();
 		const fingerprint = xDomain ?
-			`${xDomain[0]}_${xDomain[1]}_${$$.data.targets.length}` :
+			`${xDomain[0]}_${xDomain[1]}_${$$.data.targets.length}_${
+				state.hiddenTargetIds.join(",")
+			}` :
 			null;
 
 		if (fingerprint && fingerprint === state._eventRectFingerprint) {

--- a/src/ChartInternal/internals/grid.ts
+++ b/src/ChartInternal/internals/grid.ts
@@ -279,7 +279,10 @@ export default {
 
 	initFocusGrid(): void {
 		const $$ = this;
-		const {config, state: {clip}, $el} = $$;
+		const {config, state, state: {clip}, $el} = $$;
+
+		// Invalidate cached D3 selection in case grid is re-initialized
+		state._gridFocusEl = null;
 		const isFront = config.grid_front;
 		const className = `.${isFront && $el.gridLines.main ? $GRID.gridLines : $COMMON.chart}${
 			isFront ? " + *" : ""

--- a/src/ChartInternal/shape/arc.ts
+++ b/src/ChartInternal/shape/arc.ts
@@ -162,7 +162,7 @@ function _getRadiusFn(expandRate = 0) {
 	const $$ = this;
 	const {config, state} = $$;
 	const hasMultiArcGauge = $$.hasMultiArcGauge();
-	const singleArcWidth = state.gaugeArcWidth / $$.filterTargetsToShow($$.data.targets).length;
+	const singleArcWidth = state.gaugeArcWidth / $$.getTargetsToShow().length;
 	const expandWidth = expandRate ?
 		(
 			Math.min(
@@ -304,7 +304,7 @@ export default {
 		const dataType = config.data_type;
 		const padding = config[`${dataType}_padding`];
 		const w = config.gauge_width || config.donut_width;
-		const gaugeArcWidth = $$.filterTargetsToShow($$.data.targets).length *
+		const gaugeArcWidth = $$.getTargetsToShow().length *
 			config.gauge_arcs_minWidth;
 
 		// Radius reduction ratio when labels are present
@@ -1139,7 +1139,7 @@ export default {
 		const {config, state} = $$;
 		const hasMultiArcGauge = $$.hasMultiArcGauge();
 		const isFullCircle = config.gauge_fullCircle;
-		const showEmptyTextLabel = $$.filterTargetsToShow($$.data.targets).length === 0 &&
+		const showEmptyTextLabel = $$.getTargetsToShow().length === 0 &&
 			!!config.data_empty_label_text;
 
 		const startAngle = $$.getStartingAngle();

--- a/src/ChartInternal/shape/gauge.ts
+++ b/src/ChartInternal/shape/gauge.ts
@@ -84,7 +84,7 @@ export default {
 				if (hiddenTargetIds.indexOf(d.data.id) < 0) {
 					const updated = $$.updateAngle(d);
 					const innerLineLength = state.gaugeArcWidth /
-						$$.filterTargetsToShow($$.data.targets).length *
+						$$.getTargetsToShow().length *
 						(updated.index + 1);
 					const lineAngle = updated.endAngle - Math.PI / 2;
 					const arcInnerRadius = state.radius - innerLineLength;

--- a/src/ChartInternal/shape/shape.ts
+++ b/src/ChartInternal/shape/shape.ts
@@ -590,7 +590,7 @@ export default {
 		if (!isGrouped && isObjectType(config[configName])) {
 			result = {_$width: result, _$total: []};
 
-			$$.filterTargetsToShow($$.data.targets).forEach(v => {
+			$$.getTargetsToShow().forEach(v => {
 				if (config[configName][v.id]) {
 					result[v.id] = getWidth(v.id);
 					result._$total.push(result[v.id] || result._$width);


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
- Add getTargetsToShow() getter to data.ts; returns _targetsToShow during redraw cycle, falls back to filterTargetsToShow() otherwise — removes the inline || fallback duplicated across 7 call sites
- Fix _eventRectFingerprint to include hiddenTargetIds so show/hide/toggle correctly invalidates the event rect cache (prevents stale isMultipleX behavior after visibility changes)
- Fix _gridFocusEl stale DOM reference by resetting to null in initFocusGrid(), ensuring re-init always queries fresh elements
