### PR TITLE
feat(plugin-tableview): add numberFormat configuration option

### DIFF
--- a/src/Plugin/tableview/Options.ts
+++ b/src/Plugin/tableview/Options.ts
@@ -112,7 +112,23 @@ export default class Options {
 			 * @example
 			 *   nullString: "N/A"
 			 */
-			nullString: "-"
+			nullString: "-",
+
+			/**
+			 * Set number format function.
+			 * @name numberFormat
+			 * @memberof plugin-tableview
+			 * @type {function}
+			 * @returns {string}
+			 * @default function(v) { // will return formatted value according to locale settings }
+			 * @example
+			 *   numberFormat: function(v) {
+			 *     return v.toLocaleString();
+			 *   }
+			 */
+			numberFormat: function(v: number): string {
+				return v.toLocaleString();
+			}
 		};
 	}
 }

--- a/src/Plugin/tableview/index.ts
+++ b/src/Plugin/tableview/index.ts
@@ -134,7 +134,7 @@ export default class TableView extends Plugin {
 					tplProcess(i ? tpl.tbody : tpl.tbodyHeader, {
 						value: i === 0 ?
 							config.categoryFormat.bind(this)(d) :
-							(isNumber(d) ? d.toLocaleString() : config.nullString)
+							(isNumber(d) ? config.numberFormat.bind(this)(d) : config.nullString)
 					})
 				).join("")
 			}</tr>`;

--- a/test/plugin/tableview/tableview-spec.ts
+++ b/test/plugin/tableview/tableview-spec.ts
@@ -360,14 +360,14 @@ describe("PLUGIN: TABLE-VIEW", () => {
 
 		it("check if numberFormat function is applied correctly.", () => {
 			const tr = document.querySelectorAll(".bb-tableview tr");
-			const formmater = new Intl.NumberFormat("us-US", { style: "currency", currency: "USD" });
+			const formatter = new Intl.NumberFormat("us-US", { style: "currency", currency: "USD" });
 
 			[].slice.call(tr).forEach(v => {
 				const x = v.querySelector("th").textContent;
 
 				if (/202(3|4|5|6)/.test(x)) {
-					expect(v.querySelectorAll("td")[0].textContent).to.be.equal(formmater.format(x === "2023" ? 1230 : (x === "2024" ? 1234 : (x === "2025" ? 1238 : 1238))));
-					expect(v.querySelectorAll("td")[1].textContent).to.be.equal(formmater.format(x === "2023" ? 500 : (x === "2024" ? 120 : (x === "2025" ? 100 : 80))));
+					expect(v.querySelectorAll("td")[0].textContent).to.be.equal(formatter.format(x === "2023" ? 1230 : (x === "2024" ? 1234 : (x === "2025" ? 1238 : 1238))));
+					expect(v.querySelectorAll("td")[1].textContent).to.be.equal(formatter.format(x === "2023" ? 500 : (x === "2024" ? 120 : (x === "2025" ? 100 : 80))));
 				}
 			});
 		});
@@ -383,15 +383,16 @@ describe("PLUGIN: TABLE-VIEW", () => {
 			];
 		});
 
-		it("when numberFormat function is set to undefined, should show raw number value.", () => {
+		it("when numberFormat function is set to undefined, should show number value as formatted by toLocaleString.", () => {
 			const tr = document.querySelectorAll(".bb-tableview tr");
+			const formatter = v => v.toLocaleString();
 
 			[].slice.call(tr).forEach(v => {
 				const x = v.querySelector("th").textContent;
 
 				if (/202(3|4|5|6)/.test(x)) {
-					expect(v.querySelectorAll("td")[0].textContent).to.be.equal(`${(x === "2023" ? 1230 : (x === "2024" ? 1234 : (x === "2025" ? 1238 : 1238)))}`);
-					expect(v.querySelectorAll("td")[1].textContent).to.be.equal(`${(x === "2023" ? 500 : (x === "2024" ? 120 : (x === "2025" ? 100 : 80)))}`);
+					expect(v.querySelectorAll("td")[0].textContent).to.be.equal(formatter(x === "2023" ? 1230 : (x === "2024" ? 1234 : (x === "2025" ? 1238 : 1238))));
+					expect(v.querySelectorAll("td")[1].textContent).to.be.equal(formatter(x === "2023" ? 500 : (x === "2024" ? 120 : (x === "2025" ? 100 : 80))));
 				}
 			});
 		});

--- a/test/plugin/tableview/tableview-spec.ts
+++ b/test/plugin/tableview/tableview-spec.ts
@@ -352,7 +352,7 @@ describe("PLUGIN: TABLE-VIEW", () => {
 						title: "My Yearly Data List",
 						categoryTitle: "Year",
 						style: true,
-						numberFormat: v => new Intl.NumberFormat("us-US", { style: "currency", currency: "USD" }).format(v)
+						numberFormat: v => new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(v)
 					})
 				]
 			};
@@ -360,7 +360,7 @@ describe("PLUGIN: TABLE-VIEW", () => {
 
 		it("check if numberFormat function is applied correctly.", () => {
 			const tr = document.querySelectorAll(".bb-tableview tr");
-			const formatter = new Intl.NumberFormat("us-US", { style: "currency", currency: "USD" });
+			const formatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
 
 			[].slice.call(tr).forEach(v => {
 				const x = v.querySelector("th").textContent;

--- a/test/plugin/tableview/tableview-spec.ts
+++ b/test/plugin/tableview/tableview-spec.ts
@@ -18,6 +18,7 @@ describe("PLUGIN: TABLE-VIEW", () => {
 		categoryTitle: <string|undefined> undefined,
 		categoryFormat: <Function|undefined> undefined,
 		class: <string|undefined> undefined,
+		numberFormat: <Function|undefined> undefined,
 		style: true,
 		title: "어쩌고 저쩌고222",
 		updateOnToggle: true
@@ -325,6 +326,72 @@ describe("PLUGIN: TABLE-VIEW", () => {
 
 				if (/202(4|5|6)/.test(x)) {
 					expect(v.querySelectorAll("td")[x === "2026" ? 1 : 0].textContent).to.be.equal("N/A");
+				}
+			});
+		});
+	});
+
+	describe("numberFormat option", () => {
+		beforeAll(() => {
+			args = {
+				data: {
+					x: "x",
+					columns: [
+						["x", "2023", "2024", "2025", "2026"],
+						["data1", 1230, 1234, 1238, 1238],
+						["data2", 500, 120, 100, 80]
+					],
+				},
+				axis: {
+					x: {
+					  type: "category"
+					}
+				},
+				plugins: [
+					new TableView({
+						title: "My Yearly Data List",
+						categoryTitle: "Year",
+						style: true,
+						numberFormat: v => new Intl.NumberFormat("us-US", { style: "currency", currency: "USD" }).format(v)
+					})
+				]
+			};
+		});
+
+		it("check if numberFormat function is applied correctly.", () => {
+			const tr = document.querySelectorAll(".bb-tableview tr");
+			const formmater = new Intl.NumberFormat("us-US", { style: "currency", currency: "USD" });
+
+			[].slice.call(tr).forEach(v => {
+				const x = v.querySelector("th").textContent;
+
+				if (/202(3|4|5|6)/.test(x)) {
+					expect(v.querySelectorAll("td")[0].textContent).to.be.equal(formmater.format(x === "2023" ? 1230 : (x === "2024" ? 1234 : (x === "2025" ? 1238 : 1238))));
+					expect(v.querySelectorAll("td")[1].textContent).to.be.equal(formmater.format(x === "2023" ? 500 : (x === "2024" ? 120 : (x === "2025" ? 100 : 80))));
+				}
+			});
+		});
+
+		it("set options: numberFormat=undefined", () => {
+			args.plugins = [
+				new TableView({
+					title: "My Yearly Data List",
+					categoryTitle: "Year",
+					style: true,
+					numberFormat: undefined
+				})
+			];
+		});
+
+		it("when numberFormat function is set to undefined, should show raw number value.", () => {
+			const tr = document.querySelectorAll(".bb-tableview tr");
+
+			[].slice.call(tr).forEach(v => {
+				const x = v.querySelector("th").textContent;
+
+				if (/202(3|4|5|6)/.test(x)) {
+					expect(v.querySelectorAll("td")[0].textContent).to.be.equal(`${(x === "2023" ? 1230 : (x === "2024" ? 1234 : (x === "2025" ? 1238 : 1238)))}`);
+					expect(v.querySelectorAll("td")[1].textContent).to.be.equal(`${(x === "2023" ? 500 : (x === "2024" ? 120 : (x === "2025" ? 100 : 80)))}`);
 				}
 			});
 		});


### PR DESCRIPTION
## Issue
#4140 

## Details
Allow a custom formatting callback to format numeric values within the TableView cells. If provided, cell values are passed through the function before rendering to the DOM. Falls back to number.toLocaleString() output if omitted.

