### PR TITLE
fix(zoom): drag zoom boundary release + circle transition desync

### DIFF
--- a/src/ChartInternal/interactions/zoom.ts
+++ b/src/ChartInternal/interactions/zoom.ts
@@ -379,6 +379,16 @@ export default {
 			index: isRotated ? 1 : 0
 		};
 
+		// Clamp pointer position to a valid range. When axis.x.extent is
+		// configured it takes precedence; otherwise fall back to chart bounds
+		// so that releasing outside the chart (issue #4131) still produces a
+		// usable end value instead of being silently dropped by withinRange().
+		const clampPointer = (v: number): number => {
+			const [lo, hi] = extent ?? [0, isRotated ? state.height : state.width];
+
+			return Math.min(Math.max(v, lo), hi);
+		};
+
 		$$.zoomBehaviour = d3Drag()
 			.clickDistance(4)
 			.on("start", function(event) {
@@ -397,16 +407,7 @@ export default {
 						.attr("height", isRotated ? 0 : state.height);
 				}
 
-				start = getPointer(event, this as SVGAElement)[prop.index];
-
-				if (extent) {
-					if (start < extent[0]) {
-						start = extent[0];
-					} else if (start > extent[1]) {
-						start = extent[1];
-					}
-				}
-
+				start = clampPointer(getPointer(event, this as SVGAElement)[prop.index]);
 				end = start;
 
 				zoomRect
@@ -416,15 +417,7 @@ export default {
 				$$.onZoomStart(event);
 			})
 			.on("drag", function(event) {
-				end = getPointer(event, this as SVGAElement)[prop.index];
-
-				if (extent) {
-					if (end > extent[1]) {
-						end = extent[1];
-					} else if (end < extent[0]) {
-						end = extent[0];
-					}
-				}
+				end = clampPointer(getPointer(event, this as SVGAElement)[prop.index]);
 
 				zoomRect
 					.attr(prop.axis, Math.min(start, end))
@@ -434,6 +427,10 @@ export default {
 				const scale = $$.scale.zoom || $$.scale.x;
 
 				state.event = event;
+				// Final clamp: when release happens outside the chart, the
+				// last pointer value may still be out-of-range (e.g. no drag
+				// event fired between the last in-bounds move and release).
+				end = clampPointer(end);
 
 				zoomRect
 					.attr(prop.axis, 0)

--- a/src/ChartInternal/shape/point.ts
+++ b/src/ChartInternal/shape/point.ts
@@ -200,10 +200,13 @@ export default {
 				flow && sel.attr("cx", cx);
 
 				// Only animate circles that already have a position; new circles jump directly
-				// to avoid them sliding in from the origin (cx=0)
+				// to avoid them sliding in from the origin (cx=0).
+				// Use a distinct transition name from the opacity transition below —
+				// reusing the same name would interrupt the cx/cy transition before
+				// it can commit, leaving circles stranded at their old scale positions.
 				$T(sel.filter(function() {
 					return !!this.getAttribute("cx");
-				}), true, t)
+				}), true, `${t}-pos`)
 					.attr("cx", cx).attr("cy", cy).style("fill", $$.updateCircleColor.bind($$));
 
 				sel.filter(function() {

--- a/test/interactions/zoom-spec.ts
+++ b/test/interactions/zoom-spec.ts
@@ -267,7 +267,7 @@ describe("ZOOM", function() {
 			const {$: {main}, internal: {scale, $el}} = chart;
 			const eventRect = $el.eventRect.node();;
 
-		
+
 			new Promise((resolve, reject) => {
 				util.fireEvent(eventRect, "mousedown", {
 					clientX: 50,
@@ -292,7 +292,7 @@ describe("ZOOM", function() {
 						clientX: 150,
 						clientY: 100
 					}, chart);
-	
+
 					expect(eventOrder).to.be.deep.equal(["start", "zoom", "end"]);
 
 					// when
@@ -304,6 +304,102 @@ describe("ZOOM", function() {
 					done(1);
 				}, 350);
 			});
+		}));
+
+		// https://github.com/naver/billboard.js/issues/4131
+		it("onzoomend should fire when drag zoom release happens outside the chart boundary", () => new Promise(done => {
+			const {internal: {$el}} = chart;
+			const eventRect = $el.eventRect.node();
+			const widthBeforeRelease = chart.internal.state.width;
+
+			eventOrder = [];
+
+			new Promise(resolve => {
+				util.fireEvent(eventRect, "mousedown", {
+					clientX: 80,
+					clientY: 100
+				}, chart);
+
+				resolve(true);
+			}).then(() => new Promise(resolve => {
+				setTimeout(() => {
+					// drag toward the chart's right edge
+					util.fireEvent(eventRect, "mousemove", {
+						clientX: 200,
+						clientY: 100
+					}, chart);
+
+					resolve(true);
+				}, 350);
+			})).then(() => {
+				setTimeout(() => {
+					// release BEYOND the chart's right edge (simulating the
+					// user's cursor leaving the chart before mouseup).
+					util.fireEvent(eventRect, "mouseup", {
+						clientX: widthBeforeRelease + 400,
+						clientY: 100
+					}, chart);
+
+					// zoom should have been applied and onzoomend fired
+					expect(eventOrder).to.include("end");
+
+					chart.unzoom();
+					done(1);
+				}, 350);
+			});
+		}));
+
+		// https://github.com/naver/billboard.js/issues/4131 (follow-up)
+		// Circles must reposition to the new zoom scale alongside the line/axis.
+		// Previously the cx/cy transition was silently interrupted because it
+		// shared the same transition name as the opacity transition on the
+		// same selection, leaving circles stranded at pre-zoom positions while
+		// line and axis correctly moved to zoom positions.
+		// This test uses a non-zero transition duration so the bug surfaces —
+		// with duration=0 the transition commits instantly and the interruption
+		// would not leave circles stranded.
+		it("data point circles should reposition on chart.zoom() in sync with the line", () => new Promise(done => {
+			args = {
+				size: {width: 300, height: 250},
+				data: {
+					columns: [["data1", 30, 200, 100, 400, 150, 250, 150, 200, 170, 240, 350, 150]],
+					type: "line"
+				},
+				zoom: {enabled: true, type: "drag"},
+				transition: {duration: 100}
+			};
+			chart = util.generate(args);
+
+			setTimeout(() => {
+				const getCircleCx = () =>
+					chart.$.circles.nodes().map((n: any) => +n.getAttribute("cx"));
+
+				const before = getCircleCx();
+
+				// zoom into the latter half
+				chart.zoom([4, 8]);
+
+				// wait longer than transition duration so the animation completes
+				setTimeout(() => {
+					const after = getCircleCx();
+
+					// At least some circles' cx MUST differ from their pre-zoom positions.
+					// Before the point.ts fix, the batched cx transition was interrupted by
+					// the opacity transition (both used the same name), so cx values stayed
+					// frozen at the pre-zoom scale.x values.
+					const changedCount = before.filter((v, i) => Math.abs(v - after[i]) > 0.5).length;
+
+					expect(changedCount).to.be.above(0);
+
+					// Sanity: circles in the visible zoom window should land inside [0, width]
+					const width = chart.internal.state.width;
+					const inWindow = after.filter((v: number) => v >= 0 && v <= width).length;
+
+					expect(inWindow).to.be.above(0);
+
+					done(1);
+				}, 500);
+			}, 100);
 		}));
 	});
 


### PR DESCRIPTION
## Summary

Two related drag-zoom fixes addressing issue #4131 and a follow-up visual desync discovered during verification.

### 1. \`onzoomend\` missing when release outside chart boundary (#4131)

Dragging the zoom-select rectangle past the chart edge and releasing the mouse outside the plot area silently dropped the zoom — no zoom applied, \`onzoomend\` never fired.

**Cause**: pointer clamping only applied when \`axis.x.extent\` was explicitly configured. Without it, \`getPointer()\` returned out-of-range values (e.g. \`-737\` or \`> width\`), the resulting domain fell outside \`scale.x\`'s range, and \`chart.zoom()\`'s \`withinRange()\` check silently rejected the call.

**Fix**: introduce a \`clampPointer()\` helper that falls back to \`[0, state.width/height]\` when no extent is configured. Clamp during start, drag, and once more at end (in case no drag event fired between the last in-bounds move and release).

### 2. Data point circles don't transition in sync with line/axis during zoom

After zoom, circles stayed frozen at pre-zoom positions while line and axis smoothly animated to the new scale — visible desync. On reset-zoom, circles reset before the line.

**Cause**: \`redrawCircle()\` (from the batched path in #4130) schedules two transitions on overlapping selections using the **same** transition name \`t\`:

```ts
const t = getRandom();
$T(sel.filter(...), true, t).attr("cx", cx).attr("cy", cy)...  // cx/cy transition
$T(sel, ..., t).style("opacity", ...)                           // opacity transition on full set
```

d3-transition rule: a new transition with the same name on the same element interrupts the previous one. The opacity transition cancelled the cx/cy transition before it could commit, leaving circle DOM attributes stuck at pre-zoom values.

**Fix**: use a distinct name (\`\${t}-pos\`) for the cx/cy transition so it runs independently of the opacity transition.