### PR TITLE
fix(canvas): align rendering and touch interaction parity

### DIFF
--- a/src/ChartInternal/internals/grid.ts
+++ b/src/ChartInternal/internals/grid.ts
@@ -9,8 +9,26 @@ import {AXIS_DEFAULT_TICK_COUNT} from "../../config/const";
 import {getPointer, isArray, isValue} from "../../module/util";
 
 // Grid position and text anchor helpers
+const GRID_FOCUS_SELECTOR = `line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`;
 const _getGridTextAnchor = d => isValue(d.position) || "end";
 const _getGridTextDx = d => (d.position === "start" ? 4 : (d.position === "middle" ? 0 : -4));
+
+/**
+ * Get current grid focus line selection.
+ * @param {object} $$ ChartInternal context
+ * @returns {d3.selection} Grid focus line selection
+ * @private
+ */
+function _getGridFocusEl($$): d3Selection {
+	const {state, $el: {main}} = $$;
+	const cached = state._gridFocusEl;
+	const mainNode = main.node();
+	const cachedNodes = cached?.nodes?.() || [];
+
+	return cachedNodes.length && cachedNodes.every(node => mainNode?.contains(node)) ?
+		cached :
+		(state._gridFocusEl = main.selectAll(GRID_FOCUS_SELECTOR));
+}
 
 /**
  * Get grid text x value getter function
@@ -389,15 +407,11 @@ export default {
 	 */
 	showGridFocus(data?): void {
 		const $$ = this;
-		const {config, state, state: {width, height}} = $$;
+		const {config, state: {width, height}} = $$;
 		const isRotated = config.axis_rotated;
 
 		// Cache grid focus selection to avoid repeated DOM queries on mousemove
-		const focusEl = state._gridFocusEl?.size() ?
-			state._gridFocusEl :
-			(state._gridFocusEl = $$.$el.main.selectAll(
-				`line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`
-			));
+		const focusEl = _getGridFocusEl($$);
 
 		const dataToShow = (data || [focusEl.datum()]).filter(d =>
 			d && isValue($$.getBaseValue(d))
@@ -467,16 +481,12 @@ export default {
 		$$.showCircleFocus?.(data);
 	},
 
-	hideGridFocus(): void {
+	hideGridFocus(force = false): void {
 		const $$ = this;
-		const {state, state: {inputType, resizing}, $el: {main}} = $$;
+		const {state: {inputType, resizing}} = $$;
 
-		if (inputType === "mouse" || !resizing) {
-			const focusEl = state._gridFocusEl?.size() ?
-				state._gridFocusEl :
-				(state._gridFocusEl = main.selectAll(
-					`line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`
-				));
+		if (force || inputType === "mouse" || !resizing) {
+			const focusEl = _getGridFocusEl($$);
 
 			focusEl.style("visibility", "hidden");
 			$$.hideCircleFocus?.();

--- a/src/ChartInternal/internals/legend.ts
+++ b/src/ChartInternal/internals/legend.ts
@@ -17,6 +17,9 @@ import {
 	tplProcess
 } from "../../module/util";
 
+const LEGEND_TOUCH_TAP_THRESHOLD = 10;
+const LEGEND_TOUCH_CLICK_TIMEOUT = 750;
+
 /**
  * Get color string for given data id
  * Internal helper used only within this file
@@ -79,6 +82,102 @@ function _buildLegendItemMap($$, legendItems): void {
 
 	// Cache the map
 	$$.cache.add(KEY.legendItemMap, itemMap);
+}
+
+/**
+ * Get touch point from a touch event.
+ * @param {TouchEvent} event Touch event
+ * @returns {Touch | undefined} Touch point
+ * @private
+ */
+function _getLegendTouchPoint(event): Touch | undefined {
+	return event.changedTouches?.[0] || event.touches?.[0];
+}
+
+/**
+ * Store the touch start position for legend tap detection.
+ * @param {object} $$ ChartInternal context
+ * @param {string} id Legend data id
+ * @param {TouchEvent} event Touch event
+ * @private
+ */
+function _setLegendTouchStart($$, id: string, event): void {
+	const touch = _getLegendTouchPoint(event);
+
+	$$.state.legendTouch = touch ?
+		{
+			id,
+			x: touch.clientX,
+			y: touch.clientY,
+			moved: false
+		} :
+		null;
+}
+
+/**
+ * Update whether the current legend touch moved beyond tap tolerance.
+ * @param {object} $$ ChartInternal context
+ * @param {TouchEvent} event Touch event
+ * @private
+ */
+function _updateLegendTouchMove($$, event): void {
+	const start = $$.state.legendTouch;
+	const touch = start && _getLegendTouchPoint(event);
+
+	if (touch) {
+		start.moved = start.moved ||
+			Math.abs(touch.clientX - start.x) > LEGEND_TOUCH_TAP_THRESHOLD ||
+			Math.abs(touch.clientY - start.y) > LEGEND_TOUCH_TAP_THRESHOLD;
+	}
+}
+
+/**
+ * Determine whether a touch sequence is a legend tap.
+ * @param {object} $$ ChartInternal context
+ * @param {string} id Legend data id
+ * @param {TouchEvent} event Touch event
+ * @returns {boolean} Whether the touch sequence is a tap
+ * @private
+ */
+function _isLegendTouchTap($$, id: string, event): boolean {
+	_updateLegendTouchMove($$, event);
+
+	const start = $$.state.legendTouch;
+
+	$$.state.legendTouch = null;
+
+	return !!start && start.id === id && !start.moved;
+}
+
+/**
+ * Mark a touch legend tap so the following compatibility click can be skipped.
+ * @param {object} $$ ChartInternal context
+ * @param {string} id Legend data id
+ * @private
+ */
+function _markLegendTouchClick($$, id: string): void {
+	$$.state.legendLastTouchClickId = id;
+	$$.state.legendLastTouchClickTime = Date.now();
+}
+
+/**
+ * Check if a click duplicates a recent touch legend tap.
+ * @param {object} $$ ChartInternal context
+ * @param {string} id Legend data id
+ * @returns {boolean} Whether the click is duplicate
+ * @private
+ */
+function _isDuplicateLegendTouchClick($$, id: string): boolean {
+	const {state} = $$;
+	const duplicate = state.legendLastTouchClickId === id &&
+		Date.now() - (state.legendLastTouchClickTime || 0) < LEGEND_TOUCH_CLICK_TIMEOUT;
+
+	if (duplicate) {
+		state.legendLastTouchClickId = null;
+		state.legendLastTouchClickTime = 0;
+	}
+
+	return duplicate;
 }
 
 export default {
@@ -456,6 +555,39 @@ export default {
 		const hasGauge = $$.hasType("gauge");
 		const useCssRule = config.boost_useCssRule;
 		const interaction = config.legend_item_interaction;
+		const eventType = interaction.dblclick ? "dblclick" : "click";
+		const hasClickInteraction = interaction || isFunction(config.legend_item_onclick);
+
+		const handleLegendToggle = function(event, id): void {
+			if (
+				!callFn(config.legend_item_onclick, api, id, !state.hiddenTargetIds.has(id))
+			) {
+				const {altKey, type} = event;
+				const selected = d3Select(this);
+
+				if (type === "dblclick" || altKey) {
+					// when focused legend is clicked(with altKey or double clicked), reset all hiding.
+					if (
+						state.hiddenTargetIds.size &&
+						!selected.classed($LEGEND.legendItemHidden)
+					) {
+						api.show();
+					} else {
+						api.hide();
+						api.show(id);
+					}
+				} else {
+					api.toggle(id);
+
+					selected.classed($FOCUS.legendItemFocused, false);
+				}
+			}
+
+			if (isTouch) {
+				$$.hideTooltip();
+				$$.hideGridFocus?.(true);
+			}
+		};
 
 		item
 			.attr("class", function(id) {
@@ -482,39 +614,32 @@ export default {
 			}
 
 			item
-				.on(interaction.dblclick ? "dblclick" : "click",
-					interaction || isFunction(config.legend_item_onclick) ?
-						function(event, id) {
-							if (
-								!callFn(config.legend_item_onclick, api, id,
-									!state.hiddenTargetIds.has(id))
-							) {
-								const {altKey, target, type} = event;
+				.on(eventType, hasClickInteraction ?
+					function(event, id) {
+						if (
+							isTouch && event.type === "click" &&
+							_isDuplicateLegendTouchClick($$, id)
+						) {
+							return;
+						}
 
-								if (type === "dblclick" || altKey) {
-									// when focused legend is clicked(with altKey or double clicked), reset all hiding.
-									if (
-										state.hiddenTargetIds.size &&
-										target.parentNode.getAttribute("class").indexOf(
-												$LEGEND.legendItemHidden
-											) === -1
-									) {
-										api.show();
-									} else {
-										api.hide();
-										api.show(id);
-									}
-								} else {
-									api.toggle(id);
+						handleLegendToggle.call(this, event, id);
+					} :
+					null);
 
-									d3Select(this)
-										.classed($FOCUS.legendItemFocused, false);
-								}
-							}
-
-							isTouch && $$.hideTooltip();
-						} :
-						null);
+			isTouch && eventType === "click" && hasClickInteraction && item
+				.on("touchstart", function(event, id) {
+					_setLegendTouchStart($$, id, event);
+				}, {passive: true})
+				.on("touchmove", event => {
+					_updateLegendTouchMove($$, event);
+				}, {passive: true})
+				.on("touchend", function(event, id) {
+					if (_isLegendTouchTap($$, id, event)) {
+						_markLegendTouchClick($$, id);
+						handleLegendToggle.call(this, event, id);
+					}
+				}, {passive: true});
 
 			!isTouch && item
 				.on("mouseout", interaction || isFunction(config.legend_item_onout) ?

--- a/src/ChartInternal/internals/text.util.ts
+++ b/src/ChartInternal/internals/text.util.ts
@@ -334,7 +334,7 @@ function batchGetBBox(elements: SVGTextElement[]): Map<SVGTextElement, DOMRect> 
 	return toMap(
 		elements,
 		element => element,
-		element => getBBox(element)
+		element => getBBox(element, true)
 	);
 }
 

--- a/src/canvas/CanvasEngine.ts
+++ b/src/canvas/CanvasEngine.ts
@@ -27,10 +27,6 @@ export default class CanvasEngine {
 	init(container: HTMLElement, w: number, h: number): void {
 		this.canvas = document.createElement("canvas");
 		this.canvas.className = $CANVAS.canvas;
-		this.canvas.style.position = "absolute";
-		this.canvas.style.top = "0";
-		this.canvas.style.left = "0";
-		this.canvas.style.zIndex = "0";
 		this.canvas.style.display = "block";
 
 		container.appendChild(this.canvas);

--- a/src/canvas/CanvasRenderer.ts
+++ b/src/canvas/CanvasRenderer.ts
@@ -82,6 +82,7 @@ const SUBCHART_BRUSH_HANDLE_PATH = {
 type BarConnectLineType = "start-start" | "start-end" | "end-start" | "end-end";
 type CanvasBarConnectLineBox = {x: number, y: number, width: number, height: number};
 type CanvasBackgroundClassStyle = {opacity?: number, transform?: string};
+type CanvasBackgroundImageRect = {x: number, y: number, w: number, h: number};
 type CanvasLinearGradientShape = "area" | "bar";
 type CanvasLinearGradientOption = boolean | {
 	x?: [number, number],
@@ -116,6 +117,38 @@ function applyCssMatrixTransform(ctx: CanvasRenderingContext2D, transform?: stri
 			values.every(Number.isFinite) &&
 			ctx.transform(values[0], values[1], values[4], values[5], values[12], values[13]);
 	}
+}
+
+/**
+ * Get SVG image equivalent destination rect for canvas background.
+ * @param {HTMLImageElement} image Image element
+ * @param {number} width Background viewport width
+ * @param {number} height Background viewport height
+ * @returns {object} Destination rect
+ * @private
+ */
+function getPreservedAspectRatioRect(
+	image: HTMLImageElement,
+	width: number,
+	height: number
+): CanvasBackgroundImageRect {
+	const imageWidth = image.naturalWidth || image.width;
+	const imageHeight = image.naturalHeight || image.height;
+
+	if (!imageWidth || !imageHeight || !width || !height) {
+		return {x: 0, y: 0, w: width, h: height};
+	}
+
+	const scale = Math.min(width / imageWidth, height / imageHeight);
+	const w = imageWidth * scale;
+	const h = imageHeight * scale;
+
+	return {
+		x: (width - w) / 2,
+		y: (height - h) / 2,
+		w,
+		h
+	};
 }
 
 /**
@@ -888,7 +921,13 @@ export default class CanvasRenderer {
 				const entry = this.getBackgroundImage(bg.imgUrl, $$);
 
 				if (entry?.loaded) {
-					ctx.drawImage(entry.image, 0, 0, current.width, current.height);
+					const rect = getPreservedAspectRatioRect(
+						entry.image,
+						current.width,
+						current.height
+					);
+
+					ctx.drawImage(entry.image, rect.x, rect.y, rect.w, rect.h);
 				}
 			} else if (bg.color) {
 				painter.fillRect({
@@ -919,7 +958,7 @@ export default class CanvasRenderer {
 		}
 
 		const url = getLabelImageUrl(option, d);
-		const position = getLabelImagePosition($$, option, text, x, y);
+		const position = getLabelImagePosition($$, option, text, x, y, d);
 		const entry = this.getLabelImage(url, $$);
 
 		if (entry?.loaded) {
@@ -2213,15 +2252,17 @@ export default class CanvasRenderer {
 
 				const lines = label.split("\n");
 				const lineHeight = 12;
-				const centerY = y + h / 2 - (lines.length - 1) * lineHeight / 2;
+				let textX = x + w / 2;
+				let textY = y + h / 2 - (lines.length - 1) * lineHeight / 2;
 
-				ctx.fillStyle = getLabelColor($$, data, style.label.color);
 				ctx.font = style.label.font;
 				ctx.textAlign = "center";
 				ctx.textBaseline = "middle";
+				({x: textX, y: textY} = this.drawLabelImage($$, data, label, textX, textY));
+				ctx.fillStyle = getLabelColor($$, data, style.label.color);
 
 				lines.forEach((line, i) => {
-					painter.text(line, x + w / 2, centerY + i * lineHeight, {
+					painter.text(line, textX, textY + i * lineHeight, {
 						maxWidth: Math.max(0, w - 8)
 					});
 				});

--- a/src/canvas/labels.ts
+++ b/src/canvas/labels.ts
@@ -165,17 +165,21 @@ export function getLabelImageUrl(option: LabelImageOption, d): string {
  * @param {string} text Label text
  * @param {number} x Text x coordinate
  * @param {number} y Text y coordinate
+ * @param {object} d Data row
  * @returns {object} Image and text positions
  * @private
  */
 export function getLabelImagePosition($$, option: LabelImageOption, text: string, x: number,
-	y: number): LabelImagePosition {
+	y: number, d?): LabelImagePosition {
 	const {width = 0, height = 0, pos} = option;
 	const w = width / 2;
 	const h = height / 2;
 	const textHeight = getLabelDecorationBox($$.canvasEngine.ctx, text, x, y).h;
+	const fontSize = parseFloat($$.canvasEngine.ctx.font) || 12;
 	const imageX = x - w;
-	const imageY = y - h - textHeight / 2;
+	const imageY = y - h - (
+		$$.isTreemapType?.(d) ? fontSize * 0.7 : textHeight / 2
+	);
 	let textX = x;
 	let textY = y;
 
@@ -204,7 +208,9 @@ export function getLabelImagePosition($$, option: LabelImageOption, text: string
 export function getLabelColor($$, d, fallback: string): string {
 	const color = $$.updateTextColor?.(d);
 
-	return typeof color === "string" ? color : ($$.color?.(d) || fallback);
+	return typeof color === "string" ?
+		color :
+		($$.isTreemapType?.(d) ? fallback : ($$.color?.(d) || fallback));
 }
 
 /**

--- a/src/config/resolver/canvas.ts
+++ b/src/config/resolver/canvas.ts
@@ -41,6 +41,8 @@ const CANVAS_SELECTABLE_TYPE_FILTERS = [
 	isCanvasCandlestickType,
 	isCanvasTreemapType
 ];
+const CANVAS_LEGEND_TOUCH_TAP_THRESHOLD = 10;
+const CANVAS_LEGEND_TOUCH_CLICK_TIMEOUT = 750;
 const CANVAS_SUBCHART_HANDLE_SIZE = 6;
 const CANVAS_SUBCHART_CLICK_TOLERANCE = 2;
 const CANVAS_FLOW_ANIMATION_MAX_VALUES = 100000;
@@ -238,6 +240,103 @@ function revertCanvasLegendTargetFocus($$): void {
 }
 
 /**
+ * Get touch point from a canvas legend touch event.
+ * @param {TouchEvent} event Touch event
+ * @returns {Touch | undefined} Touch point
+ * @private
+ */
+function getCanvasLegendTouchPoint(event): Touch | undefined {
+	return event.changedTouches?.[0] || event.touches?.[0];
+}
+
+/**
+ * Store the touch start position for canvas legend tap detection.
+ * @param {object} $$ ChartInternal instance
+ * @param {string} id Legend data id
+ * @param {TouchEvent} event Touch event
+ * @private
+ */
+function setCanvasLegendTouchStart($$, id: string, event): void {
+	const touch = getCanvasLegendTouchPoint(event);
+
+	$$.state.canvasLegendTouch = touch ?
+		{
+			id,
+			x: touch.clientX,
+			y: touch.clientY,
+			moved: false
+		} :
+		null;
+}
+
+/**
+ * Update whether the current canvas legend touch moved beyond tap tolerance.
+ * @param {object} $$ ChartInternal instance
+ * @param {TouchEvent} event Touch event
+ * @private
+ */
+function updateCanvasLegendTouchMove($$, event): void {
+	const start = $$.state.canvasLegendTouch;
+	const touch = start && getCanvasLegendTouchPoint(event);
+
+	if (touch) {
+		start.moved = start.moved ||
+			Math.abs(touch.clientX - start.x) > CANVAS_LEGEND_TOUCH_TAP_THRESHOLD ||
+			Math.abs(touch.clientY - start.y) > CANVAS_LEGEND_TOUCH_TAP_THRESHOLD;
+	}
+}
+
+/**
+ * Determine whether a touch sequence is a canvas legend tap.
+ * @param {object} $$ ChartInternal instance
+ * @param {string} id Legend data id
+ * @param {TouchEvent} event Touch event
+ * @returns {boolean} Whether the touch sequence is a tap
+ * @private
+ */
+function isCanvasLegendTouchTap($$, id: string, event): boolean {
+	updateCanvasLegendTouchMove($$, event);
+
+	const start = $$.state.canvasLegendTouch;
+
+	$$.state.canvasLegendTouch = null;
+
+	return !!start && start.id === id && !start.moved;
+}
+
+/**
+ * Mark a canvas legend touch tap so the following compatibility click can be skipped.
+ * @param {object} $$ ChartInternal instance
+ * @param {string} id Legend data id
+ * @private
+ */
+function markCanvasLegendTouchClick($$, id: string): void {
+	$$.state.canvasLegendLastTouchClickId = id;
+	$$.state.canvasLegendLastTouchClickTime = Date.now();
+}
+
+/**
+ * Check if a canvas legend click duplicates a recent touch tap.
+ * @param {object} $$ ChartInternal instance
+ * @param {string} id Legend data id
+ * @returns {boolean} Whether the click is duplicate
+ * @private
+ */
+function isDuplicateCanvasLegendTouchClick($$, id: string): boolean {
+	const {state} = $$;
+	const duplicate = state.canvasLegendLastTouchClickId === id &&
+		Date.now() - (state.canvasLegendLastTouchClickTime || 0) <
+			CANVAS_LEGEND_TOUCH_CLICK_TIMEOUT;
+
+	if (duplicate) {
+		state.canvasLegendLastTouchClickId = null;
+		state.canvasLegendLastTouchClickTime = 0;
+	}
+
+	return duplicate;
+}
+
+/**
  * Bind canvas HTML legend interactions without invoking SVG focus paths.
  * @param {object} $$ ChartInternal instance
  * @param {object} item Legend item selection
@@ -246,11 +345,7 @@ function revertCanvasLegendTargetFocus($$): void {
 function bindCanvasHtmlLegendInteractions($$, item): void {
 	const {api, config, state} = $$;
 
-	item
-		.on("click", null)
-		.on("dblclick", null)
-		.on("mouseover", null)
-		.on("mouseout", null);
+	item.on("click dblclick mouseover mouseout touchstart touchmove touchend", null);
 
 	if (!config.interaction_enabled) {
 		return;
@@ -260,45 +355,75 @@ function bindCanvasHtmlLegendInteractions($$, item): void {
 	const eventType = typeof interaction === "object" && interaction?.dblclick ?
 		"dblclick" :
 		"click";
+	const isTouch = state.inputType === "touch";
+	const hasClickInteraction = interaction || isFunction(config.legend_item_onclick);
 
-	item.on(eventType, interaction || isFunction(config.legend_item_onclick) ?
+	const handleCanvasLegendToggle = function(event, id): void {
+		if (
+			!callFn(config.legend_item_onclick, api, id, !state.hiddenTargetIds.has(id))
+		) {
+			const selected = d3Select(this);
+
+			if (event.type === "dblclick" || event.altKey) {
+				if (
+					state.hiddenTargetIds.size &&
+					!selected.classed($LEGEND.legendItemHidden)
+				) {
+					api.show();
+				} else {
+					api.hide();
+					api.show(id);
+				}
+			} else {
+				api.toggle(id);
+				selected.classed($FOCUS.legendItemFocused, false);
+			}
+			revertCanvasLegendTargetFocus($$);
+		}
+
+		isTouch && $$.hideTooltip?.();
+	};
+
+	item.on(eventType, hasClickInteraction ?
 		function(event, id) {
 			if (
-				!callFn(config.legend_item_onclick, api, id, !state.hiddenTargetIds.has(id))
+				isTouch && event.type === "click" &&
+				isDuplicateCanvasLegendTouchClick($$, id)
 			) {
-				const selected = d3Select(this);
-
-				if (event.type === "dblclick" || event.altKey) {
-					if (
-						state.hiddenTargetIds.size &&
-						!selected.classed($LEGEND.legendItemHidden)
-					) {
-						api.show();
-					} else {
-						api.hide();
-						api.show(id);
-					}
-				} else {
-					api.toggle(id);
-					selected.classed($FOCUS.legendItemFocused, false);
-				}
-				revertCanvasLegendTargetFocus($$);
+				return;
 			}
+
+			handleCanvasLegendToggle.call(this, event, id);
 		} :
-		null)
-		.on("mouseover",
-			interaction || isFunction(config.legend_item_onover) ?
-				function(event, id) {
-					if (
-						!callFn(config.legend_item_onover, api, id, !state.hiddenTargetIds.has(id))
-					) {
-						setCanvasHtmlLegendFocus($$, id);
-						!state.transiting &&
-							$$.isTargetToShow(id) &&
-							setCanvasLegendTargetFocus($$, id);
-					}
-				} :
-				null)
+		null);
+
+	isTouch && eventType === "click" && hasClickInteraction && item
+		.on("touchstart", function(event, id) {
+			setCanvasLegendTouchStart($$, id, event);
+		}, {passive: true})
+		.on("touchmove", event => {
+			updateCanvasLegendTouchMove($$, event);
+		}, {passive: true})
+		.on("touchend", function(event, id) {
+			if (isCanvasLegendTouchTap($$, id, event)) {
+				markCanvasLegendTouchClick($$, id);
+				handleCanvasLegendToggle.call(this, event, id);
+			}
+		}, {passive: true});
+
+	!isTouch && item
+		.on("mouseover", interaction || isFunction(config.legend_item_onover) ?
+			function(event, id) {
+				if (
+					!callFn(config.legend_item_onover, api, id, !state.hiddenTargetIds.has(id))
+				) {
+					setCanvasHtmlLegendFocus($$, id);
+					!state.transiting &&
+						$$.isTargetToShow(id) &&
+						setCanvasLegendTargetFocus($$, id);
+				}
+			} :
+			null)
 		.on("mouseout", interaction || isFunction(config.legend_item_onout) ?
 			function(event, id) {
 				if (
@@ -2673,7 +2798,7 @@ const canvasInternal = {
 		}
 
 		this.dispatchCanvasDataClick(event, true);
-		this.onCanvasMouseOut();
+		this.dispatchCanvasDataOut(this.$el.canvas.node());
 		this.config.onout?.bind(this.api)(event);
 	},
 

--- a/test/esm/canvas-helper-coverage-spec.ts
+++ b/test/esm/canvas-helper-coverage-spec.ts
@@ -304,11 +304,18 @@ describe("ESM canvas helper coverage", () => {
 			const option = {url: "/img.png", width: 20, height: 10, pos: {x: 1, y: 2}};
 			const normal = getLabelImagePosition(getInternal(), option, "label", 50, 60);
 			const rotated = getLabelImagePosition(getInternal({axis_rotated: true}), option, "label", 50, 60);
+			const treemap = getLabelImagePosition({
+				...getInternal(),
+				isTreemapType: () => true
+			}, option, "label", 50, 60, datum);
 
 			expect(normal.textX).to.be.equal(50);
 			expect(normal.textY).to.be.equal(65);
 			expect(rotated.textX).to.be.equal(60);
 			expect(rotated.textY).to.be.equal(60);
+			expect(treemap.textX).to.be.equal(normal.textX);
+			expect(treemap.textY).to.be.equal(normal.textY);
+			expect(treemap.y).to.be.lessThan(normal.y);
 		});
 
 		it("resolves label background colors and draws decorations", () => {

--- a/test/esm/canvas-spec.ts
+++ b/test/esm/canvas-spec.ts
@@ -225,6 +225,18 @@ describe("ESM canvas", function() {
 		});
 	});
 
+	it("should keep the canvas surface in normal flow", () => {
+		generate(line());
+
+		const canvasEl = chart.$.canvas.node();
+
+		expect(canvasEl.style.display).to.be.equal("block");
+		expect(canvasEl.style.position).to.be.equal("");
+		expect(canvasEl.style.top).to.be.equal("");
+		expect(canvasEl.style.left).to.be.equal("");
+		expect(canvasEl.style.zIndex).to.be.equal("");
+	});
+
 	it("should not create SVG structural nodes or generated shape classes in canvas mode", () => {
 		generateWithOptions({
 			data: {
@@ -836,6 +848,90 @@ describe("ESM canvas", function() {
 
 		expect(chart.internal.state.hiddenTargetIds.has("data1")).to.be.true;
 		expect(legendItem.classList.contains("bb-legend-item-hidden")).to.be.true;
+	});
+
+	it("should toggle only touched target from the HTML legend on touch input", () => {
+		window.$$TEST$$.convertInputType = "touch";
+
+		try {
+			const chart = generateWithOptions({
+				data: {
+					columns,
+					type: line()
+				},
+				interaction: {
+					inputType: {
+						touch: true
+					}
+				}
+			});
+			const item1 = container.querySelector("button[data-id='data1']") as HTMLElement;
+			const item2 = container.querySelector("button[data-id='data2']") as HTMLElement;
+			const {x, y} = item2.getBoundingClientRect();
+			const legendTouch = new Touch({
+				identifier: Date.now(),
+				target: item2,
+				clientX: x,
+				clientY: y
+			});
+			const dispatchTouch = type => item2.dispatchEvent(new TouchEvent(type, {
+				bubbles: true,
+				cancelable: true,
+				touches: type === "touchend" ? [] : [legendTouch],
+				targetTouches: type === "touchend" ? [] : [legendTouch],
+				changedTouches: [legendTouch]
+			}));
+
+			item2.dispatchEvent(new MouseEvent("mouseover", {
+				bubbles: true
+			}));
+
+			expect(item1.style.opacity).to.be.equal("");
+
+			const canvas = chart.$.canvas.node();
+			const rect = canvas.getBoundingClientRect();
+			const {margin} = chart.internal.state;
+			const datum = chart.internal.data.targets[0].values[1];
+			const canvasTouch = new Touch({
+				identifier: Date.now() + 1,
+				target: canvas,
+				clientX: rect.left + margin.left + chart.internal.xx(datum),
+				clientY: rect.top + margin.top + chart.internal.circleY(datum, datum.index)
+			});
+
+			canvas.dispatchEvent(new TouchEvent("touchstart", {
+				bubbles: true,
+				cancelable: true,
+				touches: [canvasTouch],
+				targetTouches: [canvasTouch],
+				changedTouches: [canvasTouch]
+			}));
+
+			expect(chart.$.tooltip.style("display")).to.be.equal("block");
+
+			dispatchTouch("touchstart");
+			dispatchTouch("touchend");
+
+			expect(chart.$.tooltip.style("display")).to.be.equal("none");
+			expect(chart.internal.state.hiddenTargetIds.has("data2")).to.be.true;
+			expect(item2.classList.contains("bb-legend-item-hidden")).to.be.true;
+			expect(item1.style.opacity).to.be.equal("");
+
+			item2.dispatchEvent(new MouseEvent("click", {
+				bubbles: true
+			}));
+
+			expect(chart.internal.state.hiddenTargetIds.has("data2")).to.be.true;
+
+			dispatchTouch("touchstart");
+			dispatchTouch("touchend");
+
+			expect(chart.internal.state.hiddenTargetIds.has("data2")).to.be.false;
+			expect(item2.classList.contains("bb-legend-item-hidden")).to.be.false;
+			expect(item1.style.opacity).to.be.equal("");
+		} finally {
+			delete window.$$TEST$$.convertInputType;
+		}
 	});
 
 	it("should apply hover opacity to other canvas HTML legend items", () => {
@@ -3872,6 +3968,104 @@ describe("ESM canvas", function() {
 		fillText.mockRestore();
 	});
 
+	it("should draw treemap label images on canvas", async () => {
+		const calls: Array<{
+			type: string,
+			text?: string,
+			x?: number,
+			y?: number,
+			w?: number,
+			h?: number,
+			fillStyle?: string
+		}> = [];
+		let loadImage;
+
+		vi.stubGlobal("Image", class {
+			onload = null;
+			onerror = null;
+
+			set src(value) {
+				this._src = value;
+				loadImage = () => this.onload?.();
+			}
+
+			get src() {
+				return this._src;
+			}
+		});
+
+		const drawImage = vi
+			.spyOn(CanvasRenderingContext2D.prototype, "drawImage")
+			.mockImplementation(function(...args) {
+				if (args.length === 5) {
+					calls.push({
+						type: "image",
+						x: Number(args[1]),
+						y: Number(args[2]),
+						w: Number(args[3]),
+						h: Number(args[4])
+					});
+				}
+			});
+		const fillText = vi
+			.spyOn(CanvasRenderingContext2D.prototype, "fillText")
+			.mockImplementation(function(text, x, y) {
+				const value = String(text);
+
+				if (value === "data1" || value === "100.00%") {
+					calls.push({
+						type: "text",
+						text: value,
+						x: Number(x),
+						y: Number(y),
+						fillStyle: String(this.fillStyle)
+					});
+				}
+			});
+
+		generateWithOptions({
+			data: {
+				columns: [
+					["data1", 30]
+				],
+				type: treemap(),
+				labels: {
+					image: {
+						url: "/treemap-{=ID}.png",
+						width: 20,
+						height: 10
+					},
+					centered: true
+				}
+			}
+		});
+
+		expect(calls.some(call => call.type === "image")).to.be.false;
+
+		loadImage();
+		await Promise.resolve();
+
+		const imageIndex = calls.findIndex(call => call.type === "image");
+		const textIndex = calls.findIndex((call, index) =>
+			index > imageIndex && call.type === "text" && call.text === "data1"
+		);
+		const image = calls[imageIndex];
+		const text = calls[textIndex];
+
+		expect(imageIndex).to.be.greaterThan(-1);
+		expect(textIndex).to.be.greaterThan(-1);
+		expect(imageIndex).to.be.lessThan(textIndex);
+		expect(image.w).to.be.equal(20);
+		expect(image.h).to.be.equal(10);
+		expect(image.y).to.be.lessThan(text.y);
+		expect(text.y - (image.y + image.h)).to.be.lessThan(20);
+		expect(text.fillStyle).to.be.equal("#000000");
+
+		drawImage.mockRestore();
+		fillText.mockRestore();
+		vi.unstubAllGlobals();
+	});
+
 	it("should keep data groups for stacked area targets", () => {
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const fill = vi.spyOn(CanvasRenderingContext2D.prototype, "fill");
@@ -4515,6 +4709,53 @@ describe("ESM canvas", function() {
 		expect(onout).toHaveBeenCalledWith(d, canvas);
 	});
 
+	it("should keep canvas tooltip visible after touch drag ends", () => {
+		generateWithOptions({
+			data: {
+				columns,
+				type: scatter()
+			},
+			interaction: {
+				inputType: {
+					touch: true
+				}
+			},
+			tooltip: {
+				grouped: false
+			}
+		});
+
+		const canvas = chart.$.canvas.node();
+		const rect = canvas.getBoundingClientRect();
+		const {margin} = chart.internal.state;
+		const getTouch = (d, identifier = 1) => new Touch({
+			identifier,
+			target: canvas,
+			clientX: rect.left + margin.left + chart.internal.xx(d),
+			clientY: rect.top + margin.top + chart.internal.circleY(d, d.index)
+		});
+		const start = chart.internal.data.targets[0].values[0];
+		const end = chart.internal.data.targets[0].values[1];
+		const startTouch = getTouch(start);
+		const endTouch = getTouch(end);
+		const dispatchTouch = (type, touch) => canvas.dispatchEvent(new TouchEvent(type, {
+			cancelable: true,
+			bubbles: true,
+			touches: type === "touchend" ? [] : [touch],
+			targetTouches: type === "touchend" ? [] : [touch],
+			changedTouches: [touch]
+		}));
+
+		dispatchTouch("touchstart", startTouch);
+		dispatchTouch("touchmove", endTouch);
+
+		expect(chart.$.tooltip.style("display")).to.be.equal("block");
+
+		dispatchTouch("touchend", endTouch);
+
+		expect(chart.$.tooltip.style("display")).to.be.equal("block");
+	});
+
 	it("should prevent default for canvas touch events when configured", () => {
 		generateWithOptions({
 			data: {
@@ -4783,7 +5024,7 @@ describe("ESM canvas", function() {
 		}
 	});
 
-	it("should draw chart background image on canvas after load", () => new Promise(done => {
+	it("should draw chart background image on canvas preserving aspect ratio after load", () => new Promise(done => {
 		const drawImage = vi.spyOn(CanvasRenderingContext2D.prototype, "drawImage");
 
 		generateWithOptions({
@@ -4792,13 +5033,21 @@ describe("ESM canvas", function() {
 				type: line()
 			},
 			background: {
-				imgUrl: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Crect width='8' height='8' fill='red'/%3E%3C/svg%3E"
+				imgUrl: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='10'%3E%3Crect width='40' height='10' fill='red'/%3E%3C/svg%3E"
 			}
 		});
 
 		setTimeout(() => {
 			try {
-				expect(drawImage).toHaveBeenCalled();
+				const backgroundCall = drawImage.mock.calls.find(call =>
+					call.length === 5 &&
+					call[1] === 0 &&
+					call[2] === 80 &&
+					call[3] === 320 &&
+					call[4] === 80
+				);
+
+				expect(backgroundCall).not.to.be.undefined;
 				done();
 			} catch (error) {
 				done(error);

--- a/test/internals/legend-spec.ts
+++ b/test/internals/legend-spec.ts
@@ -683,6 +683,77 @@ describe("LEGEND", () => {
 
 			expect(legend.classed($FOCUS.legendItemFocused)).to.false;
 		});
+
+		it("should toggle only touched legend item on touch input", () => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, -200, 100, 200, 190, 280],
+						["data2", 30, 200, 120, 400, 150, 150]
+					]
+				},
+				interaction: {
+					inputType: {
+						touch: true
+					}
+				},
+				transition: {
+					duration: 0
+				}
+			};
+			chart.destroy();
+			chart = util.generate(args);
+
+			const legend1 = chart.$.legend.select(`.${$LEGEND.legendItem}-data1`);
+			const legend2 = chart.$.legend.select(`.${$LEGEND.legendItem}-data2`);
+			const node = legend2.node();
+			const {x, y} = node.getBoundingClientRect();
+			const touch = new Touch({
+				identifier: Date.now(),
+				target: node,
+				clientX: x,
+				clientY: y
+			});
+			const dispatchTouch = type => node.dispatchEvent(new TouchEvent(type, {
+				bubbles: true,
+				cancelable: true,
+				touches: type === "touchend" ? [] : [touch],
+				targetTouches: type === "touchend" ? [] : [touch],
+				changedTouches: [touch]
+			}));
+			const xgridFocus = chart.$.grid.main.select(`line.${$FOCUS.xgridFocus}`);
+
+			chart.tooltip.show({index: 1});
+
+			expect(chart.$.tooltip.style("display")).to.be.equal("block");
+			expect(xgridFocus.style("visibility")).to.not.be.equal("hidden");
+
+			dispatchTouch("touchstart");
+			dispatchTouch("touchend");
+
+			expect(chart.$.tooltip.style("display")).to.be.equal("none");
+			expect(chart.$.grid.main.select(`line.${$FOCUS.xgridFocus}`).style("visibility"))
+				.to.be.equal("hidden");
+			expect(legend2.classed($LEGEND.legendItemHidden)).to.be.true;
+			expect(+legend2.style("opacity")).to.be.equal(0.15);
+			expect(legend1.classed($LEGEND.legendItemHidden)).to.be.false;
+			expect(legend1.node().style.opacity).to.be.equal("");
+
+			util.fireEvent(node, "click", {
+				clientX: x,
+				clientY: y
+			}, chart);
+
+			expect(legend2.classed($LEGEND.legendItemHidden)).to.be.true;
+
+			dispatchTouch("touchstart");
+			dispatchTouch("touchend");
+
+			expect(legend2.classed($LEGEND.legendItemHidden)).to.be.false;
+			expect(legend2.node().style.opacity).to.be.equal("");
+			expect(legend1.classed($LEGEND.legendItemHidden)).to.be.false;
+			expect(legend1.node().style.opacity).to.be.equal("");
+		});
 	});
 
 	describe("legend transition", () => {

--- a/test/shape/treemap-spec.ts
+++ b/test/shape/treemap-spec.ts
@@ -655,6 +655,65 @@ describe("TREEMAP", () => {
 					expect(isFinite(bbox.height)).to.be.true;
 				});
 			});
+
+			it("should center labels when chart is vertically offset", () => {
+				const container = util.sandbox("treemap-label-offset", {
+					style: "position:absolute;top:720px;left:0;width:640px;height:480px;"
+				});
+				const treemap = util.generate({
+					bindto: "#treemap-label-offset",
+					data: {
+						rows: [
+							["data1", "data2", "data3", "data4"],
+							[300, 200, 500, 380]
+						],
+						type: "treemap",
+						labels: {
+							centered: true
+						}
+					},
+					treemap: {
+						tile: "dice",
+						label: {
+							format: value => value
+						}
+					}
+				});
+
+				let checked = 0;
+
+				treemap.internal.$el.treemap.selectAll("g").each(function(d) {
+					const rect = this.querySelector("rect");
+					const text = treemap.$.text.texts
+						.filter(textData => textData.id === d.data.id)
+						.node();
+
+					if (!rect || !text) {
+						return;
+					}
+
+					const [tileX, tileY] = this
+						.getAttribute("transform")
+						.trim()
+						.split(",")
+						.map(parseNum);
+					const rectWidth = +rect.getAttribute("width");
+					const rectHeight = +rect.getAttribute("height");
+					const textX = +text.getAttribute("x");
+					const textY = +text.getAttribute("y");
+
+					checked++;
+					expect(textX).to.be.greaterThan(tileX);
+					expect(textX).to.be.lessThan(tileX + rectWidth);
+					expect(textY).to.be.greaterThan(tileY);
+					expect(textY).to.be.lessThan(tileY + rectHeight);
+				});
+
+				expect(checked).to.be.equal(4);
+
+				treemap.destroy();
+				container.remove();
+			});
 		});
 
 		describe("with centered labels disabled", () => {


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
Align canvas behavior with SVG rendering for recent demo regressions.

- Preserve canvas background image aspect ratio.
- Keep the canvas surface in normal document flow.
- Fix treemap label image and text rendering in canvas mode.
- Normalize mobile legend touch toggling.
- Hide active tooltips and focus grid lines after legend taps.