### PR TITLE
refactor(all): fix potential bugs & improve perf

### DIFF
--- a/src/Chart/api/chart.ts
+++ b/src/Chart/api/chart.ts
@@ -4,6 +4,7 @@
  */
 import {window} from "../../module/browser";
 import {isDefined, isEmpty, notEmpty} from "../../module/util";
+import {cleanupWorkers} from "../../module/worker";
 
 export default {
 	/**
@@ -130,6 +131,9 @@ export default {
 
 			$$.charts.splice($$.charts.indexOf(this), 1);
 
+			// release cached web workers/Object URLs when no chart instance remains
+			$$.charts.length === 0 && cleanupWorkers();
+
 			// detach events
 			$$.unbindAllEvents();
 
@@ -139,6 +143,8 @@ export default {
 				window.cancelAnimationFrame?.(state.canvasFlowFrame);
 			state.canvasFlowFrame = null;
 			state.canvasFlowFinish = null;
+			state.pendingRaf !== null && window.cancelAnimationFrame?.(state.pendingRaf);
+			state.pendingRaf = null;
 			$$.canvasRenderer?.destroy();
 			$$.canvasEngine?.destroy();
 			$$.resizeFunction?.clear();

--- a/src/Chart/api/export.ts
+++ b/src/Chart/api/export.ts
@@ -154,15 +154,11 @@ function getGlyph(svg: SVGElement): TTextGlyph[] {
 			};
 
 			if (t.childElementCount > 1) {
-				const text: TTextGlyph[] = [];
-
 				toArray(t.querySelectorAll("tspan"))
 					.filter(filterFn)
 					.forEach((ts: SVGTSpanElement) => {
 						glyph.push(getStyleFn(ts));
 					});
-
-				return text;
 			} else {
 				glyph.push(getStyleFn(t));
 			}

--- a/src/Chart/api/flow.ts
+++ b/src/Chart/api/flow.ts
@@ -125,6 +125,11 @@ export default {
 			$$.data.targets.forEach(t => {
 				for (let i = 0; i < notfoundIds.length; i++) {
 					if (t.id === notfoundIds[i]) {
+						// target can have no values when fully flowed out
+						if (!t.values[t.values.length - 1]) {
+							continue;
+						}
+
 						tail = t.values[t.values.length - 1].index + 1;
 
 						for (let j = 0; j < length; j++) {

--- a/src/Chart/api/focus.ts
+++ b/src/Chart/api/focus.ts
@@ -29,6 +29,23 @@ export default {
 		const $$ = this.internal;
 		const {state} = $$;
 		const targetIds = $$.mapToTargetIds(targetIdsValue);
+
+		if (state.isCanvasMode) {
+			const focusedIds = targetIds.filter($$.isTargetToShow, $$);
+			const focusedSet = new Set(focusedIds);
+			const defocusedIds = $$.mapToTargetIds()
+				.filter(id => !focusedSet.has(id) && $$.isTargetToShow(id));
+
+			$$.revertLegend();
+			$$.toggleFocusLegend(defocusedIds, false);
+			$$.toggleFocusLegend(focusedIds, true);
+
+			state.focusedTargetIds = focusedSet;
+			state.defocusedTargetIds = new Set(defocusedIds);
+			$$.renderCanvasFrame?.(undefined, null, false);
+			return;
+		}
+
 		const candidates = $$.$el.svg.selectAll(
 			$$.selectorTargets(targetIds.filter($$.isTargetToShow, $$))
 		);
@@ -72,6 +89,18 @@ export default {
 		const $$ = this.internal;
 		const {state} = $$;
 		const targetIds = $$.mapToTargetIds(targetIdsValue);
+
+		if (state.isCanvasMode) {
+			const defocusedIds = targetIds.filter($$.isTargetToShow, $$);
+
+			$$.toggleFocusLegend(defocusedIds, false);
+
+			defocusedIds.forEach(id => state.focusedTargetIds.delete(id));
+			state.defocusedTargetIds = new Set(defocusedIds);
+			$$.renderCanvasFrame?.(undefined, null, false);
+			return;
+		}
+
 		const candidates = $$.$el.svg.selectAll(
 			$$.selectorTargets(targetIds.filter($$.isTargetToShow, $$))
 		);
@@ -112,6 +141,25 @@ export default {
 		const $$ = this.internal;
 		const {config, state, $el} = $$;
 		const targetIds = $$.mapToTargetIds(targetIdsValue);
+
+		if (state.isCanvasMode) {
+			const changed = !!state.focusedTargetIds?.size || !!state.defocusedTargetIds?.size;
+
+			if (config.legend_show) {
+				$$.showLegend(targetIds.filter($$.isLegendToShow.bind($$)));
+				$el.legend.selectAll($$.selectorLegends(targetIds))
+					.filter(function() {
+						return d3Select(this).classed($FOCUS.legendItemFocused);
+					})
+					.classed($FOCUS.legendItemFocused, false);
+			}
+
+			state.focusedTargetIds = new Set();
+			state.defocusedTargetIds = new Set();
+			changed && $$.renderCanvasFrame?.(undefined, null, false);
+			return;
+		}
+
 		const candidates = $el.svg.selectAll($$.selectorTargets(targetIds)); // should be for all targets
 
 		candidates.classed($FOCUS.focused, false).classed($FOCUS.defocused, false);

--- a/src/Chart/api/load.ts
+++ b/src/Chart/api/load.ts
@@ -197,7 +197,15 @@ export default {
 		// unload if needed
 		if (hasUnload) {
 			// TODO: do not unload if target will load (included in url/rows/columns)
-			$$.unload($$.mapToTargetIds(args.unload === true ? null : args.unload), () => {
+			const unloadIds = $$.mapToTargetIds(args.unload === true ? null : args.unload);
+
+			$$.unload(unloadIds, () => {
+				if (!$$.config || !$$.cache) {
+					return;
+				}
+
+				$$.cache.remove(unloadIds);
+
 				// to mitigate improper rendering for multiple consecutive calls
 				// https://github.com/naver/billboard.js/issues/2121
 				requestIdleCallback(() => $$.loadFromArgs(args));
@@ -251,6 +259,10 @@ export default {
 		$$.state._eventRectFingerprint = null;
 
 		$$.unload(ids, () => {
+			if (!$$.config || !$$.cache) {
+				return;
+			}
+
 			$$.redraw({
 				withUpdateOrgXDomain: true,
 				withUpdateXDomain: true,

--- a/src/Chart/api/subchart.ts
+++ b/src/Chart/api/subchart.ts
@@ -59,7 +59,9 @@ const subchart = function<T = TDomain[]>(domainValue?: T): T | undefined {
 			);
 
 			if (isWithinRange) {
-				state.domain = domain;
+				// store a copy: brush events mutate state.domain in place,
+				// which would corrupt the caller-passed array
+				state.domain = domain.slice();
 
 				brush.move(
 					brush.getSelection(),

--- a/src/Chart/api/tooltip.ts
+++ b/src/Chart/api/tooltip.ts
@@ -111,6 +111,40 @@ const tooltip = {
 			index = args.index;
 		}
 
+		if ($$.state.isCanvasMode) {
+			const targets = $$.filterTargetsToShow?.() || $$.data.targets;
+			const selectedData = args.data?.id && !config.tooltip_grouped ?
+				targets
+					.filter(target => target.id === args.data.id)
+					.map(target => target.values[index ?? args.data.index])
+					.filter(Boolean) :
+				targets
+					.map(target => target.values[index])
+					.filter(Boolean);
+			const canvas = $el.canvas?.node?.();
+			const shape = $$.state.canvasShape || $$.getDrawShape?.();
+			const first = selectedData[0];
+			const point = mouse || (
+				first && shape?.pos?.cx && shape?.pos?.cy ?
+					[
+						$$.state.margin.left + shape.pos.cx(first),
+						$$.state.margin.top + shape.pos.cy(first)
+					] :
+					undefined
+			);
+
+			if (!selectedData.length || !canvas) {
+				return;
+			}
+
+			$$.state.canvasFocusKey = selectedData
+				.map(v => `${v.id}:${v.index}`)
+				.join("|");
+			$$.renderCanvasFocus?.(selectedData, point);
+			$$.showTooltip?.(selectedData, canvas);
+			return;
+		}
+
 		(inputType === "mouse" ? ["mouseover", "mousemove"] : ["touchstart"]).forEach(eventName => {
 			$$.dispatchEvent(eventName, index, mouse);
 		});
@@ -128,6 +162,7 @@ const tooltip = {
 		const data = tooltip?.datum();
 
 		if (isCanvasMode) {
+			$$.state.canvasFocusKey = null;
 			$$.hideTooltip(true);
 			$$.clearCanvasFocus?.();
 			return;

--- a/src/Chart/api/zoom.ts
+++ b/src/Chart/api/zoom.ts
@@ -59,7 +59,9 @@ const zoom = function<T = TDomainRange>(domainValue?: T): T | undefined {
 			);
 
 			if (isWithinRange) {
-				state.domain = domain;
+				// store a copy: brush events mutate state.domain in place,
+				// which would corrupt the caller-passed array
+				state.domain = domain.slice();
 
 				domain = $$.getZoomDomainValue(domain);
 

--- a/src/Chart/api/zoom.ts
+++ b/src/Chart/api/zoom.ts
@@ -69,9 +69,13 @@ const zoom = function<T = TDomainRange>(domainValue?: T): T | undefined {
 				$$.api.tooltip.hide();
 
 				if (config.subchart_show) {
-					const x = scale.zoom || scale.x;
+					if (state.isCanvasMode) {
+						$$.setCanvasSubchartDomain?.(domain, true, false);
+					} else {
+						const x = scale.zoom || scale.x;
 
-					$$.brush.getSelection().call($$.brush.move, domain.map(x));
+						$$.brush.getSelection().call($$.brush.move, domain.map(x));
+					}
 					// resultDomain = domain;
 				} else {
 					// in case of 'config.zoom_rescale=true', use org.xScale
@@ -233,9 +237,11 @@ export default {
 		const {config, $el: {canvas, eventRect, zoomResetBtn}, scale: {zoom}, state} = $$;
 		const target = state.isCanvasMode ? canvas : eventRect;
 
-		if (zoom) {
+		if (zoom || (state.isCanvasMode && config.subchart_show && state.domain)) {
 			config.subchart_show ?
-				$$.brush.getSelection().call($$.brush.move, null) :
+				(state.isCanvasMode ?
+					$$.clearCanvasSubchartDomain?.(true, false) :
+					$$.brush.getSelection().call($$.brush.move, null)) :
 				$$.zoom.updateTransformScale(d3ZoomIdentity);
 
 			$$.updateZoom(true);

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -759,7 +759,7 @@ class Axis {
 		let count = config.axis_x_tick_count;
 		let values;
 
-		if (fit || (count && fit)) {
+		if (fit) {
 			values = $$.mapTargetsToUniqueXs(targets);
 
 			// if given count is greater than the value length, then limit the count.
@@ -1105,7 +1105,7 @@ class Axis {
 
 			// do not compute if domain or currentMaxTickDomain is same
 			if (isDomainSame || isCurrentMaxTickDomainSame) {
-				return currentTickMax.size;
+				return currentTickMax;
 			} else {
 				currentTickMax.domain = domain;
 			}
@@ -1601,6 +1601,9 @@ class Axis {
 							break;
 						}
 					}
+
+					// culling.max <= 1 or a single tick can't satisfy the loop condition
+					intervalForCulling = intervalForCulling ?? tickSize;
 
 					// Build index map once: O(n) instead of O(n²) indexOf per tick
 					const tickIndexMap = new Map();

--- a/src/ChartInternal/Axis/AxisRenderer.ts
+++ b/src/ChartInternal/Axis/AxisRenderer.ts
@@ -160,13 +160,15 @@ export default class AxisRenderer {
 				let tspan: d3Selection = tickText
 					.selectAll("tspan")
 					.data((d, index) => {
-						const split = params.tickMultiline ?
-							splitTickText(d, scale1, ticks, isLeftRight, sizeFor1Char.w) :
-							(
-								isArray(helper.textFormatted(d)) ?
-									helper.textFormatted(d).concat() :
-									[helper.textFormatted(d)]
-							);
+						let split;
+
+						if (params.tickMultiline) {
+							split = splitTickText(d, scale1, ticks, isLeftRight, sizeFor1Char.w);
+						} else {
+							const formatted = helper.textFormatted(d);
+
+							split = isArray(formatted) ? formatted.concat() : [formatted];
+						}
 
 						counts[index] = split.length;
 

--- a/src/ChartInternal/Axis/AxisRendererHelper.ts
+++ b/src/ChartInternal/Axis/AxisRendererHelper.ts
@@ -4,7 +4,7 @@
  * @ignore
  */
 import type {d3Selection} from "../../../types/types";
-import {getBBox, isDefined, isNumber, isString, isValue} from "../../module/util";
+import {getBBox, isDefined, isValue} from "../../module/util";
 import {getScale} from "../internals/scale";
 
 export default class AxisRendererHelper {
@@ -133,15 +133,6 @@ export default class AxisRendererHelper {
 				ticks = scale
 					.ticks(...(this.config.tickArguments || []));
 			}
-
-			ticks = ticks
-				.map(v => {
-					// round the tick value if is number
-					const r = (isString(v) && isNumber(v) && !isNaN(v) &&
-						Math.round(v * 10) / 10) || v;
-
-					return r;
-				});
 		}
 
 		return ticks;

--- a/src/ChartInternal/data/convert.ts
+++ b/src/ChartInternal/data/convert.ts
@@ -63,8 +63,8 @@ function _setXS(
 				xsData = ((params.appendXs && $$.data.xs[id]) || [])
 					.concat(
 						data.map((d, i) => {
-							const rawX = isValue(d[xKey]);
-							return rawX ? $$.generateTargetX(rawX, id, i) : false;
+							const rawX = d[xKey];
+							return isValue(rawX) ? $$.generateTargetX(rawX, id, i) : false;
 						}).filter(v => v !== false)
 					);
 			} else if (config.data_x) {
@@ -107,7 +107,7 @@ export default {
 		if (args.bindto) {
 			data = {};
 
-			["url", "mimeType", "headers", "keys", "json", "keys", "rows", "columns"]
+			["url", "mimeType", "headers", "keys", "json", "rows", "columns"]
 				.forEach(v => {
 					const key = `data_${v}`;
 
@@ -163,7 +163,6 @@ export default {
 		const params = {
 			appendXs,
 			xs,
-			idConverter: config.data_idConverter.bind($$.api),
 			categorized: axis?.isCategorized(),
 			timeSeries: axis?.isTimeSeries(),
 			customX: axis?.isCustomX()
@@ -179,13 +178,14 @@ export default {
 				null;
 
 		// convert to target
+		const idConverter = config.data_idConverter.bind($$.api);
 		const targets = ids.map((id, index) => {
-			const convertedId = config.data_idConverter.bind($$.api)(id);
+			const convertedId = idConverter(id);
 			const xKey = $$.getXKey(id);
 			const isCategory = params.customX && params.categorized;
-			const hasCategory = isCategory && (() => {
+			const hasCategory = isCategory && index === 0 && (() => {
 				const categorySet = toSet(config.axis_x_categories);
-				return data.every(v => categorySet.has(v.x));
+				return data.every(v => categorySet.has(v[xKey]));
 			})();
 
 			// when .load() with 'append' option is used for indexed axis
@@ -207,7 +207,7 @@ export default {
 
 					// use x as categories if custom x and categorized
 					if ((isCategory || state.hasRadar) && index === 0 && !isUndefined(rawX)) {
-						if (!hasCategory && index === 0 && i === 0 && !isDataAppend) {
+						if (!hasCategory && i === 0 && !isDataAppend) {
 							config.axis_x_categories = [];
 
 							if (categoryIndexMap) {

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -29,6 +29,12 @@ import {
 } from "../../module/util";
 import type {IData, IDataPoint, IDataRow} from "./IData";
 
+// ranged data key-to-index lookup, used by getRangedData()
+const rangedDataKeyIndex: Record<string, Record<string, number>> = {
+	areaRange: {high: 0, mid: 1, low: 2},
+	candlestick: {open: 0, high: 1, low: 2, close: 3, volume: 4}
+};
+
 export default {
 	isX(key) {
 		const $$ = this;
@@ -413,7 +419,7 @@ export default {
 						sum[i] = 0;
 					}
 
-					sum[i] += ~~v.value;
+					sum[i] += isNumber(v.value) ? v.value : 0;
 				});
 			});
 
@@ -461,7 +467,7 @@ export default {
 
 		if (hiddenTargetIds.size) {
 			total = api.data.values.bind(api)([...hiddenTargetIds])
-				.reduce((p, c) => p + c);
+				.reduce((p, c) => p + c, 0);
 		}
 
 		return total;
@@ -1266,13 +1272,9 @@ export default {
 			if (type === "bar") {
 				return value.reduce((a, c) => c - a);
 			} else {
-				// @ts-ignore
-				const index = {
-					areaRange: ["high", "mid", "low"],
-					candlestick: ["open", "high", "low", "close", "volume"]
-				}[type].indexOf(key);
+				const index = rangedDataKeyIndex[type]?.[key as string] ?? -1;
 
-				return index >= 0 && value ? value[index] : undefined;
+				return index >= 0 ? value[index] : undefined;
 			}
 		} else if (value && key) {
 			return value[key];
@@ -1362,7 +1364,9 @@ export default {
 
 						if (hiddenSum.length) {
 							hiddenSum = hiddenSum
-								.reduce((acc, curr) => acc.map((v, i) => ~~v + curr[i]));
+								.reduce((acc, curr) =>
+									acc.map((v, i) => (isNumber(v) ? v : 0) + curr[i])
+								);
 
 							total = total.map((v, i) => v - hiddenSum[i]);
 						}

--- a/src/ChartInternal/data/load.ts
+++ b/src/ChartInternal/data/load.ts
@@ -47,29 +47,29 @@ export default {
 				});
 			}
 
-			// Update/Add data
+			// Update/Add data: index incoming targets by id to avoid O(n×m) scans
+			const incoming = new Map<string, any>(targets.map(t => [t.id, t]));
+
 			data.targets.forEach(d => {
-				for (let i = 0; i < targets.length; i++) {
-					if (d.id === targets[i].id) {
-						if (append) {
-							const values = targets[i].values;
+				const t = incoming.get(d.id);
 
-							for (let j = 0; j < values.length; j++) {
-								d.values.push(values[j]);
-							}
-						} else {
-							d.values = targets[i].values;
+				if (t) {
+					if (append) {
+						const values = t.values;
+
+						for (let j = 0; j < values.length; j++) {
+							d.values.push(values[j]);
 						}
-
-						targets.splice(i, 1);
-						break;
+					} else {
+						d.values = t.values;
 					}
+
+					incoming.delete(d.id);
 				}
 			});
 
-			for (let i = 0; i < targets.length; i++) {
-				data.targets.push(targets[i]); // add remained
-			}
+			// add remained
+			incoming.forEach(t => data.targets.push(t));
 		}
 
 		if ($$.state.isCanvasMode) {
@@ -187,17 +187,20 @@ export default {
 		targetIds = targetIds.filter(id => $$.hasTarget($$.data.targets, id));
 
 		// If no target, call done and return
-		if (!targetIds || targetIds.length === 0) {
+		if (targetIds.length === 0) {
 			done();
 			return;
 		}
 
+		// remove in a single pass instead of re-filtering per id
+		const unloadIds = new Set(targetIds);
+
 		if (state.isCanvasMode) {
 			targetIds.forEach(id => {
 				state.withoutFadeIn[id] = false;
-				$$.data.targets = $$.data.targets.filter(t => t.id !== id);
 			});
 
+			$$.data.targets = $$.data.targets.filter(t => !unloadIds.has(t.id));
 			$$.removeHiddenTargetIds(targetIds);
 			$$.removeHiddenLegendIds(targetIds);
 			$$.updateTypesElements();
@@ -217,12 +220,12 @@ export default {
 				$el.legend.selectAll(`.${$LEGEND.legendItem}${suffixId}`).remove();
 			}
 
-			// Remove target
-			$$.data.targets = $$.data.targets.filter(t => t.id !== id);
-
 			// Remove custom point def element
 			hasLegendDefsPoint && $el.defs?.select(`#${$$.getDefsPointId(suffixId)}`).remove();
 		});
+
+		// Remove targets
+		$$.data.targets = $$.data.targets.filter(t => !unloadIds.has(t.id));
 
 		// since treemap uses different data types, it needs to be transformed
 		state.hasFunnel && $$.updateFunnel($$.data.targets);

--- a/src/ChartInternal/interactions/drag.ts
+++ b/src/ChartInternal/interactions/drag.ts
@@ -65,8 +65,8 @@ export default {
 					let toggle;
 
 					if (shape.classed($CIRCLE.circle)) {
-						const x: number = +shape.attr("cx") * 1;
-						const y: number = +shape.attr("cy") * 1;
+						const x: number = +shape.attr("cx");
+						const y: number = +shape.attr("cy");
 
 						toggle = $$.togglePoint;
 						isWithin = minX < x && x < maxX && minY < y && y < maxY;

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -270,10 +270,11 @@ export default {
 		const isRotated = config.axis_rotated;
 		const isMultipleX = $$.isMultipleX();
 
-		// Skip recalculation if scale domain or visibility hasn't changed
+		// Skip recalculation if scale domain, plot size or visibility hasn't changed.
+		// width/height must be part of the key: resize keeps the domain but moves coords.
 		const xDomain = xScale?.domain();
 		const fingerprint = xDomain ?
-			`${xDomain[0]}_${xDomain[1]}_${$$.data.targets.length}_${
+			`${xDomain[0]}_${xDomain[1]}_${state.width}_${state.height}_${$$.data.targets.length}_${
 				[...state.hiddenTargetIds].join(",")
 			}` :
 			null;
@@ -324,9 +325,6 @@ export default {
 							(xScale(x.prev) + xScale(d.x)) / 2
 						);
 					} else {
-						x.prev = x.prev ?? xDomain[0];
-						x.next = x.next ?? xDomain[1];
-
 						val = Math.max(0, (xScale(x.next) - xScale(x.prev)) / 2);
 					}
 
@@ -488,7 +486,7 @@ export default {
 
 		// Show cursor as pointer if point is close to mouse position
 		if ($$.isBarType(closest.id) || dist < $$.getPointSensitivity(closest)) {
-			$$.$el.svg.select(`.${$EVENT.eventRect}`).style("cursor", "pointer");
+			$$.$el.eventRect.style("cursor", "pointer");
 
 			if (
 				triggerEvent && (
@@ -519,7 +517,7 @@ export default {
 			return;
 		}
 
-		$$.$el.svg.select(`.${$EVENT.eventRect}`).style("cursor", null);
+		$$.$el.eventRect?.style("cursor", null);
 		$$.hideGridFocus?.();
 
 		if (tooltip) {
@@ -639,9 +637,9 @@ export default {
 				.on("mouseout", event => {
 					state.event = event;
 
-					// chart is destroyed
+					// chart is destroyed ($$.config, not the closure-captured one, becomes null)
 					if (
-						!config || $$.hasArcType() || eventReceiver.currentIdx === -1 ||
+						!$$.config || $$.hasArcType() || eventReceiver.currentIdx === -1 ||
 						!config.interaction_onout
 					) {
 						return;
@@ -728,11 +726,12 @@ export default {
 
 		const mouse = getPointer(state.event, this);
 		const closest = $$.findClosestFromTargets(targetsToShow, mouse);
-		const sensitivity = $$.getPointSensitivity(closest);
 
 		if (!closest) {
 			return;
 		}
+
+		const sensitivity = $$.getPointSensitivity(closest);
 
 		// select if selection enabled
 		if ($$.isBarType(closest.id) || $$.dist(closest, mouse) < sensitivity) {

--- a/src/ChartInternal/interactions/interaction.ts
+++ b/src/ChartInternal/interactions/interaction.ts
@@ -226,7 +226,8 @@ export default {
 			// value 4, is to adjust coordinate value set from: scale.ts - updateScales(): $$.getResettedPadding(1)
 			let y = top + (mouse ? mouse[1] : 0) + (isRotated ? 4 : 0);
 
-			if (hasViewBox(svg)) {
+			// eventRect doesn't exist for radar/funnel/treemap charts
+			if (hasViewBox(svg) && $$.$el.eventRect) {
 				const ctm = getTransformCTM($$.$el.eventRect.node(), x, y, false);
 
 				x = ctm.x;
@@ -264,10 +265,13 @@ export default {
 	 */
 	unbindZoomEvent(): void {
 		const $$ = this;
-		const {$el: {canvas, eventRect, zoomResetBtn}} = $$;
+		const {$el: {canvas, eventRect, svg, zoomResetBtn}} = $$;
 
 		eventRect?.on(".zoom wheel.zoom .drag", null);
 		canvas?.on(".zoom wheel.zoom .drag", null);
+
+		// remove the Safari wheel workaround listener bound in bindZoomOnEventRect()
+		svg?.on("wheel", null);
 
 		zoomResetBtn?.on("click", null)
 			.style("display", "none");

--- a/src/ChartInternal/interactions/zoom.ts
+++ b/src/ChartInternal/interactions/zoom.ts
@@ -296,6 +296,11 @@ export default {
 		const useRAF = sourceEvent && isMousemove && config.zoom_type !== "wheel";
 
 		const executeRedraw = () => {
+			// chart can be destroyed before a RAF-deferred frame fires
+			if (!$$.config) {
+				return;
+			}
+
 			$$.redraw({
 				withTransition: doTransition,
 				withY: config.zoom_rescale,
@@ -497,6 +502,12 @@ export default {
 						.attr("width", isRotated ? state.width : 0)
 						.attr("height", isRotated ? 0 : state.height);
 				}
+
+				// refresh the fixed dimension: the chart may have been resized since creation
+				zoomRect?.attr(
+					isRotated ? "width" : "height",
+					isRotated ? state.width : state.height
+				);
 
 				start = clampPointer(getZoomDragPointer($$, event, this)[prop.index]);
 				end = start;

--- a/src/ChartInternal/internals/clip.ts
+++ b/src/ChartInternal/internals/clip.ts
@@ -103,8 +103,8 @@ export default {
 			const clipId = `${clip.id}-xaxisticktexts`;
 
 			$$.appendClip(defs, clipId);
-			clip.pathXAxisTickTexts = $$.getClipPath(clip.idXAxisTickTexts);
 			clip.idXAxisTickTexts = clipId;
+			clip.pathXAxisTickTexts = $$.getClipPath(clip.idXAxisTickTexts);
 		}
 
 		if (

--- a/src/ChartInternal/internals/grid.ts
+++ b/src/ChartInternal/internals/grid.ts
@@ -7,6 +7,7 @@ import type {d3Selection} from "../../../types/types";
 import {$AXIS, $COMMON, $FOCUS, $GRID} from "../../config/classes";
 import {AXIS_DEFAULT_TICK_COUNT} from "../../config/const";
 import {getPointer, isArray, isValue} from "../../module/util";
+import type {IDataRow} from "../data/IData";
 
 // Grid position and text anchor helpers
 const GRID_FOCUS_SELECTOR = `line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`;
@@ -142,13 +143,15 @@ export default {
 				const grid = d3Select(this);
 
 				Object.keys(state.xgridAttr).forEach(id => {
-					grid.attr(id, state.xgridAttr[id])
-						.style("opacity", () => (
-							grid.attr(isRotated ? "y1" : "x1") === (isRotated ? state.height : 0) ?
-								"0" :
-								null
-						));
+					grid.attr(id, state.xgridAttr[id]);
 				});
+
+				// hide the gridline overlapping the axis line (attr() returns a string)
+				grid.style("opacity", () => (
+					+grid.attr(isRotated ? "y1" : "x1") === (isRotated ? state.height : 0) ?
+						"0" :
+						null
+				));
 			});
 		}
 	},
@@ -413,7 +416,7 @@ export default {
 		// Cache grid focus selection to avoid repeated DOM queries on mousemove
 		const focusEl = _getGridFocusEl($$);
 
-		const dataToShow = (data || [focusEl.datum()]).filter(d =>
+		const dataToShow: IDataRow[] = (data || [focusEl.datum()]).filter(d =>
 			d && isValue($$.getBaseValue(d))
 		);
 
@@ -527,7 +530,7 @@ export default {
 		let gridData: Date[] = [];
 
 		if (type === "year") {
-			const xDomain = $$.getXDomain();
+			const xDomain = $$.getXDomain($$.data.targets);
 			const [firstYear, lastYear] = xDomain.map(v => v.getFullYear());
 
 			for (let i = firstYear; i <= lastYear; i++) {

--- a/src/ChartInternal/internals/legend.ts
+++ b/src/ChartInternal/internals/legend.ts
@@ -67,6 +67,14 @@ function _buildLegendItemMap($$, legendItems): void {
 		return;
 	}
 
+	// rebuild from all rendered items, not the passed (possibly enter-only) selection,
+	// so existing items aren't dropped from the map when new series are loaded
+	const allItems = $$.$el.legend?.selectAll(`.${$LEGEND.legendItem}`);
+
+	if (allItems && !allItems.empty()) {
+		legendItems = allItems;
+	}
+
 	// Convert D3 selection to array of [id, node] pairs
 	const items: Array<{id: string, node: HTMLElement}> = [];
 
@@ -258,8 +266,7 @@ export default {
 		} else if (!state.hasTreemap) {
 			$$.updateLegendElement(
 				targetIds || $$.mapToIds($$.data.targets),
-				optionz,
-				transitions
+				optionz
 			);
 		}
 
@@ -522,11 +529,13 @@ export default {
 
 		if (config.legend_show && isEmpty(targetIds)) {
 			config.legend_show = false;
-			legend.style("visibility", "hidden");
+			legend?.style("visibility", "hidden");
 		}
 
 		$$.addHiddenLegendIds(targetIds);
-		legend.selectAll($$.selectorLegends(targetIds))
+
+		// legend element isn't created when the chart was generated with legend.show=false
+		legend?.selectAll($$.selectorLegends(targetIds))
 			.style("opacity", "0")
 			.style("visibility", "hidden");
 	},
@@ -1066,41 +1075,55 @@ export default {
 		if (usePoint) {
 			const tiles = legend.selectAll(`.${$LEGEND.legendItemPoint}`)
 				.data(targetIdz);
+			const isRectangleTile = config.legend_item_tile_type !== "circle";
+			const tileWidth = isRectangleTile ?
+				config.legend_item_tile_width :
+				config.legend_item_tile_r * 2;
+			const tileHeight = isRectangleTile ?
+				config.legend_item_tile_height :
+				config.legend_item_tile_r * 2;
+			const iconWidth = tileWidth * 0.75;
+			const iconHeight = tileHeight * 0.75;
+			const customScaleX = tileWidth / 8;
+			const customScaleY = tileHeight / 8;
 
 			$T(tiles, withTransition)
 				.each(function() {
 					const nodeName = this.nodeName.toLowerCase();
-					const pointR = config.point_r;
 					let x = "x";
 					let y = "y";
-					let xOffset = 2;
-					let yOffset = 2.5;
 					let radius = null;
 					let width = <number | null>null;
 					let height = <number | null>null;
 
 					if (nodeName === "circle") {
-						const size = pointR * 0.2;
-
 						x = "cx";
 						y = "cy";
-						radius = pointR + size;
-						xOffset = pointR * 2;
-						yOffset = -size;
+						radius = Math.min(iconWidth, iconHeight) / 2;
 					} else if (nodeName === "rect") {
-						const size = pointR * 2.5;
-
-						width = size;
-						height = size;
-						yOffset = 3;
+						width = iconWidth;
+						height = iconHeight;
 					}
 
-					d3Select(this)
-						.attr(x, d => posFn.x1Tile(d) + xOffset)
-						.attr(y, d => posFn.yTile(d) - yOffset)
+					const tile = d3Select(this)
+						.attr("transform", null)
+						.attr("x", null)
+						.attr("y", null)
+						.attr("cx", null)
+						.attr("cy", null)
 						.attr("r", radius)
 						.attr("width", width)
 						.attr("height", height);
+
+					if (nodeName === "use") {
+						tile.attr("transform", d =>
+							`translate(${posFn.x1Tile(d)} ${posFn.yTile(d) - tileHeight / 2}) ` +
+							`scale(${customScaleX} ${customScaleY})`);
+					} else {
+						tile
+							.attr(x, d => posFn.x1Tile(d) + ((tileWidth - (width || 0)) / 2))
+							.attr(y, d => posFn.yTile(d) - ((height || 0) / 2));
+					}
 				});
 		} else {
 			const tiles = legend.selectAll(`.${$LEGEND.legendItemTile}`)

--- a/src/ChartInternal/internals/legend.ts
+++ b/src/ChartInternal/internals/legend.ts
@@ -1092,7 +1092,7 @@ export default {
 					const nodeName = this.nodeName.toLowerCase();
 					let x = "x";
 					let y = "y";
-					let radius = null;
+					let radius = <number | null>null;
 					let width = <number | null>null;
 					let height = <number | null>null;
 

--- a/src/ChartInternal/internals/redraw.ts
+++ b/src/ChartInternal/internals/redraw.ts
@@ -353,6 +353,6 @@ export default {
 		}
 
 		// Draw with new sizes & scales
-		$$.redraw(options, transitions);
+		$$.redraw(options);
 	}
 };

--- a/src/ChartInternal/internals/region.ts
+++ b/src/ChartInternal/internals/region.ts
@@ -78,6 +78,7 @@ export default {
 
 		label = $T(label, withTransition)
 			.text(d => d.label?.text)
+			// pre-rotate so that the centering math below measures the rotated bounding box
 			.attr("transform", ({label}) => label.rotated ? ` rotate(-90)` : null)
 			.attr("transform", function(d) {
 				const {x = 0, y = 0, center = false, rotated = false} = d.label ?? {};

--- a/src/ChartInternal/internals/text.ts
+++ b/src/ChartInternal/internals/text.ts
@@ -40,7 +40,7 @@ export default {
 		return $$.isBarType(d) &&
 				!meetsLabelThreshold.call($$, Math.abs($$.getRatio("bar", d)), "bar") ?
 			"0" :
-			($$.hasDataLabel ? null : "0");
+			($$.hasDataLabel() ? null : "0");
 	},
 
 	/**
@@ -280,8 +280,8 @@ export default {
 					(this.getAttribute("x") || this.getAttribute("transform"))), t);
 			const isInverted = config[`axis_${axis?.getId(d.id)}_inverted`];
 			let pos = {
-				x: getX.bind(this)(d, i, labelDimension),
-				y: getY.bind(this)(d, i, labelDimension)
+				x: getX.call(this, d, i, labelDimension),
+				y: getY.call(this, d, i, labelDimension)
 			};
 
 			if (angle) {

--- a/src/ChartInternal/internals/title.ts
+++ b/src/ChartInternal/internals/title.ts
@@ -100,6 +100,15 @@ export default {
 	},
 
 	/**
+	 * Get canvas title height using the same SVG text measurement as title padding.
+	 * @returns {number} Title height
+	 * @private
+	 */
+	getCanvasTitleHeight(): number {
+		return _getCanvasTitleHeight(this);
+	},
+
+	/**
 	 * Get title padding
 	 * @returns {number} padding value
 	 * @private
@@ -111,7 +120,7 @@ export default {
 		const paddingBottom = config.title_padding.bottom || 0;
 
 		if (state.isCanvasMode && config.title_text) {
-			return paddingTop + _getCanvasTitleHeight($$) + paddingBottom;
+			return paddingTop + $$.getCanvasTitleHeight() + paddingBottom;
 		}
 
 		if (!title?.node()) {

--- a/src/ChartInternal/internals/tooltip.ts
+++ b/src/ChartInternal/internals/tooltip.ts
@@ -194,7 +194,9 @@ export default {
 		for (i = 0; i < len; i++) {
 			row = d[i];
 
-			if (!row || !(getRowValue(row) || getRowValue(row) === 0)) {
+			const rowValue = row && getRowValue(row);
+
+			if (!row || !(rowValue || rowValue === 0)) {
 				continue;
 			}
 

--- a/src/ChartInternal/shape/arc.ts
+++ b/src/ChartInternal/shape/arc.ts
@@ -433,8 +433,9 @@ export default {
 		const radius = config.gauge_fullCircle || (forRange && !hasGauge) ?
 			$$.getArcLength() :
 			gStart * -2;
+		const isSingleArcGauge = d.data && $$.isGaugeType(d.data) && !$$.hasMultiArcGauge();
 
-		if (d.data && $$.isGaugeType(d.data) && !$$.hasMultiArcGauge()) {
+		if (isSingleArcGauge) {
 			const {gauge_min: gMin, gauge_max: gMax} = config;
 
 			// to prevent excluding total data sum during the init(when data.hide option is used), use $$.rendered state value
@@ -449,14 +450,37 @@ export default {
 		}
 
 		if (forRange === false) {
-			pie($$.filterTargetsToShow())
-				.forEach((t, i) => {
-					if (!found && t.data.id === d.data?.id) {
-						found = true;
-						d = t;
-						d.index = i;
-					}
-				});
+			// cache the pie layout per redraw: updateAngle() is called per arc/label,
+			// recomputing the full layout each time makes redraw O(n²) for many slices.
+			// The single arc gauge layout isn't cacheable: its angles depend on
+			// state.rendered, which can flip within the same redraw generation.
+			let layout;
+
+			if (isSingleArcGauge) {
+				layout = pie($$.filterTargetsToShow());
+			} else {
+				const cacheKey = "$arcPieLayout";
+				let cached = $$.cache.get(cacheKey);
+
+				if (!cached || cached.generation !== state.redrawGeneration) {
+					cached = {
+						generation: state.redrawGeneration,
+						layout: pie($$.filterTargetsToShow())
+					};
+
+					$$.cache.add(cacheKey, cached);
+				}
+
+				layout = cached.layout;
+			}
+
+			layout.forEach((t, i) => {
+				if (!found && t.data.id === d.data?.id) {
+					found = true;
+					d = t;
+					d.index = i;
+				}
+			});
 		}
 
 		if (isNaN(d.startAngle)) {
@@ -565,7 +589,7 @@ export default {
 			let rangeText = arcs.selectAll(`.${$ARC.arcRange}`)
 				.data(values);
 
-			rangeText.exit();
+			rangeText.exit().remove();
 
 			rangeText = $T(rangeText.enter()
 				.append("text")
@@ -678,7 +702,8 @@ export default {
 		// MEMO: avoid to cancel transition
 		if (transiting) {
 			const interval = setInterval(() => {
-				if (!transiting) {
+				// check the live state value: the destructured one is stale within this closure
+				if (!$$.state.transiting) {
 					clearInterval(interval);
 
 					$el.legend.selectAll(`.${$FOCUS.legendItemFocused}`).size() > 0 &&
@@ -1013,6 +1038,15 @@ export default {
 				}
 
 				state.transiting = false;
+
+				// release the redraw snapshot when a no-transition redraw skipped
+				// afterRedraw() because this arc transition was still running
+				if (state.redrawing) {
+					state.redrawing = false;
+					state._targetsToShow = null;
+					state._cachedDrawShape = null;
+				}
+
 				callFn(config.onrendered, $$.api);
 			});
 
@@ -1128,7 +1162,8 @@ export default {
 
 			radian = radius * ((value - min) / (max - min));
 		} else {
-			radian = arcLength * (value / total);
+			// guard against 0/0 = NaN when all data is zero or hidden
+			radian = total ? arcLength * (value / total) : 0;
 		}
 
 		return (startingAngle + radian) * (180 / Math.PI);

--- a/src/ChartInternal/shape/bar.ts
+++ b/src/ChartInternal/shape/bar.ts
@@ -163,20 +163,22 @@ export default {
 						connectLineCache.set(d.id, connectLineType);
 					}
 
-					// for bar.coonectLine option
+					// for bar.connectLine option
 					if (path.length > 1) {
 						barPath.push(path[1]);
+					}
 
-						if (i === arr.length - 1) {
-							const barConnectLineNode = $$.$T(
-								d3Select(this.parentNode.querySelector(`.${$BAR.barConnectLine}`)),
-								withTransition,
-								getRandom()
-							);
+					// flush per series even when the last datum is null,
+					// otherwise the accumulated path leaks into the next series
+					if (i === arr.length - 1 && barPath.length) {
+						const barConnectLineNode = $$.$T(
+							d3Select(this.parentNode.querySelector(`.${$BAR.barConnectLine}`)),
+							withTransition,
+							getRandom()
+						);
 
-							$$.updateConnectLine(barConnectLineNode, connectLineType, barPath);
-							barPath.splice(0);
-						}
+						$$.updateConnectLine(barConnectLineNode, connectLineType, barPath);
+						barPath.splice(0);
 					}
 
 					return path[0];

--- a/src/ChartInternal/shape/core/path.ts
+++ b/src/ChartInternal/shape/core/path.ts
@@ -8,20 +8,15 @@ type PathContext = CanvasRenderingContext2D | null | undefined;
 type PathResult = string | void;
 
 /**
- * Get values with null/step handling for line-like paths.
+ * Get values with step handling for line-like paths.
  * @param {object} $$ ChartInternal instance
- * @param {object} target Data target
+ * @param {object} d Data target (needs `.id` for per-series step type detection)
+ * @param {Array} values Null-filtered values to draw
  * @returns {Array} Drawable values
  * @private
  */
-function getLineValues($$, target): any[] {
-	let values = $$.config.line_connectNull ? $$.filterRemoveNull(target.values) : target.values;
-
-	if ($$.isStepType(target)) {
-		values = $$.convertValuesToStep(values);
-	}
-
-	return values;
+function getLineValues($$, d, values): any[] {
+	return $$.isStepType(d) ? $$.convertValuesToStep(values) : values;
 }
 
 /**
@@ -84,7 +79,7 @@ export function generateDrawLinePath(
 
 				path = $$.lineWithRegions(values, scale.zoom || x, y, regions);
 			} else {
-				path = line.curve($$.getCurve(d))(getLineValues($$, {values}));
+				path = line.curve($$.getCurve(d))(getLineValues($$, d, values));
 			}
 		} else {
 			if (values[0]) {

--- a/src/ChartInternal/shape/funnel.ts
+++ b/src/ChartInternal/shape/funnel.ts
@@ -320,7 +320,7 @@ export default {
 		const getTarget = event => {
 			const target = event.isTrusted ? event.target : state.eventReceiver.rect?.node();
 
-			if (/^path$/i.test(target.tagName)) {
+			if (target && /^path$/i.test(target.tagName)) {
 				state.event = event;
 				return d3Select(target).datum();
 			}
@@ -413,9 +413,9 @@ export default {
 
 		let accumulated = 0;
 
-		targets.each((d, i) => {
+		targets.each(d => {
 			const start = accumulated;
-			const ratio = (targets?.[i] ?? d).ratio;
+			const {ratio} = d;
 
 			accumulated += ratio;
 

--- a/src/ChartInternal/shape/line.ts
+++ b/src/ChartInternal/shape/line.ts
@@ -142,47 +142,6 @@ export default {
 		];
 	},
 
-	/**
-	 * Get the curve interpolate
-	 * @param {Array} d Data object
-	 * @returns {function}
-	 * @private
-	 */
-	getCurve(d): Function {
-		const $$ = this;
-		const isRotatedStepType = $$.config.axis_rotated && $$.isStepType(d);
-
-		// when is step & rotated, should be computed in different way
-		// https://github.com/naver/billboard.js/issues/471
-		return isRotatedStepType ?
-			context => {
-				const step = $$.getInterpolate(d)(context);
-
-				// keep the original method
-				step.orgPoint = step.point;
-
-				// to get rotated path data
-				step.pointRotated = function(x, y) {
-					this._point === 1 && (this._point = 2);
-
-					const y1 = this._y * (1 - this._t) + y * this._t;
-
-					this._context.lineTo(this._x, y1);
-					this._context.lineTo(x, y1);
-
-					this._x = x;
-					this._y = y;
-				};
-
-				step.point = function(x, y) {
-					this._point === 0 ? this.orgPoint(x, y) : this.pointRotated(x, y);
-				};
-
-				return step;
-			} :
-			$$.getInterpolate(d);
-	},
-
 	generateDrawLine(lineIndices, isSub?: boolean): (d) => string {
 		const $$ = this;
 
@@ -267,6 +226,11 @@ export default {
 		// Generate
 		const axisType = {x: $$.axis.getAxisType("x"), y: $$.axis.getAxisType("y")};
 		let path = "";
+
+		// empty or all-null series has nothing to draw
+		if (!d.length) {
+			return path;
+		}
 
 		// clone the line path to be used to get length value
 		const target = $$.$el.line.filter(({id}) => id === d[0].id);
@@ -357,9 +321,11 @@ export default {
 			// if not last x tick, then should draw rest of path that is not drawn yet
 			!isLastX && dashArray.dash.push(getLength(tempNode, path));
 
-			tempNode.remove();
 			target.attr("stroke-dasharray", dashArray.dash.join(" "));
 		}
+
+		// make sure the cloned node is removed even when no dash segment was produced
+		tempNode.remove();
 
 		return path;
 	},

--- a/src/ChartInternal/shape/point.ts
+++ b/src/ChartInternal/shape/point.ts
@@ -494,7 +494,7 @@ export default {
 					mainCircles = $$.$T(mainCircles, withTransition, getTransitionName());
 				}
 
-				selectedCircles && $$.$T(mainCircles, withTransition, getTransitionName());
+				selectedCircles && $$.$T(selectedCircles, withTransition, getTransitionName());
 			}
 
 			return mainCircles

--- a/src/ChartInternal/shape/shape.ts
+++ b/src/ChartInternal/shape/shape.ts
@@ -225,7 +225,7 @@ export default {
 		const shape = {type: <TShape>{}, indices: <TShape>{}, pos: {}};
 
 		!hasTreemap && ["bar", "candlestick", "line", "area"].forEach(v => {
-			const name = capitalize(/^(bubble|scatter)$/.test(v) ? "line" : v);
+			const name = capitalize(v);
 
 			if (
 				$$.hasType(v) || $$.hasTypeOf(name) || (
@@ -1037,12 +1037,16 @@ export default {
 		const $$ = this;
 		const isRotatedStepType = $$.config.axis_rotated && $$.isStepType(d);
 
+		// when is step & rotated, should be computed in different way
+		// https://github.com/naver/billboard.js/issues/471
 		return isRotatedStepType ?
 			context => {
 				const step = $$.getInterpolate(d)(context);
 
+				// keep the original method
 				step.orgPoint = step.point;
 
+				// to get rotated path data
 				step.pointRotated = function(x, y) {
 					this._point === 1 && (this._point = 2);
 

--- a/src/ChartInternal/shape/treemap.ts
+++ b/src/ChartInternal/shape/treemap.ts
@@ -75,7 +75,7 @@ export default {
 			const target = event.isTrusted ? event.target : state.eventReceiver.rect?.node();
 			let data;
 
-			if (/^rect$/i.test(target.tagName)) {
+			if (target && /^rect$/i.test(target.tagName)) {
 				state.event = event;
 				data = d3Select(target).datum();
 			}

--- a/src/canvas/CanvasAxisRenderer.ts
+++ b/src/canvas/CanvasAxisRenderer.ts
@@ -25,6 +25,7 @@ import {
 import CanvasEngine from "./CanvasEngine";
 import CanvasPainter, {CanvasRect} from "./CanvasPainter";
 import CanvasTheme from "./CanvasTheme";
+import {getFontSize} from "./util";
 
 type GridLine = Partial<GridLineOptions>;
 type AdditionalAxisOptions = {
@@ -35,7 +36,8 @@ type AdditionalAxisOptions = {
 	outerTick: boolean
 };
 
-const X_AXIS_TICK_TEXT_CLIP_PADDING = 10;
+const X_AXIS_TICK_TEXT_HORIZONTAL_CLIP_PADDING = 20;
+const X_AXIS_TICK_TEXT_VERTICAL_CLIP_PADDING = 15;
 
 /**
  * Get x tick text direction. Text labels stay outside the chart even when tick lines are inner.
@@ -68,9 +70,9 @@ function getYTickTextDirection(isRotated: boolean, isY2: boolean): number {
  */
 function getHorizontalXAxisClipRect(margin, width: number, height: number): CanvasRect {
 	return {
-		x: margin.left - X_AXIS_TICK_TEXT_CLIP_PADDING,
+		x: margin.left - X_AXIS_TICK_TEXT_HORIZONTAL_CLIP_PADDING,
 		y: 0,
-		w: width + (X_AXIS_TICK_TEXT_CLIP_PADDING * 2),
+		w: width + (X_AXIS_TICK_TEXT_HORIZONTAL_CLIP_PADDING * 2),
 		h: height
 	};
 }
@@ -86,9 +88,9 @@ function getHorizontalXAxisClipRect(margin, width: number, height: number): Canv
 function getRotatedXAxisClipRect(margin, width: number, height: number): CanvasRect {
 	return {
 		x: 0,
-		y: margin.top - X_AXIS_TICK_TEXT_CLIP_PADDING,
+		y: margin.top - X_AXIS_TICK_TEXT_VERTICAL_CLIP_PADDING,
 		w: width,
-		h: height + (X_AXIS_TICK_TEXT_CLIP_PADDING * 2)
+		h: height + (X_AXIS_TICK_TEXT_VERTICAL_CLIP_PADDING * 2)
 	};
 }
 
@@ -205,19 +207,6 @@ function formatTick(format: AxisTickFormat, tick: AxisTickValue): string {
 }
 
 /**
- * Get font size from canvas font shorthand.
- * @param {string} font Canvas font shorthand
- * @returns {number} Font size
- * @private
- */
-function getFontSize(font: string): number {
-	const match = /(\d+(?:\.\d+)?)px/.exec(font);
-	const size = match ? parseFloat(match[1]) : parseFloat(font);
-
-	return Number.isFinite(size) ? size : 12;
-}
-
-/**
  * Get axis tick text font for a specific axis.
  * @param {object} axisStyle Canvas axis style
  * @param {string} id Axis id
@@ -244,6 +233,28 @@ function getXTickTextLineHeight(painter: CanvasPainter, fontSize: number): numbe
 	const svgFallbackHeight = (fontSize || 10) * (11.5 / 10);
 
 	return Math.max(fontSize, fontBoxHeight, actualBoxHeight, svgFallbackHeight);
+}
+
+/**
+ * Get SVG-compatible y position for rotated bottom x-axis tick text.
+ * @param {number} rotate Tick text rotation
+ * @returns {number} Local SVG text y coordinate
+ * @private
+ */
+function getRotatedXTickTextY(rotate: number): number {
+	const r2 = rotate / 15;
+
+	return 11.5 - 2.5 * r2 * (rotate > 0 ? 1 : -1);
+}
+
+/**
+ * Get SVG-compatible tspan dx for rotated bottom x-axis tick text.
+ * @param {number} rotate Tick text rotation
+ * @returns {number} Local tspan dx
+ * @private
+ */
+function getRotatedXTickTextDx(rotate: number): number {
+	return 8 * Math.sin(Math.PI * (rotate / 180));
 }
 
 /**
@@ -356,11 +367,13 @@ function getXTickTextWidth($$, ticks: AxisTickValue[], isRotated: boolean, targe
  * @param {Array} ticks X-axis tick values
  * @param {boolean} isRotated Whether axis is rotated
  * @param {function} targetScale X scale
+ * @param {number} [maxWidth] Pre-computed max tick text width (invariant per draw pass)
  * @returns {Array} Tick text lines
  * @private
  */
 function getXTickTextLines($$, painter: CanvasPainter, format: AxisTickFormat, tick: AxisTickValue,
-	ticks: AxisTickValue[] = [], isRotated = false, targetScale = getXScale($$)): string[] {
+	ticks: AxisTickValue[] = [], isRotated = false, targetScale = getXScale($$),
+	maxWidth?: number): string[] {
 	const value = format ? format(tick) : tick;
 
 	if (value == null) {
@@ -380,7 +393,7 @@ function getXTickTextLines($$, painter: CanvasPainter, format: AxisTickFormat, t
 	return $$.config.axis_x_tick_multiline ?
 		splitTickTextByWidth(
 			text,
-			getXTickTextWidth($$, ticks, isRotated, targetScale),
+			maxWidth ?? getXTickTextWidth($$, ticks, isRotated, targetScale),
 			painter
 		) :
 		[text];
@@ -794,6 +807,10 @@ export default class CanvasAxisRenderer {
 				ctx.strokeStyle = axis.tickColor;
 				ctx.lineWidth = axis.tickWidth;
 
+				// invariant across ticks: measure/resolve once per draw pass
+				const lineHeight = getXTickTextLineHeight(painter, getFontSize(tickFont));
+				const tickTextWidth = getXTickTextWidth($$, ticks, isRotated, scale.subX);
+
 				for (const tick of ticks) {
 					const tickPos = scale.subX(normalizeXValue($$, tick));
 					const tx = margin2.left + tickPos;
@@ -825,9 +842,9 @@ export default class CanvasAxisRenderer {
 						tick,
 						ticks,
 						isRotated,
-						scale.subX
+						scale.subX,
+						tickTextWidth
 					);
-					const lineHeight = getXTickTextLineHeight(painter, getFontSize(tickFont));
 					let textX;
 					let textY;
 
@@ -875,13 +892,14 @@ export default class CanvasAxisRenderer {
 		const fontSize = getFontSize(title.font);
 		const lineHeight = fontSize * 1.5;
 		const {x, align} = getTitleTextPosition(config.title_position, current.width);
-		const y = config.title_padding.top || 0;
+		const titleHeight = $$.getCanvasTitleHeight?.() ?? fontSize;
+		const y = (config.title_padding.top || 0) + titleHeight;
 
 		painter.withState(() => {
 			ctx.font = title.font;
 			ctx.fillStyle = title.color;
 			ctx.textAlign = align;
-			ctx.textBaseline = "top";
+			ctx.textBaseline = "alphabetic";
 
 			lines.forEach((line, i) => {
 				ctx.fillText(line, x, y + (i ? fontSize + ((i - 1) * lineHeight) : 0));
@@ -1369,14 +1387,22 @@ export default class CanvasAxisRenderer {
 					return;
 				}
 
+				// invariant across ticks: measure/resolve once per draw pass
+				const tickFont = getAxisTickFont(axis, "x");
+				const tickLineHeight = getXTickTextLineHeight(painter, getFontSize(tickFont));
+				const tickTextWidth = getXTickTextWidth($$, ticks, isRotated, targetScale);
+
 				ticks.forEach((tick, tickIndex) => {
 					this.drawXAxisTickText($$, tick, format, axis.labelColor, {
 						isRotated,
 						rangeEnd,
 						rangeStart,
 						tickCount: ticks.length,
+						tickFont,
 						tickIndex,
+						tickLineHeight,
 						tickTextDirection,
+						tickTextWidth,
 						tickRotate,
 						tickTextPosition,
 						targetScale,
@@ -1625,7 +1651,7 @@ export default class CanvasAxisRenderer {
 			return;
 		}
 
-		const tickFont = getAxisTickFont(axis, "x");
+		const tickFont = options.tickFont ?? getAxisTickFont(axis, "x");
 
 		ctx.font = tickFont;
 		ctx.fillStyle = fill;
@@ -1637,9 +1663,11 @@ export default class CanvasAxisRenderer {
 			tick,
 			ticks,
 			isRotated,
-			targetScale
+			targetScale,
+			options.tickTextWidth
 		);
-		const lineHeight = getXTickTextLineHeight(painter, getFontSize(tickFont));
+		const lineHeight = options.tickLineHeight ??
+			getXTickTextLineHeight(painter, getFontSize(tickFont));
 		let textX;
 		let textY;
 
@@ -1649,6 +1677,27 @@ export default class CanvasAxisRenderer {
 			textY = ty + (tickTextPosition.y || 0);
 			ctx.textAlign = getXTickTextAlign($$, options);
 			ctx.textBaseline = "middle";
+		} else if (tickRotate) {
+			const fontSize = getFontSize(tickFont);
+			const firstDy = tickTextPosition.y ?
+				resolveTextOffset(tickTextPosition.y, fontSize) :
+				0.71 * fontSize;
+			const textDx = getRotatedXTickTextDx(tickRotate) +
+				(tickTextPosition.x || 0);
+			const textY = getRotatedXTickTextY(tickRotate) + firstDy;
+
+			ctx.textAlign = getXTickTextAlign($$, options);
+			ctx.textBaseline = "alphabetic";
+			painter.withState(textCtx => {
+				textCtx.translate(tx, y);
+				textCtx.rotate(tickRotate * Math.PI / 180);
+
+				lines.forEach((line, i) => {
+					textCtx.fillText(line, textDx, textY + (i * lineHeight));
+				});
+			});
+
+			return;
 		} else {
 			textX = tx + (tickTextPosition.x || 0);
 			textY = y + ((AXIS_TICK_SIZE + AXIS_TICK_PADDING) * tickTextDirection) +

--- a/src/canvas/CanvasEngine.ts
+++ b/src/canvas/CanvasEngine.ts
@@ -46,6 +46,9 @@ export default class CanvasEngine {
 		const width = Math.max(0, w);
 		const height = Math.max(0, h);
 
+		// re-read: dpr changes when the window moves across monitors or zoom changes
+		this.dpr = window.devicePixelRatio || 1;
+
 		this.canvas.width = width * this.dpr;
 		this.canvas.height = height * this.dpr;
 		this.canvas.style.width = `${width}px`;
@@ -127,10 +130,17 @@ export default class CanvasEngine {
 				return;
 			}
 
-			frame.width = canvas.width;
-			frame.height = canvas.height;
+			// assigning width/height reallocates and clears the backing store,
+			// so only assign on size change and clearRect otherwise
 			frameCtx.setTransform(1, 0, 0, 1, 0, 0);
-			frameCtx.clearRect(0, 0, canvas.width, canvas.height);
+
+			if (frame.width !== canvas.width || frame.height !== canvas.height) {
+				frame.width = canvas.width;
+				frame.height = canvas.height;
+			} else {
+				frameCtx.clearRect(0, 0, canvas.width, canvas.height);
+			}
+
 			frameCtx.drawImage(canvas, 0, 0);
 		}
 	}

--- a/src/canvas/CanvasPainter.ts
+++ b/src/canvas/CanvasPainter.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
+import {getFontSize} from "./util";
 
 export type CanvasRect = {x: number, y: number, w: number, h: number};
 export type CanvasRectRadius = number | {tl?: number, tr?: number, br?: number, bl?: number};
@@ -298,7 +299,7 @@ export default class CanvasPainter {
 		style?: CanvasStyle & {angle?: number, maxWidth?: number}): void {
 		this.withState(ctx => {
 			const lines = text.split("\n");
-			const lineHeight = parseFloat(style?.font || ctx.font) || 12;
+			const lineHeight = getFontSize(style?.font || ctx.font);
 			const firstLineY = lines.length > 1 ? -((lines.length - 1) * lineHeight) : 0;
 
 			this.applyStyle(style);

--- a/src/canvas/CanvasRenderer.ts
+++ b/src/canvas/CanvasRenderer.ts
@@ -33,7 +33,6 @@ import {
 	getLabelImagePosition,
 	getLabelImageUrl,
 	getLabelPosition,
-	getLabelRowKey,
 	getLabelText,
 	getPointLabelAnchor,
 	getRotatedLabelPosition,
@@ -45,6 +44,7 @@ import {
 	DENSE_SCATTER_POINT_CULL_THRESHOLD,
 	getCanvasShapeIndices,
 	getCanvasTargetVisibleRange,
+	getFontSize,
 	hasCanvasDrawableValue,
 	isCanvasAreaType,
 	isCanvasBarType,
@@ -654,12 +654,14 @@ function getPointFillStyle(
 	const stops = Array.isArray(gradientOption.stops) ?
 		gradientOption.stops :
 		[[0.1, null, 1], [0.9, null, 0]];
+	const gradientX = x + (cx - 0.5) * r * 2;
+	const gradientY = y + (cy - 0.5) * r * 2;
 	const gradient = ctx.createRadialGradient(
-		x + (cx - 0.5) * r * 2,
-		y + (cy - 0.5) * r * 2,
+		gradientX,
+		gradientY,
 		0,
-		x,
-		y,
+		gradientX,
+		gradientY,
 		Math.max(1, r * radius * 2)
 	);
 
@@ -670,7 +672,13 @@ function getPointFillStyle(
 			color = fallback;
 		}
 
-		gradient.addColorStop(offset, withOpacity(color, stopOpacity));
+		// addColorStop throws IndexSizeError for out-of-range offsets
+		const numericOffset = Number(offset);
+		const parsedOffset = Number.isFinite(numericOffset) ?
+			Math.max(0, Math.min(1, numericOffset)) :
+			0;
+
+		gradient.addColorStop(parsedOffset, withOpacity(color, stopOpacity));
 	});
 
 	return gradient;
@@ -1187,7 +1195,7 @@ export default class CanvasRenderer {
 		const {ctx, painter, theme: {style}} = this;
 		const {margin2, width2, height2} = state;
 		const rect = {x: margin2.left, y: margin2.top, w: width2, h: height2};
-		const targets = $$.filterTargetsToShow($$.data.targets)
+		const targets = $$.filterTargetsToShow()
 			.filter(isCanvasRenderableTarget.bind(null, $$));
 
 		painter.withState(() => {
@@ -1278,11 +1286,7 @@ export default class CanvasRenderer {
 									return;
 								}
 
-								const color = value._isUp ?
-									$$.color(target.id) :
-									(config.candlestick_color_down?.[target.id] ||
-										config.candlestick_color_down ||
-										$$.color(target.id));
+								const color = getCandlestickColor($$, {id: target.id}, value);
 
 								ctx.strokeStyle = color;
 								ctx.fillStyle = color;
@@ -1461,7 +1465,7 @@ export default class CanvasRenderer {
 		const {ctx, painter, theme: {style}} = this;
 		const isBar = isCanvasBarType.bind(null, $$);
 		const isExpanded = getExpandedFocusMatcher($$, focusData, isCanvasBarType);
-		const targets = $$.filterTargetsToShow($$.data.targets)
+		const targets = $$.filterTargetsToShow()
 			.filter(isBar)
 			.filter(isCanvasRenderableTarget.bind(null, $$));
 		const getPoints = $$.generateGetBarPoints(
@@ -1580,7 +1584,7 @@ export default class CanvasRenderer {
 		const {ctx, painter, theme: {style}} = this;
 		const isCandlestick = isCanvasCandlestickType.bind(null, $$);
 		const isExpanded = getExpandedFocusMatcher($$, focusData, isCanvasCandlestickType);
-		const targets = $$.filterTargetsToShow($$.data.targets)
+		const targets = $$.filterTargetsToShow()
 			.filter(isCandlestick)
 			.filter(isCanvasRenderableTarget.bind(null, $$));
 		const getPoints = $$.generateGetCandlestickPoints?.(
@@ -1668,7 +1672,7 @@ export default class CanvasRenderer {
 	drawLines($$, shape): void {
 		const {ctx, painter, theme: {style}} = this;
 		const isLine = isCanvasLineType.bind(null, $$);
-		const targets = $$.filterTargetsToShow($$.data.targets)
+		const targets = $$.filterTargetsToShow()
 			.filter(isLine)
 			.filter(isCanvasRenderableTarget.bind(null, $$));
 		const indices = getCanvasShapeIndices($$, shape, TYPE.LINE, isLine);
@@ -1707,7 +1711,7 @@ export default class CanvasRenderer {
 	drawAreas($$, shape, focusData?): void {
 		const {ctx, painter, theme: {style}} = this;
 		const isArea = isCanvasAreaType.bind(null, $$);
-		const targets = $$.filterTargetsToShow($$.data.targets)
+		const targets = $$.filterTargetsToShow()
 			.filter(isArea)
 			.filter(isCanvasRenderableTarget.bind(null, $$));
 		const indices = getCanvasShapeIndices($$, shape, TYPE.AREA, isArea);
@@ -1731,7 +1735,8 @@ export default class CanvasRenderer {
 					ctx,
 					target,
 					"area",
-					getCanvasAreaBounds($$, target, indices),
+					// bounds computation is a full O(n) pass: skip when no gradient is set
+					$$.config.area_linearGradient ? getCanvasAreaBounds($$, target, indices) : null,
 					color
 				);
 				drawCanvasArea($$, target, indices, painter);
@@ -1763,7 +1768,7 @@ export default class CanvasRenderer {
 		}
 
 		painter.withTranslation(margin.left, margin.top, () => {
-			for (const target of $$.filterTargetsToShow($$.data.targets)) {
+			for (const target of $$.filterTargetsToShow()) {
 				if (
 					!isCanvasPointType($$, target) ||
 					!isCanvasRenderableTarget($$, target) ||
@@ -2058,7 +2063,7 @@ export default class CanvasRenderer {
 				false
 			) :
 			null;
-		const targets = $$.filterTargetsToShow($$.data.targets)
+		const targets = $$.filterTargetsToShow()
 			.filter(target =>
 				(
 					isCanvasBarType($$, target) ||
@@ -2068,13 +2073,17 @@ export default class CanvasRenderer {
 				) &&
 				isCanvasRenderableTarget($$, target)
 			);
-		const labelRows: any[] = [];
-		const labelTexts = new Map<string, string>();
+		// single filtering pass: keep target-local index `i`, it drives geometry lookup
+		const targetRows: Array<{d, i: number, text: string}[]> = [];
+		let labelCount = 0;
 
 		targets.forEach(target => {
 			const range = getCanvasTargetVisibleRange($$, target);
+			const data = $$.labelishData(target);
+			const rows: {d, i: number, text: string}[] = [];
 
-			$$.labelishData(target).forEach(d => {
+			for (let i = 0; i < data.length; i++) {
+				const d = data[i];
 				const text = getLabelText($$, d);
 
 				if (
@@ -2083,39 +2092,27 @@ export default class CanvasRenderer {
 					d.index < range.end &&
 					hasCanvasDrawableValue($$, d)
 				) {
-					labelRows.push(d);
-					labelTexts.set(getLabelRowKey(d), text);
+					rows.push({d, i, text});
 				}
-			});
+			}
+
+			labelCount += rows.length;
+			rows.length && targetRows.push(rows);
 		});
 
 		const texts = {
-			size: () => labelRows.length
+			size: () => labelCount
 		};
 
 		painter.withTranslation(margin.left, margin.top, () => {
 			ctx.font = style.label.font;
 			ctx.textAlign = "center";
 
-			targets
-				.forEach(target => {
-					const data = $$.labelishData(target);
-					const range = getCanvasTargetVisibleRange($$, target);
-
-					for (let i = 0; i < data.length; i++) {
-						const d = data[i];
-						const text = labelTexts.get(getLabelRowKey(d));
+			targetRows
+				.forEach(rows => {
+					for (const {d, i, text} of rows) {
 						let x;
 						let y;
-
-						if (
-							!text ||
-							d.index < range.start ||
-							d.index >= range.end ||
-							!hasCanvasDrawableValue($$, d)
-						) {
-							continue;
-						}
 
 						if (isCanvasBarType($$, d) && barPoints) {
 							const geometry = getCanvasBarGeometry($$, barPoints, d, i);
@@ -2198,7 +2195,7 @@ export default class CanvasRenderer {
 	 */
 	drawEmptyLabel($$): void {
 		const text = $$.config.data_empty_label_text;
-		const targetsToShow = $$.filterTargetsToShow($$.data.targets);
+		const targetsToShow = $$.filterTargetsToShow();
 
 		if (!text || targetsToShow.length) {
 			return;
@@ -2328,15 +2325,36 @@ export default class CanvasRenderer {
 				}
 
 				const lines = label.split("\n");
-				const lineHeight = 12;
-				let textX = x + w / 2;
-				let textY = y + h / 2 - (lines.length - 1) * lineHeight / 2;
+				const isCentered = !!config.data_labels.centered;
 
 				ctx.font = style.label.font;
-				ctx.textAlign = "center";
-				ctx.textBaseline = "middle";
+				const lineHeight = getFontSize(ctx.font);
+				const metrics = ctx.measureText(lines[0] ?? "");
+				const fontBoundingHeight = (
+					(metrics.fontBoundingBoxAscent || 0) +
+					(metrics.fontBoundingBoxDescent || 0)
+				) || (
+					(metrics.actualBoundingBoxAscent || 0) +
+					(metrics.actualBoundingBoxDescent || 0)
+				);
+				const textHeight = Math.max(lineHeight, fontBoundingHeight) +
+					((lines.length - 1) * lineHeight);
+				const blockY = isCentered ? y + h / 2 : y + textHeight + 5;
+				let textX = isCentered ? x + w / 2 : x + 5;
+				let textY = blockY - (lines.length - 1) * lineHeight / (isCentered ? 2 : 1);
+
+				ctx.textAlign = isCentered ? "center" : "left";
+				ctx.textBaseline = isCentered ? "middle" : "alphabetic";
 				({x: textX, y: textY} = this.drawLabelImage($$, data, label, textX, textY));
 				ctx.fillStyle = getLabelColor($$, data, style.label.color);
+				drawLabelDecorations(
+					$$,
+					painter,
+					data,
+					label,
+					textX,
+					isCentered ? textY + ((lines.length - 1) * lineHeight / 2) : blockY
+				);
 
 				lines.forEach((line, i) => {
 					painter.text(line, textX, textY + i * lineHeight, {
@@ -2452,19 +2470,20 @@ export default class CanvasRenderer {
 						const {x, y} = getRenderDataPoint($$, d);
 						const baseR = $$.pointR?.(d) ?? 2.5;
 						const r = $$.pointExpandedR?.(d) ?? (baseR * 1.75);
-						const color = getCanvasOverColor($$, d) || $$.color(d.id);
+						const overColor = getCanvasOverColor($$, d);
+						const color = overColor || $$.color(d.id);
 
 						if (!isFiniteCanvasCoordinate(x, y)) {
 							return;
 						}
 
 						drawPointPattern(painter, pointType, x, y, r, {
-							fill: getCanvasOverColor($$, d) ||
+							fill: overColor ||
 								style.focusPoint.fill ||
 								style.shape.pointFillColor ||
 								color,
 							lineWidth: style.focusPoint.lineWidth,
-							stroke: getCanvasOverColor($$, d) || style.focusPoint.stroke || color,
+							stroke: overColor || style.focusPoint.stroke || color,
 							alpha: getPointOpacity($$, d)
 						}, baseR);
 					});

--- a/src/canvas/HitDetector.ts
+++ b/src/canvas/HitDetector.ts
@@ -170,7 +170,7 @@ export default class HitDetector {
 	 */
 	rebuild($$, shape): void {
 		const {current, margin, width, height} = $$.state;
-		const targets = $$.filterTargetsToShow($$.data.targets);
+		const targets = $$.filterTargetsToShow();
 
 		this.bars = [];
 		this.points = [];
@@ -375,13 +375,13 @@ export default class HitDetector {
 	}
 
 	/**
-	 * Find the nearest data row for the given canvas coordinates.
+	 * Hit-test bars at the given canvas coordinates.
 	 * @param {number} mx Mouse x coordinate
 	 * @param {number} my Mouse y coordinate
 	 * @returns {object|null} Matching data row
 	 * @private
 	 */
-	findNearest(mx: number, my: number): any | null {
+	private hitBar(mx: number, my: number): any | null {
 		for (const item of getGridItems(this.barGrid, mx, my, BAR_CELL_SIZE)) {
 			const {w = 0, h = 0} = item;
 
@@ -395,14 +395,17 @@ export default class HitDetector {
 			}
 		}
 
-		if (!this.pointBased && this.grouped && this.isWithinPlot(mx, my)) {
-			const item = this.findNearestIndexItem(mx, my);
+		return null;
+	}
 
-			if (item) {
-				return item.data;
-			}
-		}
-
+	/**
+	 * Find the nearest point within sensitivity at the given canvas coordinates.
+	 * @param {number} mx Mouse x coordinate
+	 * @param {number} my Mouse y coordinate
+	 * @returns {object|null} Matching data row
+	 * @private
+	 */
+	private hitPoint(mx: number, my: number): any | null {
 		let nearest: HitItem | null = null;
 		let min = Number.POSITIVE_INFINITY;
 
@@ -422,6 +425,31 @@ export default class HitDetector {
 	}
 
 	/**
+	 * Find the nearest data row for the given canvas coordinates.
+	 * @param {number} mx Mouse x coordinate
+	 * @param {number} my Mouse y coordinate
+	 * @returns {object|null} Matching data row
+	 * @private
+	 */
+	findNearest(mx: number, my: number): any | null {
+		const bar = this.hitBar(mx, my);
+
+		if (bar) {
+			return bar;
+		}
+
+		if (!this.pointBased && this.grouped && this.isWithinPlot(mx, my)) {
+			const item = this.findNearestIndexItem(mx, my);
+
+			if (item) {
+				return item.data;
+			}
+		}
+
+		return this.hitPoint(mx, my);
+	}
+
+	/**
 	 * Find the nearest directly hit shape row, excluding grouped index fallback.
 	 * @param {number} mx Mouse x coordinate
 	 * @param {number} my Mouse y coordinate
@@ -429,35 +457,7 @@ export default class HitDetector {
 	 * @private
 	 */
 	findNearestShape(mx: number, my: number): any | null {
-		for (const item of getGridItems(this.barGrid, mx, my, BAR_CELL_SIZE)) {
-			const {w = 0, h = 0} = item;
-
-			if (
-				mx >= item.x &&
-				mx <= item.x + w &&
-				my >= item.y &&
-				my <= item.y + h
-			) {
-				return item.data;
-			}
-		}
-
-		let nearest: HitItem | null = null;
-		let min = Number.POSITIVE_INFINITY;
-
-		for (const item of getGridItems(this.pointGrid, mx, my, this.pointCellSize, 1)) {
-			const dx = item.x - mx;
-			const dy = item.y - my;
-			const dist = Math.sqrt(dx * dx + dy * dy);
-			const sensitivity = item.sensitivity ?? HIT_DISTANCE;
-
-			if (dist <= sensitivity && dist < min) {
-				min = dist;
-				nearest = item;
-			}
-		}
-
-		return nearest?.data ?? null;
+		return this.hitBar(mx, my) ?? this.hitPoint(mx, my);
 	}
 
 	/**

--- a/src/canvas/axisTicks.ts
+++ b/src/canvas/axisTicks.ts
@@ -507,8 +507,7 @@ function getStepTicks(domain: number[], stepSize: number): number[] {
 export function getXTickValues($$, cull = true): AxisTickValue[] {
 	const {axis, config} = $$;
 	const targetScale = getXScale($$);
-	const targetsToShow = $$.getTargetsToShow?.() ||
-		$$.filterTargetsToShow($$.data.targets);
+	const targetsToShow = $$.getTargetsToShow?.() || $$.filterTargetsToShow();
 	const cache = $$.state._canvasXTickValuesCache ||
 		($$.state._canvasXTickValuesCache = new Map<string, AxisTickValue[]>());
 	const cacheKey = getXTickCacheKey($$, cull);
@@ -603,8 +602,7 @@ function getSubXTickCullMax($$): number | undefined {
 export function getSubXTickValues($$): AxisTickValue[] {
 	const {axis, config, scale} = $$;
 	const targetScale = scale.subX;
-	const targetsToShow = $$.getTargetsToShow?.() ||
-		$$.filterTargetsToShow($$.data.targets);
+	const targetsToShow = $$.getTargetsToShow?.() || $$.filterTargetsToShow();
 	const cullMax = getSubXTickCullMax($$);
 	const cull = (ticks: AxisTickValue[]): AxisTickValue[] => cullTicks(ticks, cullMax);
 

--- a/src/canvas/labels.ts
+++ b/src/canvas/labels.ts
@@ -5,6 +5,7 @@
 import {isFunction, isNumber, isObject, isString, parseShorthand, tplProcess} from "../module/util";
 import CanvasPainter, {CanvasRect} from "./CanvasPainter";
 import {
+	getFontSize,
 	isCanvasBubbleType,
 	isCanvasCandlestickType,
 	isCanvasLineType,
@@ -175,7 +176,7 @@ export function getLabelImagePosition($$, option: LabelImageOption, text: string
 	const w = width / 2;
 	const h = height / 2;
 	const textHeight = getLabelDecorationBox($$.canvasEngine.ctx, text, x, y).h;
-	const fontSize = parseFloat($$.canvasEngine.ctx.font) || 12;
+	const fontSize = getFontSize($$.canvasEngine.ctx.font);
 	const imageX = x - w;
 	const imageY = y - h - (
 		$$.isTreemapType?.(d) ? fontSize * 0.7 : textHeight / 2
@@ -285,10 +286,13 @@ export function getLabelDecorationBox(
 	const lines = text.split("\n");
 	const metrics = lines.map(line => ctx.measureText(line));
 	const width = Math.max(...metrics.map(metric => metric.width), 0);
-	const fontSize = parseFloat(ctx.font) || 12;
+	const fontSize = getFontSize(ctx.font);
 	const lineHeight = fontSize * LABEL_LINE_HEIGHT_RATIO;
 	const fontBoundingHeight = metrics[0] ?
 		(metrics[0].fontBoundingBoxAscent || 0) + (metrics[0].fontBoundingBoxDescent || 0) :
+		0;
+	const baselineDescent = metrics[0] ?
+		metrics[0].fontBoundingBoxDescent || metrics[0].actualBoundingBoxDescent || 0 :
 		0;
 	const height = lines.length > 1 ? lineHeight * lines.length : Math.max(
 		fontSize,
@@ -306,10 +310,11 @@ export function getLabelDecorationBox(
 
 	if (ctx.textBaseline === "middle") {
 		textY -= height / 2;
+	} else if (ctx.textBaseline === "alphabetic") {
+		textY -= height - baselineDescent;
 	} else if (
 		ctx.textBaseline === "bottom" ||
-		ctx.textBaseline === "ideographic" ||
-		ctx.textBaseline === "alphabetic"
+		ctx.textBaseline === "ideographic"
 	) {
 		textY -= height;
 	}

--- a/src/canvas/util.ts
+++ b/src/canvas/util.ts
@@ -16,6 +16,20 @@ export type CanvasPointOccupancyGrid = {
 };
 
 /**
+ * Get font size from canvas font shorthand.
+ * `parseFloat()` alone fails for style/weight-prefixed shorthands like "bold 20px sans-serif".
+ * @param {string} font Canvas font shorthand
+ * @returns {number} Font size
+ * @private
+ */
+export function getFontSize(font: string): number {
+	const match = /(\d+(?:\.\d+)?)px/.exec(font);
+	const size = match ? parseFloat(match[1]) : parseFloat(font);
+
+	return Number.isFinite(size) ? size : 12;
+}
+
+/**
  * Get cached or generated shape indices for a canvas target type.
  * @param {object} $$ ChartInternal instance
  * @param {object} shape Cached draw shape object

--- a/src/config/Options/common/main.ts
+++ b/src/config/Options/common/main.ts
@@ -336,7 +336,7 @@ export default {
 	 * @memberof Options
 	 * @type {object}
 	 * @property {object} [transition] transition object
-	 * @property {number} [transition.duration=350] duration in milliseconds
+	 * @property {number} [transition.duration=250] duration in milliseconds
 	 * @example
 	 * transition: {
 	 *    duration: 500

--- a/src/config/Options/interaction/zoom.ts
+++ b/src/config/Options/interaction/zoom.ts
@@ -75,7 +75,6 @@ export default {
 	zoom_enabled: <boolean>false,
 	zoom_type: <"wheel" | "drag">"wheel",
 	zoom_extent: <number[] | undefined>undefined,
-	zoom_privileged: false,
 	zoom_rescale: false,
 	zoom_onzoom: <Function | undefined>undefined,
 	zoom_onzoomstart: <Function | undefined>undefined,

--- a/src/config/classes.ts
+++ b/src/config/classes.ts
@@ -218,6 +218,7 @@ export default {
 	...$FOCUS,
 	...$FUNNEL,
 	...$GRID,
+	...$LEVEL,
 	...$RADAR,
 	...$REGION,
 	...$SELECT,

--- a/src/config/resolver/canvas.ts
+++ b/src/config/resolver/canvas.ts
@@ -124,7 +124,7 @@ function getCanvasLegendPointIcon($$, id: string): string {
 		"style=\"display:block;width:100%;height:100%;overflow:visible;pointer-events:none\"";
 	const paintAttrs = `fill="${color}" stroke="${color}"`;
 
-	if (/^rect(angle)?$/i.test(pattern) || pattern === "rectangle") {
+	if (/^rect(angle)?$/i.test(pattern)) {
 		return `<svg ${svgAttrs}><rect x="1" y="1" width="6" height="6" ${paintAttrs}></rect></svg>`;
 	}
 
@@ -3020,16 +3020,24 @@ const canvasInternal = {
 		state._canvasXTickValuesCache = null;
 
 		$$.canvasEngine.beginFrame(state.current.width, $$.getCanvasSurfaceHeight());
-		$$.canvasRenderer.drawBackground($$);
-		$$.canvasAxisRenderer.drawTitle($$);
-		state.hasAxis && $$.canvasAxisRenderer.draw($$);
-		$$.canvasRenderer.draw($$, drawShape);
-		state.hasAxis && $$.config.grid_lines_front && $$.canvasAxisRenderer.drawGridLines($$);
-		$$.canvasRenderer.drawSubchart($$, drawShape);
-		state.hasAxis && $$.canvasAxisRenderer.drawSubXAxis($$);
-		$$.canvasRenderer.drawEmptyLabel($$);
-		rebuildHit && $$.hitDetector.rebuild($$, drawShape);
-		$$.canvasEngine.endFrame();
+
+		try {
+			// user callbacks (tick format, data label format, etc.) run within:
+			// guard so a throwing formatter can't leak the saved context state
+			$$.canvasRenderer.drawBackground($$);
+			$$.canvasAxisRenderer.drawTitle($$);
+			state.hasAxis && $$.canvasAxisRenderer.draw($$);
+			$$.canvasRenderer.draw($$, drawShape);
+			state.hasAxis && $$.config.grid_lines_front &&
+				$$.canvasAxisRenderer.drawGridLines($$);
+			$$.canvasRenderer.drawSubchart($$, drawShape);
+			state.hasAxis && $$.canvasAxisRenderer.drawSubXAxis($$);
+			$$.canvasRenderer.drawEmptyLabel($$);
+			rebuildHit && $$.hitDetector.rebuild($$, drawShape);
+		} finally {
+			$$.canvasEngine.endFrame();
+		}
+
 		$$.canvasEngine.clearOverlay();
 		state.canvasFocusMainRedraw = false;
 		focusData && $$.renderCanvasFocus(focusData);
@@ -3050,15 +3058,20 @@ const canvasInternal = {
 			const drawShape = state.canvasShape || $$.getDrawShape();
 
 			$$.canvasEngine.beginFrame(state.current.width, $$.getCanvasSurfaceHeight());
-			$$.canvasRenderer.drawBackground($$);
-			$$.canvasAxisRenderer.drawTitle($$);
-			state.hasAxis && $$.canvasAxisRenderer.draw($$);
-			$$.canvasRenderer.draw($$, drawShape, focusData);
-			state.hasAxis && $$.config.grid_lines_front && $$.canvasAxisRenderer.drawGridLines($$);
-			$$.canvasRenderer.drawSubchart($$, drawShape);
-			state.hasAxis && $$.canvasAxisRenderer.drawSubXAxis($$);
-			$$.canvasRenderer.drawEmptyLabel($$);
-			$$.canvasEngine.endFrame();
+
+			try {
+				$$.canvasRenderer.drawBackground($$);
+				$$.canvasAxisRenderer.drawTitle($$);
+				state.hasAxis && $$.canvasAxisRenderer.draw($$);
+				$$.canvasRenderer.draw($$, drawShape, focusData);
+				state.hasAxis && $$.config.grid_lines_front &&
+					$$.canvasAxisRenderer.drawGridLines($$);
+				$$.canvasRenderer.drawSubchart($$, drawShape);
+				state.hasAxis && $$.canvasAxisRenderer.drawSubXAxis($$);
+				$$.canvasRenderer.drawEmptyLabel($$);
+			} finally {
+				$$.canvasEngine.endFrame();
+			}
 		}
 
 		state.canvasFocusMainRedraw = !!withMainRedraw;

--- a/src/module/Cache.ts
+++ b/src/module/Cache.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import type {DataRow} from "../../types/types";
-import {isString, isValue} from "./util";
+import {isString} from "./util";
 
 /**
  * Constant for cache key
@@ -86,9 +86,8 @@ export default class Cache {
 
 			return targets;
 		} else {
-			const value = this.cache.get(key as string);
-
-			return isValue(value) ? value : null;
+			// use .has() so stored falsy values (false, "", 0) aren't reported as a miss
+			return this.cache.has(key as string) ? this.cache.get(key as string) : null;
 		}
 	}
 

--- a/src/module/generator.ts
+++ b/src/module/generator.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import type {d3Transition} from "../../types/types";
-import {requestIdleCallback, window} from "./browser";
+import {cancelIdleCallback, requestIdleCallback, window} from "./browser";
 import {isArray, isNumber, isTabVisible, runUntil} from "./util";
 
 const {setTimeout, clearTimeout} = window;
@@ -23,11 +23,13 @@ export function generateResize(option: boolean | number) {
 		callResizeFn.clear();
 
 		if (option === false) {
-			requestIdleCallback(() => {
+			timeout = requestIdleCallback(() => {
+				timeout = null;
 				fn.forEach((f: Function) => f());
 			}, {timeout: 200});
 		} else {
 			timeout = setTimeout(() => {
+				timeout = null;
 				fn.forEach((f: Function) => f());
 			}, isNumber(option) ? option : 200);
 		}
@@ -35,13 +37,18 @@ export function generateResize(option: boolean | number) {
 
 	callResizeFn.clear = () => {
 		if (timeout) {
-			clearTimeout(timeout);
+			(option === false ? cancelIdleCallback : clearTimeout)(timeout);
 			timeout = null;
 		}
 	};
 
 	callResizeFn.add = f => fn.push(f);
-	callResizeFn.remove = f => fn.splice(fn.indexOf(f), 1);
+
+	callResizeFn.remove = f => {
+		const index = fn.indexOf(f);
+
+		index !== -1 && fn.splice(index, 1);
+	};
 
 	return callResizeFn;
 }

--- a/src/module/util/dom.ts
+++ b/src/module/util/dom.ts
@@ -38,21 +38,25 @@ function getCssSelector(s: string): string {
  */
 function _getRect(
 	relativeViewport: boolean,
-	node: SVGElement & Partial<{rect: DOMRect | SVGRect}>,
+	node: SVGElement & Partial<{rectClient: DOMRect, rectBBox: SVGRect}>,
 	forceEval = false
 ): DOMRect | SVGRect {
 	const _ = n => n[relativeViewport ? "getBoundingClientRect" : "getBBox"]();
+
+	// cache per API: getBoundingClientRect(viewport coords) and getBBox(local coords)
+	// return different values for the same node and must not share one slot
+	const cacheKey = relativeViewport ? "rectClient" : "rectBBox";
 
 	if (forceEval) {
 		return _(node);
 	} else {
 		// will cache the value if the element is not a SVGElement or the width is not set
-		const needEvaluate = !("rect" in node) || (
-			"rect" in node && node.hasAttribute("width") &&
-			node.rect!.width !== +(node.getAttribute("width") || 0)
+		const needEvaluate = !(cacheKey in node) || (
+			node.hasAttribute("width") &&
+			node[cacheKey]!.width !== +(node.getAttribute("width") || 0)
 		);
 
-		return needEvaluate ? (node.rect = _(node)) : node.rect!;
+		return needEvaluate ? (node[cacheKey] = _(node)) : node[cacheKey]!;
 	}
 }
 
@@ -307,7 +311,8 @@ function getElementPos(element: SVGElement | undefined, type: "x" | "y"): number
 function hasViewBox(svg: d3Selection): boolean {
 	const attr = svg.attr("viewBox");
 
-	return attr ? /(\d+(\.\d+)?){3}/.test(attr) : false;
+	// a valid viewBox has 4 numeric tokens: "min-x min-y width height"
+	return attr ? attr.trim().split(/[\s,]+/).length === 4 : false;
 }
 
 /**
@@ -324,7 +329,8 @@ function hasStyle(node, condition: Record<string, string>, all = false): boolean
 	for (const [key, value] of Object.entries(condition)) {
 		has = isD3Node ? node.style(key) === value : node.style[key] === value;
 
-		if (all === false && has) {
+		// any-mode: stop on first match / all-mode: stop on first mismatch
+		if (all ? !has : has) {
 			break;
 		}
 	}

--- a/src/module/util/object.ts
+++ b/src/module/util/object.ts
@@ -84,7 +84,7 @@ function endall(transition, cb: Function): void {
 	let n = 0;
 
 	const end = function(...args) {
-		!--n && cb.apply(this, ...args);
+		!--n && cb.apply(this, args);
 	};
 
 	// if is transition selection
@@ -137,7 +137,9 @@ const toArray = (v: CSSStyleDeclaration | any): any => [].slice.call(v);
  */
 function deepClone(...objectN) {
 	const clone = v => {
-		if (isObject(v) && v.constructor) {
+		if (isArray(v)) {
+			return v.map(clone);
+		} else if (isObject(v) && v.constructor) {
 			const r = new v.constructor();
 
 			for (const k in v) {
@@ -302,7 +304,7 @@ const getRange = (start: number, end: number, step = 1): number[] => {
 	const res: number[] = [];
 	const n = Math.max(0, Math.ceil((end - start) / step)) | 0;
 
-	for (let i = start; i < n; i++) {
+	for (let i = 0; i < n; i++) {
 		res.push(start + i * step);
 	}
 

--- a/src/module/worker.ts
+++ b/src/module/worker.ts
@@ -7,6 +7,9 @@ import {window} from "./browser";
 // Store worker cache in memory
 const cache: {[key: string]: {src: string, worker: Worker | null}} = {};
 
+// Correlation id for worker request/response matching
+let messageId = 0;
+
 /**
  * Get or create cached worker resources (Object URL, Worker)
  * @param {function} fn Function to be executed in worker
@@ -26,8 +29,8 @@ function getOrCreateWorkerResources(fn: Function, depsFn?: Function[]): {key: st
 			`${depsString}
 
 			self.onmessage=function({data}) {
-				const result = (${fnString}).apply(null, data);
-				self.postMessage(result);
+				const result = (${fnString}).apply(null, data.args);
+				self.postMessage({id: data.id, result});
 			};`
 		], {
 			type: "text/javascript"
@@ -113,14 +116,19 @@ export function runWorker(
 
 		runFn = function(...args: unknown[]) {
 			if (worker) {
-				// trigger worker
-				worker.postMessage(args);
+				// workers are cached and shared: match the response by id so concurrent
+				// callers don't steal each other's result
+				const id = ++messageId;
 
-				// listen worker
-				worker.onmessage = function(e: MessageEvent) {
-					// Object URL and Worker are cached and reused
-					return callback(e.data);
+				const handler = function(e: MessageEvent) {
+					if (e.data?.id === id) {
+						worker.removeEventListener("message", handler);
+						callback(e.data.result);
+					}
 				};
+
+				worker.addEventListener("message", handler);
+				worker.postMessage({id, args});
 			}
 		};
 	}

--- a/test/api/canvas-spec.ts
+++ b/test/api/canvas-spec.ts
@@ -1,0 +1,470 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+/* global describe, afterEach, beforeAll, it, expect */
+import {afterEach, beforeAll, describe, expect, it, vi} from "vitest";
+import bb, {
+	bar,
+	canvas,
+	category,
+	exportApi,
+	flow,
+	grid,
+	line,
+	regions,
+	scatter,
+	selection,
+	subchart,
+	zoom
+} from "../../src/index.canvas";
+import {$FOCUS, $LEGEND} from "../../src/config/classes";
+
+describe("API canvas", () => {
+	let chart;
+	let container;
+
+	const columns = [
+		["data1", 30, 200, 100, 400],
+		["data2", 50, 20, 10, 40]
+	];
+
+	beforeAll(() => {
+		canvas();
+		category();
+		exportApi();
+		flow();
+		grid();
+		regions();
+		selection();
+		subchart();
+		zoom();
+	});
+
+	afterEach(() => {
+		chart?.destroy();
+		container?.remove();
+		chart = null;
+		container = null;
+		vi.restoreAllMocks();
+	});
+
+	function generateWithOptions(options = {}) {
+		container = document.createElement("div");
+		container.style.cssText = "position:absolute;top:0;left:0;width:360px;height:260px;";
+		document.body.appendChild(container);
+
+		return (chart = bb.generate({
+			bindto: container,
+			render: {
+				mode: canvas()
+			},
+			size: {
+				width: 360,
+				height: 260
+			},
+			transition: {
+				duration: 0
+			},
+			data: {
+				columns,
+				type: line()
+			},
+			...options
+		}));
+	}
+
+	function legendItem(id: string): HTMLButtonElement {
+		return container.querySelector(`button[data-id="${id}"]`);
+	}
+
+	it("updates data, color, name and visibility APIs without SVG targets", () => {
+		generateWithOptions({
+			data: {
+				columns,
+				type: line()
+			}
+		});
+
+		const {internal} = chart;
+		const initialGeneration = internal.state.redrawGeneration;
+
+		expect(chart.data.values("data1")).to.deep.equal([30, 200, 100, 400]);
+		expect(container.querySelector("svg")).to.be.null;
+		expect(legendItem("data1")).not.to.be.null;
+
+		expect(chart.data.names({data1: "Alpha"})).to.deep.include({data1: "Alpha"});
+		expect(legendItem("data1").textContent).to.contain("Alpha");
+
+		chart.data.colors({data1: "#123456"});
+		expect(chart.data.colors().data1).to.be.equal("#123456");
+		expect(legendItem("data1").querySelector(`.${$LEGEND.legendItemTile}`)?.style.backgroundColor)
+			.to.be.equal("rgb(18, 52, 86)");
+
+		chart.hide("data1");
+		expect(internal.state.hiddenTargetIds.has("data1")).to.be.true;
+		expect(legendItem("data1").classList.contains($LEGEND.legendItemHidden)).to.be.true;
+
+		chart.show("data1");
+		expect(internal.state.hiddenTargetIds.has("data1")).to.be.false;
+		expect(legendItem("data1").classList.contains($LEGEND.legendItemHidden)).to.be.false;
+
+		chart.toggle("data2");
+		expect(internal.state.hiddenTargetIds.has("data2")).to.be.true;
+
+		expect(internal.state.redrawGeneration).to.be.greaterThan(initialGeneration);
+	});
+
+	it("updates canvas HTML legend through legend.show/hide APIs", () => {
+		generateWithOptions();
+
+		const {internal} = chart;
+		const item = legendItem("data1");
+		const initialGeneration = internal.state.redrawGeneration;
+
+		chart.legend.hide("data1");
+		expect(internal.state.hiddenLegendIds.has("data1")).to.be.true;
+		expect(item.style.visibility).to.be.equal("hidden");
+		expect(item.style.opacity).to.be.equal("0");
+
+		chart.legend.show("data1");
+		expect(internal.state.hiddenLegendIds.has("data1")).to.be.false;
+		expect(item.style.visibility).to.be.equal("");
+		expect(item.style.opacity).to.be.equal("");
+		expect(internal.state.redrawGeneration).to.be.greaterThan(initialGeneration);
+	});
+
+	it("applies focus, defocus and revert APIs to canvas focus state and legend", () => {
+		generateWithOptions({
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40],
+					["data3", 70, 90, 60, 120]
+				],
+				type: line()
+			}
+		});
+
+		const {internal} = chart;
+		const draw = vi.spyOn(internal.canvasRenderer, "draw");
+
+		chart.focus("data2");
+		expect(internal.state.focusedTargetIds.has("data2")).to.be.true;
+		expect(internal.state.defocusedTargetIds.has("data1")).to.be.true;
+		expect(legendItem("data2").classList.contains($FOCUS.legendItemFocused)).to.be.true;
+		expect(draw).toHaveBeenCalled();
+
+		draw.mockClear();
+
+		chart.defocus(["data1", "data3"]);
+		expect(internal.state.defocusedTargetIds.has("data1")).to.be.true;
+		expect(internal.state.defocusedTargetIds.has("data3")).to.be.true;
+		expect(legendItem("data1").style.opacity).to.be.equal("0.3");
+		expect(draw).toHaveBeenCalled();
+
+		draw.mockClear();
+
+		chart.revert();
+		expect(internal.state.focusedTargetIds.size).to.be.equal(0);
+		expect(internal.state.defocusedTargetIds.size).to.be.equal(0);
+		expect(legendItem("data1").style.opacity).to.be.equal("");
+		expect(draw).toHaveBeenCalled();
+	});
+
+	it("updates axis labels, domains and ranges through axis APIs", () => {
+		const fillText = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText");
+
+		generateWithOptions({
+			data: {
+				columns,
+				axes: {
+					data1: "y",
+					data2: "y2"
+				},
+				type: line()
+			},
+			axis: {
+				y: {
+					label: "Y"
+				},
+				y2: {
+					show: true,
+					label: "Y2"
+				}
+			}
+		});
+
+		fillText.mockClear();
+
+		const labels = chart.axis.labels({
+			y: "Canvas Y",
+			y2: "Canvas Y2"
+		});
+
+		expect(labels).to.deep.equal({
+			y: "Canvas Y",
+			y2: "Canvas Y2"
+		});
+		expect(fillText.mock.calls.some(([text]) => text === "Canvas Y")).to.be.true;
+		expect(fillText.mock.calls.some(([text]) => text === "Canvas Y2")).to.be.true;
+
+		chart.axis.min({x: -1, y: 0, y2: 5});
+		chart.axis.max({x: 10, y: 500, y2: 100});
+		expect(chart.axis.min()).to.deep.equal({x: -1, y: 0, y2: 5});
+		expect(chart.axis.max()).to.deep.equal({x: 10, y: 500, y2: 100});
+
+		chart.axis.range({min: {y: -20}, max: {y: 600}});
+		expect(chart.axis.range()).to.deep.include({
+			min: {x: -1, y: -20, y2: 5},
+			max: {x: 10, y: 600, y2: 100}
+		});
+	});
+
+	it("updates x, category, group and config APIs in canvas mode", () => {
+		const fillText = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText");
+
+		generateWithOptions({
+			data: {
+				x: "x",
+				columns: [
+					["x", "a", "b", "c", "d"],
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40]
+				],
+				type: bar()
+			},
+			axis: {
+				x: {
+					type: "category"
+				}
+			}
+		});
+
+		expect(chart.x()).to.deep.equal(["a", "b", "c", "d"]);
+		expect(chart.categories()).to.deep.equal(["a", "b", "c", "d"]);
+
+		fillText.mockClear();
+
+		const categories = ["A", "B", "C", "D"];
+
+		expect(chart.categories(categories)).to.deep.equal(categories);
+		expect(chart.category(1, "Beta")).to.be.equal("Beta");
+		expect(chart.categories()).to.deep.equal(["A", "Beta", "C", "D"]);
+		expect(fillText.mock.calls.some(([text]) => text === "Beta")).to.be.true;
+
+		const xValues = ["Q1", "Q2", "Q3", "Q4"];
+
+		expect(chart.x(xValues)).to.deep.equal(xValues);
+		expect(chart.x()).to.deep.equal(xValues);
+
+		expect(chart.groups()).to.deep.equal([]);
+		chart.groups([["data1", "data2"]]);
+		expect(chart.groups()).to.deep.equal([["data1", "data2"]]);
+
+		expect(chart.config("axis.x.type")).to.be.equal("category");
+		expect(chart.config("axis.x.label", "Canvas X", true)).to.be.equal("Canvas X");
+		expect(chart.config("axis.x.label")).to.be.equal("Canvas X");
+		expect(fillText.mock.calls.some(([text]) => text === "Canvas X")).to.be.true;
+	});
+
+	it("updates xs API in canvas mode", () => {
+		generateWithOptions({
+			data: {
+				xs: {
+					data1: "x1",
+					data2: "x2"
+				},
+				columns: [
+					["x1", 10, 30, 45, 60],
+					["x2", 20, 40, 55, 80],
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40]
+				],
+				type: line()
+			}
+		});
+
+		expect(chart.xs()).to.deep.equal({
+			data1: [10, 30, 45, 60],
+			data2: [20, 40, 55, 80]
+		});
+
+		const xs = {
+			data1: [15, 35, 58, 70],
+			data2: [25, 45, 68, 90]
+		};
+
+		expect(chart.xs(xs)).to.deep.equal(xs);
+		expect(chart.xs()).to.deep.equal(xs);
+	});
+
+	it("updates grid and region APIs on the canvas frame", () => {
+		const fillText = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText");
+		const fillRect = vi.spyOn(CanvasRenderingContext2D.prototype, "fillRect");
+
+		generateWithOptions({
+			data: {
+				columns,
+				type: line()
+			}
+		});
+
+		chart.xgrids([{value: 1, text: "X one"}]);
+		chart.ygrids.add({value: 100, text: "Y one"});
+		expect(chart.xgrids()).to.deep.equal([{value: 1, text: "X one"}]);
+		expect(chart.ygrids()).to.deep.equal([{value: 100, text: "Y one"}]);
+		expect(fillText.mock.calls.some(([text]) => text === "X one")).to.be.true;
+		expect(fillText.mock.calls.some(([text]) => text === "Y one")).to.be.true;
+
+		chart.ygrids.remove({value: 100});
+		expect(chart.ygrids()).to.deep.equal([]);
+
+		chart.regions([
+			{axis: "y", start: 100, end: 200, class: "region-y"}
+		]);
+		expect(chart.regions()).to.deep.equal([
+			{axis: "y", start: 100, end: 200, class: "region-y"}
+		]);
+		expect(fillRect).toHaveBeenCalled();
+
+		chart.regions.remove({classes: ["region-y"]});
+		expect(chart.regions()).to.deep.equal([]);
+	});
+
+	it("loads, unloads and flows data through canvas APIs", () => new Promise(done => {
+		generateWithOptions({
+			data: {
+				columns,
+				type: line()
+			}
+		});
+
+		chart.load({
+			columns: [
+				["data3", 10, 30, 50, 70]
+			],
+			done() {
+				expect(chart.data.values("data3")).to.deep.equal([10, 30, 50, 70]);
+				expect(legendItem("data3")).not.to.be.null;
+				expect(container.querySelector("svg")).to.be.null;
+
+				chart.unload({
+					ids: "data3",
+					done() {
+						expect(chart.data("data3")).to.deep.equal([]);
+						expect(legendItem("data3")).to.be.null;
+
+						chart.flow({
+							columns: [
+								["data1", 500],
+								["data2", 60]
+							],
+							done() {
+								expect(chart.data.values("data1").at(-1)).to.be.equal(500);
+								done(1);
+							}
+						});
+					}
+				});
+			}
+		});
+	}));
+
+	it("selects and unselects canvas data through selection APIs", () => {
+		generateWithOptions({
+			data: {
+				columns,
+				type: bar(),
+				selection: {
+					enabled: true
+				}
+			}
+		});
+
+		chart.select("data1", [1, 3], true);
+		expect(chart.selected().map(d => `${d.id}:${d.index}`)).to.deep.equal([
+			"data1:1",
+			"data1:3"
+		]);
+		expect(chart.internal.state.canvasSelection.has("data1:1")).to.be.true;
+		expect(chart.internal.state.canvasSelection.has("data1:3")).to.be.true;
+
+		chart.unselect("data1", [1]);
+		expect(chart.selected().map(d => `${d.id}:${d.index}`)).to.deep.equal(["data1:3"]);
+		expect(chart.internal.state.canvasSelection.has("data1:1")).to.be.false;
+
+		chart.unselect();
+		expect(chart.selected()).to.deep.equal([]);
+		expect(chart.internal.state.canvasSelection.size).to.be.equal(0);
+	});
+
+	it("shows and hides canvas tooltip through tooltip APIs", () => {
+		generateWithOptions({
+			data: {
+				x: "x",
+				columns: [
+					["x", "a", "b", "c", "d"],
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40]
+				],
+				type: scatter()
+			},
+			axis: {
+				x: {
+					type: "category"
+				}
+			}
+		});
+
+		chart.tooltip.show({
+			index: 1,
+			mouse: [chart.internal.state.margin.left + 50, chart.internal.state.margin.top + 50]
+		});
+
+		expect(chart.$.tooltip.style("display")).to.be.equal("block");
+		expect(chart.$.tooltip.text()).to.contain("data1");
+		expect(chart.internal.state.canvasFocusKey).not.to.be.null;
+
+		chart.tooltip.hide();
+		expect(chart.$.tooltip.style("display")).to.be.equal("none");
+		expect(chart.internal.state.canvasFocusKey).to.be.null;
+	});
+
+	it("supports zoom, unzoom, subchart, resize and export APIs in canvas mode", () => {
+		generateWithOptions({
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400, 150, 250],
+					["data2", 50, 20, 10, 40, 80, 60]
+				],
+				type: line()
+			},
+			zoom: {
+				enabled: true
+			},
+			subchart: {
+				show: true
+			}
+		});
+
+		chart.zoom([1, 4]);
+		expect(chart.zoom().map(Math.round)).to.deep.equal([1, 4]);
+
+		chart.unzoom();
+		expect(chart.internal.scale.zoom).to.be.null;
+
+		expect(() => chart.subchart.show()).to.not.throw();
+		expect(() => chart.subchart.hide()).to.not.throw();
+
+		expect(() => chart.flush()).to.not.throw();
+
+		chart.resize({width: 420, height: 280});
+		expect(chart.internal.state.current.width).to.be.equal(420);
+		expect(chart.$.canvas.node().style.width).to.be.equal("420px");
+
+		const dataUrl = chart.export();
+		expect(/^data:image\/png;base64,/.test(dataUrl)).to.be.true;
+	});
+});

--- a/test/esm/canvas-axis-renderer-coverage-spec.ts
+++ b/test/esm/canvas-axis-renderer-coverage-spec.ts
@@ -4,7 +4,7 @@
  */
 /* eslint-disable */
 // @ts-nocheck
-import {describe, expect, it} from "vitest";
+import {describe, expect, it, vi} from "vitest";
 
 import CanvasAxisRenderer from "../../src/canvas/CanvasAxisRenderer";
 
@@ -140,7 +140,9 @@ function makeContext(overrides = {}) {
 				}))
 			}]
 		},
-		filterTargetsToShow: targets => targets,
+		filterTargetsToShow(targets) {
+			return targets ?? this.data.targets;
+		},
 		config: {
 			axis_rotated: false,
 			axis_tooltip: {backgroundColor: {x: "#111", y: "#222", y2: "#333"}},
@@ -246,6 +248,27 @@ describe("ESM canvas axis renderer coverage", () => {
 		renderer.drawAxisTooltip(ctx, [70, 60]);
 
 		expect(renderer.ctx).to.not.be.null;
+	});
+
+	it("adds extra horizontal clip padding for rotated x tick text", () => {
+		const {renderer} = makeAxisRenderer();
+		const ctx = makeContext();
+		const rects: Array<{x: number, y: number, w: number, h: number}> = [];
+		const rect = vi.spyOn(CanvasRenderingContext2D.prototype, "rect")
+			.mockImplementation(function(x, y, w, h) {
+				rects.push({x, y, w, h});
+			});
+
+		renderer.draw(ctx);
+
+		expect(rects.some(({x, y, w, h}) =>
+			x === 10 &&
+			y === 0 &&
+			w === 160 &&
+			h === 220
+		)).to.be.true;
+
+		rect.mockRestore();
 	});
 
 	it("draws rotated axes, category regions and rotated axis tooltips", () => {

--- a/test/esm/canvas-axis-ticks-coverage-spec.ts
+++ b/test/esm/canvas-axis-ticks-coverage-spec.ts
@@ -109,7 +109,9 @@ function getInternal(overrides = {}) {
 			grid_y_ticks: undefined
 		},
 		data: {targets: [target]},
-		filterTargetsToShow: targets => targets,
+		filterTargetsToShow(targets) {
+			return targets ?? this.data.targets;
+		},
 		format: {
 			dataTime: () => value => new Date(`${value}T00:00:00Z`)
 		},

--- a/test/esm/canvas-axis-title-spec.ts
+++ b/test/esm/canvas-axis-title-spec.ts
@@ -53,7 +53,17 @@ describe("ESM canvas axis and title", () => {
 	}
 
 	it("draws title text on canvas and reserves top padding", () => {
-		const fillText = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText");
+		const titleRecords: Array<{baseline: string, y: number}> = [];
+		const fillText = vi
+			.spyOn(CanvasRenderingContext2D.prototype, "fillText")
+			.mockImplementation(function(text, _x, y) {
+				if (text === "Canvas Title") {
+					titleRecords.push({
+						baseline: this.textBaseline,
+						y: Number(y)
+					});
+				}
+			});
 
 		generateWithOptions({});
 		const topWithoutTitle = chart.internal.state.margin.top;
@@ -74,6 +84,11 @@ describe("ESM canvas axis and title", () => {
 		});
 
 		expect(fillText.mock.calls.some(([text]) => text === "Canvas Title")).to.be.true;
+		expect(titleRecords[0]?.baseline).to.be.equal("alphabetic");
+		expect(titleRecords[0]?.y).to.be.closeTo(
+			8 + chart.internal.getCanvasTitleHeight(),
+			0.1
+		);
 		expect(chart.internal.state.margin.top).to.be.greaterThan(topWithoutTitle);
 	});
 
@@ -262,9 +277,9 @@ describe("ESM canvas axis and title", () => {
 		const {current, margin, width} = chart.internal.state;
 
 		expect(records.some(record =>
-			record.x === margin.left - 10 &&
+			record.x === margin.left - 20 &&
 			record.y === 0 &&
-			record.w === width + 20 &&
+			record.w === width + 40 &&
 			record.h === current.height
 		)).to.be.true;
 
@@ -296,9 +311,9 @@ describe("ESM canvas axis and title", () => {
 
 		expect(records.some(record =>
 			record.x === 0 &&
-			record.y === margin.top - 10 &&
+			record.y === margin.top - 15 &&
 			record.w === current.width &&
-			record.h === height + 20
+			record.h === height + 30
 		)).to.be.true;
 
 		rect.mockRestore();

--- a/test/esm/canvas-helper-coverage-spec.ts
+++ b/test/esm/canvas-helper-coverage-spec.ts
@@ -576,6 +576,27 @@ describe("ESM canvas helper coverage", () => {
 			]);
 		});
 
+		it("includes alphabetic baseline descent in label decoration boxes", () => {
+			const ctx = {
+				font: "10px sans-serif",
+				textAlign: "center",
+				textBaseline: "alphabetic",
+				measureText: () => ({
+					width: 20,
+					fontBoundingBoxAscent: 10,
+					fontBoundingBoxDescent: 2
+				})
+			};
+			const box = getLabelDecorationBox(ctx, "30", 50, 60);
+
+			expect(box).to.deep.equal({
+				x: 40,
+				y: 50,
+				w: 20,
+				h: 12
+			});
+		});
+
 		it("resolves rotated label anchors and positions", () => {
 			expect(getLabelRotateAnchor(90)).to.be.equal("end");
 			expect(getLabelRotateAnchor(180)).to.be.equal("middle");

--- a/test/esm/canvas-hit-detector-coverage-spec.ts
+++ b/test/esm/canvas-hit-detector-coverage-spec.ts
@@ -43,7 +43,9 @@ function makeContext(type, overrides = {}) {
 			tooltip_grouped: true
 		},
 		data: {targets},
-		filterTargetsToShow: list => list,
+		filterTargetsToShow(list) {
+			return list ?? this.data.targets;
+		},
 		generateGetBarPoints: () => (d, i) => [[i * 30, 0], [i * 30 + 12, 18]],
 		generateGetCandlestickPoints: () => (d, i) => [[i * 30, 4], [i * 30 + 10, 16], [i * 30 + 5, 0, 20]],
 		getBaseValue: d => d.value,

--- a/test/esm/canvas-internal-coverage-spec.ts
+++ b/test/esm/canvas-internal-coverage-spec.ts
@@ -192,7 +192,9 @@ function makeContext(overrides = {}) {
 		},
 		data: {targets},
 		filterByX: (list, x) => list.flatMap(target => target.values.filter(v => v.x === x)),
-		filterTargetsToShow: list => list,
+		filterTargetsToShow(list) {
+			return list ?? this.data.targets;
+		},
 		generateClass: (base, id) => `${base} ${base}-${id}`,
 		getBaseValue: d => d.value,
 		getCanvasSurfaceHeight() {

--- a/test/esm/canvas-label-decoration-spec.ts
+++ b/test/esm/canvas-label-decoration-spec.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 /* global describe, afterEach, beforeAll, it, expect */
 import {afterEach, beforeAll, describe, expect, it, vi} from "vitest";
-import bb, {bar, canvas, line} from "../../src/index.canvas";
+import bb, {bar, canvas, line, treemap} from "../../src/index.canvas";
 
 describe("ESM canvas data label decorations", () => {
 	let chart;
@@ -15,6 +15,7 @@ describe("ESM canvas data label decorations", () => {
 		canvas();
 		bar();
 		line();
+		treemap();
 	});
 
 	afterEach(() => {
@@ -52,6 +53,17 @@ describe("ESM canvas data label decorations", () => {
 		}));
 	}
 
+	function getTransformedRect(ctx, x, y, w, h) {
+		const matrix = ctx.getTransform();
+
+		return {
+			x: (matrix.a * x) + (matrix.c * y) + matrix.e,
+			y: (matrix.b * x) + (matrix.d * y) + matrix.f,
+			w: matrix.a * w,
+			h: matrix.d * h
+		};
+	}
+
 	it("draws label backgrounds before canvas label text", () => {
 		const calls = [];
 		let boundApi;
@@ -83,6 +95,81 @@ describe("ESM canvas data label decorations", () => {
 		const textIndex = calls.findIndex(call => call.type === "text" && call.text === "30");
 
 		expect(boundApi).to.equal(chart);
+		expect(backgroundIndex).to.be.greaterThan(-1);
+		expect(textIndex).to.be.greaterThan(-1);
+		expect(backgroundIndex).to.be.lessThan(textIndex);
+	});
+
+	it("aligns bar label background bounds with SVG alphabetic baseline", () => {
+		const rects = [];
+
+		vi.spyOn(CanvasRenderingContext2D.prototype, "fillRect")
+			.mockImplementation(function(x, y, w, h) {
+				rects.push({
+					style: String(this.fillStyle),
+					rect: getTransformedRect(this, x, y, w, h)
+				});
+			});
+
+		generateWithOptions({
+			data: {
+				columns: [
+					["data1", 30, -200],
+					["data2", -50, 150]
+				],
+				type: bar(),
+				labels: {
+					backgroundColors: "yellow",
+					colors: "red"
+				}
+			}
+		});
+
+		const blueBars = rects.filter(({style}) => style === "#1f77b4");
+		const yellowLabels = rects.filter(({style}) => style === "#ffff00");
+		const positiveGap = blueBars[0].rect.y -
+			(yellowLabels[0].rect.y + yellowLabels[0].rect.h);
+		const negativeOverlap = (blueBars[1].rect.y + blueBars[1].rect.h) -
+			yellowLabels[1].rect.y;
+
+		expect(positiveGap).to.be.closeTo(1, 1);
+		expect(negativeOverlap).to.be.closeTo(1, 1);
+	});
+
+	it("draws treemap label backgrounds before canvas label text", () => {
+		const calls = [];
+
+		vi.spyOn(CanvasRenderingContext2D.prototype, "fillRect").mockImplementation(function() {
+			calls.push({type: "fillRect", style: String(this.fillStyle)});
+		});
+		vi.spyOn(CanvasRenderingContext2D.prototype, "fillText").mockImplementation(function(text) {
+			calls.push({type: "text", text: String(text), style: String(this.fillStyle)});
+		});
+
+		generateWithOptions({
+			data: {
+				columns: [
+					["data1", 30],
+					["data2", 20]
+				],
+				type: treemap(),
+				labels: {
+					backgroundColors: "yellow",
+					colors: "#000"
+				}
+			},
+			treemap: {
+				label: {
+					threshold: 0
+				}
+			}
+		});
+
+		const backgroundIndex = calls.findIndex(call =>
+			call.type === "fillRect" && call.style === "#ffff00"
+		);
+		const textIndex = calls.findIndex(call => call.type === "text" && call.text === "data1");
+
 		expect(backgroundIndex).to.be.greaterThan(-1);
 		expect(textIndex).to.be.greaterThan(-1);
 		expect(backgroundIndex).to.be.lessThan(textIndex);

--- a/test/esm/canvas-renderer-coverage-spec.ts
+++ b/test/esm/canvas-renderer-coverage-spec.ts
@@ -113,7 +113,9 @@ function makeContext() {
 			subchart_showHandle: true
 		},
 		data: {targets},
-		filterTargetsToShow: list => list,
+		filterTargetsToShow(list) {
+			return list ?? this.data.targets;
+		},
 		generateGetBarPoints: () => (d, i) => [[i * 28, 0], [i * 28 + 12, 18]],
 		generateGetCandlestickPoints: () => (d, i) => [[i * 28, 4], [i * 28 + 10, 16], [i * 28 + 5, 0, 20]],
 		getBaseValue: d => d.value,
@@ -691,6 +693,88 @@ describe("ESM canvas renderer coverage", () => {
 		renderer.drawTreemaps(ctx);
 
 		expect(renderer.ctx).to.not.be.null;
+	});
+
+	it("positions treemap labels using SVG-compatible centered option", () => {
+		const {renderer} = makeRenderer();
+		const ctx = makeContext();
+		const records: Array<{
+			text: string,
+			x: number,
+			y: number,
+			textAlign: string,
+			textBaseline: string
+		}> = [];
+		const fillText = vi
+			.spyOn(CanvasRenderingContext2D.prototype, "fillText")
+			.mockImplementation(function(text, x, y) {
+				records.push({
+					text: String(text),
+					x: Number(x),
+					y: Number(y),
+					textAlign: this.textAlign,
+					textBaseline: this.textBaseline
+				});
+			});
+		const left = 20;
+		const top = 10;
+		const width = 100;
+		const height = 70;
+		const lineHeight = 10;
+		renderer.ctx.font = "10px sans-serif";
+		const metrics = renderer.ctx.measureText("tile");
+		const fontBoundingHeight = (
+			(metrics.fontBoundingBoxAscent || 0) +
+			(metrics.fontBoundingBoxDescent || 0)
+		) || (
+			(metrics.actualBoundingBoxAscent || 0) +
+			(metrics.actualBoundingBoxDescent || 0)
+		);
+		const textHeight = Math.max(lineHeight, fontBoundingHeight) + lineHeight;
+
+		ctx.config.data_type = TYPE.TREEMAP;
+		ctx.config.data_types = {tile: TYPE.TREEMAP};
+		ctx.config.data_labels = {centered: false};
+		ctx.config.treemap_label_format = () => "tile\n80%";
+		ctx.config.treemap_label_show = true;
+		ctx.config.treemap_label_threshold = 0;
+		ctx.getTreemapRoot = () => ({
+			children: [{
+				data: {id: "tile", name: "tile", ratio: 0.8, value: 3},
+				x0: 1,
+				x1: 6,
+				y0: 1,
+				y1: 8
+			}]
+		});
+		ctx.scale.x = value => value * 20;
+		ctx.scale.y = value => value * 10;
+
+		renderer.drawTreemaps(ctx);
+
+		const nonCentered = records.find(record => record.text === "tile");
+		const nonCenteredSecondLine = records.find(record => record.text === "80%");
+
+		expect(nonCentered?.x).to.be.equal(left + 5);
+		expect(nonCentered?.y).to.be.equal(top + textHeight + 5 - lineHeight);
+		expect(nonCenteredSecondLine?.y).to.be.equal(top + textHeight + 5);
+		expect(nonCentered?.textAlign).to.be.equal("left");
+		expect(nonCentered?.textBaseline).to.be.equal("alphabetic");
+
+		records.length = 0;
+		ctx.config.data_labels.centered = true;
+		renderer.drawTreemaps(ctx);
+
+		const centered = records.find(record => record.text === "tile");
+		const centeredSecondLine = records.find(record => record.text === "80%");
+
+		expect(centered?.x).to.be.equal(left + width / 2);
+		expect(centered?.y).to.be.equal(top + height / 2 - 5);
+		expect(centeredSecondLine?.y).to.be.equal(top + height / 2 + 5);
+		expect(centered?.textAlign).to.be.equal("center");
+		expect(centered?.textBaseline).to.be.equal("middle");
+
+		fillText.mockRestore();
 	});
 
 	it("clears image caches on destroy", () => {

--- a/test/esm/canvas-spec.ts
+++ b/test/esm/canvas-spec.ts
@@ -4140,11 +4140,28 @@ describe("ESM canvas", function() {
 				type: scatter()
 			},
 			point: {
+				r: 20,
 				radialGradient: true
 			}
 		});
 
+		const {cx, cy} = chart.internal.getDrawShape().pos;
+		const d = chart.internal.data.targets[0].values[0];
+		const x = cx(d);
+		const y = cy(d);
+		const gradientX = x + (0.3 - 0.5) * 20 * 2;
+		const gradientY = y + (0.3 - 0.5) * 20 * 2;
+
 		expect(createRadialGradient).toHaveBeenCalled();
+
+		const args = createRadialGradient.mock.calls[0].map(Number);
+
+		expect(args[0]).to.be.closeTo(gradientX, 0.1);
+		expect(args[1]).to.be.closeTo(gradientY, 0.1);
+		expect(args[2]).to.be.equal(0);
+		expect(args[3]).to.be.closeTo(gradientX, 0.1);
+		expect(args[4]).to.be.closeTo(gradientY, 0.1);
+		expect(args[5]).to.be.closeTo(20 * 0.7 * 2, 0.1);
 
 		createRadialGradient.mockRestore();
 	});
@@ -6823,49 +6840,83 @@ describe("ESM canvas", function() {
 	});
 
 	it("should keep category bar width when x tick text is rotated on canvas", () => {
-		generateWithOptions({
-			data: {
-				x: "x",
-				columns: [
-					[
-						"x",
-						"www.somesitename1.com",
-						"www.somesitename2.com",
-						"www.somesitename3.com",
-						"www.somesitename4.com",
-						"www.somesitename5.com",
-						"www.somesitename6.com",
-						"www.somesitename7.com",
-						"www.somesitename8.com",
-						"www.somesitename9.com",
-						"www.somesitename10.com",
-						"www.somesitename11.com",
-						"www.somesitename12.com"
+		const records: Array<{
+			text: string,
+			x: number,
+			y: number,
+			font: string,
+			textAlign: string,
+			textBaseline: string
+		}> = [];
+		const fillText = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText")
+			.mockImplementation(function(this: CanvasRenderingContext2D, text, x, y) {
+				records.push({
+					text: String(text),
+					x: Number(x),
+					y: Number(y),
+					font: this.font,
+					textAlign: this.textAlign,
+					textBaseline: this.textBaseline
+				});
+			});
+
+		try {
+			generateWithOptions({
+				data: {
+					x: "x",
+					columns: [
+						[
+							"x",
+							"www.somesitename1.com",
+							"www.somesitename2.com",
+							"www.somesitename3.com",
+							"www.somesitename4.com",
+							"www.somesitename5.com",
+							"www.somesitename6.com",
+							"www.somesitename7.com",
+							"www.somesitename8.com",
+							"www.somesitename9.com",
+							"www.somesitename10.com",
+							"www.somesitename11.com",
+							"www.somesitename12.com"
+						],
+						["pv", 90, 100, 140, 200, 100, 400, 90, 100, 140, 200, 100, 400]
 					],
-					["pv", 90, 100, 140, 200, 100, 400, 90, 100, 140, 200, 100, 400]
-				],
-				type: bar()
-			},
-			axis: {
-				x: {
-					type: "category",
-					tick: {
-						rotate: -70,
-						multiline: false,
-						tooltip: true
+					type: bar()
+				},
+				axis: {
+					x: {
+						type: "category",
+						tick: {
+							rotate: -70,
+							multiline: false,
+							tooltip: true
+						}
 					}
 				}
-			}
-		});
+			});
 
-		const $$ = chart.internal;
-		const barIndices = $$.getShapeIndices($$.isBarType);
-		const getPoints = $$.generateGetBarPoints(barIndices, false);
-		const points = getPoints($$.data.targets[0].values[0], 0);
-		const barWidth = Math.abs(points[2][0] - points[0][0]);
+			const $$ = chart.internal;
+			const barIndices = $$.getShapeIndices($$.isBarType);
+			const getPoints = $$.generateGetBarPoints(barIndices, false);
+			const points = getPoints($$.data.targets[0].values[0], 0);
+			const barWidth = Math.abs(points[2][0] - points[0][0]);
+			const firstTick = records.find(({text}) => text === "www.somesitename1.com");
+			const fontSize = parseFloat(/(\d+(?:\.\d+)?)px/.exec(firstTick?.font || "")?.[1] || "10");
+			const rotate = -70;
+			const expectedX = 8 * Math.sin(Math.PI * (rotate / 180));
+			const expectedY = 11.5 - 2.5 * (rotate / 15) * -1 + (0.71 * fontSize);
 
-		expect($$.axis.x.tickInterval($$.getMaxDataCount())).to.be.greaterThan(0);
-		expect(barWidth).to.be.greaterThan(5);
+			expect($$.axis.x.tickInterval($$.getMaxDataCount())).to.be.greaterThan(0);
+			expect(barWidth).to.be.greaterThan(5);
+			expect(firstTick?.textAlign).to.be.equal("right");
+			expect(firstTick?.textBaseline).to.be.equal("alphabetic");
+			expect(firstTick?.x).to.be.closeTo(expectedX, 0.1);
+			expect(firstTick?.y).to.be.closeTo(expectedY, 1);
+			expect(firstTick?.y).to.be.lessThan(AXIS_TICK_SIZE + AXIS_TICK_PADDING);
+		} finally {
+			fillText.mockRestore();
+		}
 	});
 
 	it("should render timeseries y and y2 axes on canvas", () => {
@@ -8403,7 +8454,7 @@ describe("ESM canvas", function() {
 		expect(labels).not.to.contain("x:4.0");
 		expect(labels).not.to.contain("x:11.0");
 		expect(rect.mock.calls.some(([x, y, w, h]) =>
-			x === margin.left - 10 && y === 0 && w === width + 20 && h === current.height
+			x === margin.left - 20 && y === 0 && w === width + 40 && h === current.height
 		)).to.be.true;
 
 		rect.mockRestore();

--- a/test/internals/legend-spec.ts
+++ b/test/internals/legend-spec.ts
@@ -524,6 +524,12 @@ describe("LEGEND", () => {
 				// check if referenced defs node exists
 				if (pointTagName[idx] === "use") {					
 					expect($el.defs.select(this.getAttribute("href")).size()).to.be.equal(1);
+					expect(this.getAttribute("transform")).to.contain("scale(1.25 1.25)");
+				} else if (pointTagName[idx] === "circle") {
+					expect(+this.getAttribute("r")).to.be.equal(3.75);
+				} else if (pointTagName[idx] === "rect") {
+					expect(+this.getAttribute("width")).to.be.equal(7.5);
+					expect(+this.getAttribute("height")).to.be.equal(7.5);
 				}
 
 				expect(nodeName).to.be.equal(pointTagName[idx]);

--- a/test/internals/util-spec.ts
+++ b/test/internals/util-spec.ts
@@ -73,7 +73,7 @@ describe("UTIL", function() {
 			});
 
 			// @ts-ignore
-			expect(document.body.rect).to.be.deep.equal(rect);
+			expect(document.body.rectClient).to.be.deep.equal(rect);
 		});
 	});
 

--- a/test/module/module-coverage-spec.ts
+++ b/test/module/module-coverage-spec.ts
@@ -142,18 +142,28 @@ describe("MODULE coverage helpers", () => {
 			const terminated: string[] = [];
 
 			class MockWorker {
-				onmessage = null;
 				onerror = null;
 				src;
+				listeners: Function[] = [];
 
 				constructor(src) {
 					this.src = src;
 					created.push(src);
 				}
 
-				postMessage(args) {
+				addEventListener(type, fn) {
+					this.listeners.push(fn);
+				}
+
+				removeEventListener(type, fn) {
+					this.listeners = this.listeners.filter(f => f !== fn);
+				}
+
+				postMessage(data) {
 					setTimeout(() => {
-						this.onmessage?.({data: args[0] * 3});
+						const e = {data: {id: data.id, result: data.args[0] * 3}};
+
+						this.listeners.slice().forEach(fn => fn(e));
 					});
 				}
 
@@ -327,7 +337,7 @@ describe("MODULE coverage helpers", () => {
 			expect(getMinMax("min", dates)).to.be.deep.equal(new Date(1));
 			expect(getMinMax("max", [])).to.be.undefined;
 			expect(getRange(0, 5)).to.be.deep.equal([0, 1, 2, 3, 4]);
-			expect(getRange(1, 6, 2)).to.be.deep.equal([3, 5]);
+			expect(getRange(1, 6, 2)).to.be.deep.equal([1, 3, 5]);
 			expect(findIndex(boxes, 11, 0, boxes.length - 1, false)).to.be.equal(1);
 			expect(findIndex(boxes, 7, 0, boxes.length - 1, false)).to.be.equal(-1);
 			expect(findIndex(rotatedBoxes, 21, 0, rotatedBoxes.length - 1, true)).to.be.equal(2);


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
- Handle focus, defocus and revert without SVG targets in canvas mode.
- Keep legend focus state and canvas frames in sync for those APIs.
- Route tooltip.show and tooltip.hide through canvas focus rendering.
- Clear canvas focus state when programmatic tooltip APIs hide the tooltip.
- Use canvas subchart domain helpers for zoom and unzoom instead of SVG brush access.
- Add API canvas tests under test/api for core public APIs and canvas-only behavior.
