### PR TITLE
refactor(all): Improve ESM and canvas runtime reliability

### DIFF
--- a/config/rollup/esm.js
+++ b/config/rollup/esm.js
@@ -33,6 +33,7 @@ const plugins = [
 ];
 
 const external = id => /^d3-/.test(id);
+const hasSideEffects = id => /[/\\]src[/\\]Chart[/\\]api[/\\]stubs\.ts$/.test(id);
 
 const bbPlugins = readdirSync(resolvePath("../src/Plugin/"), {
         withFileTypes: true
@@ -64,7 +65,7 @@ export default [
             banner: getBannerStr()
         },
         treeshake: {
-            moduleSideEffects: false,
+            moduleSideEffects: hasSideEffects,
             propertyReadSideEffects: false
         },
         plugins,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
 	},
 	"sideEffects": [
 		"dist/**/*.css",
+		"dist-esm/Chart/api/stubs.js",
+		"src/Chart/api/stubs.ts",
 		"src/index.ts"
 	],
 	"repository": {

--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -919,10 +919,18 @@ export default class ChartInternal {
 		$$.resizeFunction = resizeFunction;
 
 		// attach resize event
-		if (resize_auto === "parent") {
-			($$.resizeFunction.resizeObserver = new ResizeObserver($$.resizeFunction.bind($$)))
+		if (resize_auto === "parent" && window.ResizeObserver) {
+			($$.resizeFunction.resizeObserver = new window.ResizeObserver(
+				$$.resizeFunction.bind($$)
+			))
 				.observe($el.chart.node().parentNode);
 		} else {
+			if (resize_auto === "parent") {
+				// ResizeObserver unavailable: parent-specific resize won't be detected
+				window.console?.warn?.(
+					"[billboard.js] resize.auto='parent' requires ResizeObserver; falling back to window resize."
+				);
+			}
 			window.addEventListener("resize", $$.resizeFunction);
 		}
 	}

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -274,7 +274,9 @@ export default {
 		// width/height must be part of the key: resize keeps the domain but moves coords.
 		const xDomain = xScale?.domain();
 		const fingerprint = xDomain ?
-			`${xDomain[0]}_${xDomain[1]}_${state.width}_${state.height}_${$$.data.targets.length}_${
+			`${xDomain[0]}_${
+				xDomain[1]
+			}_${state.width}_${state.height}_${$$.data.targets.length}_${state.dataGeneration}_${
 				[...state.hiddenTargetIds].join(",")
 			}` :
 			null;

--- a/src/ChartInternal/shape/shape.ts
+++ b/src/ChartInternal/shape/shape.ts
@@ -499,14 +499,16 @@ export default {
 			$$.filterTargetsToShow($$.data.targets.filter(typeFilter, $$))
 		);
 
-		// Create cache key based on target IDs
+		// Same IDs can receive new values through load()/flow(), so ID-only
+		// caching can leave stacked offsets pointing at stale row maps.
+		const dataGeneration = $$.state.dataGeneration;
 		const targetIds = targets.map(t => t.id).join("_");
 		const cacheKey = `${KEY.shapeOffset}_${targetIds}`;
 
 		// Check if result is already cached
 		const cachedData = $$.cache.get(cacheKey);
 
-		if (cachedData) {
+		if (cachedData?.generation === dataGeneration) {
 			return cachedData;
 		}
 
@@ -542,7 +544,7 @@ export default {
 			return out;
 		}, {});
 
-		const result = {indexMapByTargetId, shapeOffsetTargets};
+		const result = {generation: dataGeneration, indexMapByTargetId, shapeOffsetTargets};
 
 		// Cache the result
 		$$.cache.add(cacheKey, result);

--- a/src/canvas/CanvasRenderer.ts
+++ b/src/canvas/CanvasRenderer.ts
@@ -189,6 +189,22 @@ function drawCanvasArea($$, target, indices, painter: CanvasPainter, isSub = fal
 }
 
 /**
+ * Get a target copy clipped to the current visible x range.
+ * @param {object} $$ ChartInternal instance
+ * @param {object} target Data target
+ * @returns {object} Original target or a visible values copy
+ * @private
+ */
+function getVisibleCanvasTarget($$, target) {
+	const range = getCanvasTargetVisibleRange($$, target);
+
+	return range.start === 0 && range.end === target.values.length ? target : {
+		...target,
+		values: target.values.slice(range.start, range.end)
+	};
+}
+
+/**
  * Get focused row for a datum or target.
  * @param {Array} focusData Focused data rows
  * @param {object} d Rendered data row or target
@@ -1657,8 +1673,7 @@ export default class CanvasRenderer {
 			d &&
 			(
 				isCanvasBarType($$, d) ||
-				isCanvasCandlestickType($$, d) ||
-				(isCanvasPointType($$, d) && getPointOpacity($$, d) < 1)
+				isCanvasCandlestickType($$, d)
 			)
 		);
 	}
@@ -1684,7 +1699,9 @@ export default class CanvasRenderer {
 
 		painter.withTranslation(margin.left, margin.top, () => {
 			for (const target of targets) {
-				if (!target.values.some(hasCanvasDrawableValue.bind(null, $$))) {
+				const visibleTarget = getVisibleCanvasTarget($$, target);
+
+				if (!visibleTarget.values.some(hasCanvasDrawableValue.bind(null, $$))) {
 					continue;
 				}
 
@@ -1693,9 +1710,9 @@ export default class CanvasRenderer {
 					style.shape.lineFocusedWidth :
 					style.shape.lineWidth;
 				ctx.strokeStyle = $$.color(target.id);
-				$$.config.data_regions?.[target.id] ?
-					drawCanvasLineWithDataRegions($$, target, painter) :
-					drawCanvasLine($$, target, indices, painter);
+				$$.config.data_regions?.[visibleTarget.id] ?
+					drawCanvasLineWithDataRegions($$, visibleTarget, painter) :
+					drawCanvasLine($$, visibleTarget, indices, painter);
 			}
 			ctx.globalAlpha = 1;
 		});
@@ -1723,23 +1740,26 @@ export default class CanvasRenderer {
 
 		painter.withTranslation(margin.left, margin.top, () => {
 			for (const target of targets) {
-				if (!target.values.some(hasCanvasDrawableValue.bind(null, $$))) {
+				const visibleTarget = getVisibleCanvasTarget($$, target);
+
+				if (!visibleTarget.values.some(hasCanvasDrawableValue.bind(null, $$))) {
 					continue;
 				}
 
-				const color = getCanvasRenderColor($$, target, focusData);
+				const color = getCanvasRenderColor($$, visibleTarget, focusData);
 
 				ctx.globalAlpha = style.shape.areaOpacity * getCanvasTargetFocusOpacity($$, target);
 				ctx.fillStyle = getCanvasLinearGradientFill(
 					$$,
 					ctx,
-					target,
+					visibleTarget,
 					"area",
-					// bounds computation is a full O(n) pass: skip when no gradient is set
+					// Bounds computation walks visible rows, so skip it when no gradient is set.
+					// Use the original target so the range cache stays aligned with unsliced values.
 					$$.config.area_linearGradient ? getCanvasAreaBounds($$, target, indices) : null,
 					color
 				);
-				drawCanvasArea($$, target, indices, painter);
+				drawCanvasArea($$, visibleTarget, indices, painter);
 			}
 			ctx.globalAlpha = 1;
 		});
@@ -2073,14 +2093,13 @@ export default class CanvasRenderer {
 				) &&
 				isCanvasRenderableTarget($$, target)
 			);
-		// single filtering pass: keep target-local index `i`, it drives geometry lookup
-		const targetRows: Array<{d, i: number, text: string}[]> = [];
+		const targetRows: Array<{d, text: string}[]> = [];
 		let labelCount = 0;
 
 		targets.forEach(target => {
 			const range = getCanvasTargetVisibleRange($$, target);
 			const data = $$.labelishData(target);
-			const rows: {d, i: number, text: string}[] = [];
+			const rows: {d, text: string}[] = [];
 
 			for (let i = 0; i < data.length; i++) {
 				const d = data[i];
@@ -2092,7 +2111,7 @@ export default class CanvasRenderer {
 					d.index < range.end &&
 					hasCanvasDrawableValue($$, d)
 				) {
-					rows.push({d, i, text});
+					rows.push({d, text});
 				}
 			}
 
@@ -2110,12 +2129,12 @@ export default class CanvasRenderer {
 
 			targetRows
 				.forEach(rows => {
-					for (const {d, i, text} of rows) {
+					for (const {d, text} of rows) {
 						let x;
 						let y;
 
 						if (isCanvasBarType($$, d) && barPoints) {
-							const geometry = getCanvasBarGeometry($$, barPoints, d, i);
+							const geometry = getCanvasBarGeometry($$, barPoints, d, d.index);
 
 							if (!geometry) {
 								continue;
@@ -2148,7 +2167,7 @@ export default class CanvasRenderer {
 								$$,
 								candlestickPoints,
 								d,
-								i
+								d.index
 							);
 							const isUp = value?._isUp;
 
@@ -2171,7 +2190,7 @@ export default class CanvasRenderer {
 								"middle" :
 								(isUp ? "bottom" : "top");
 						} else if (cx && cy) {
-							({x, y} = getShapePoint(shape.pos, d, i));
+							({x, y} = getShapePoint(shape.pos, d, d.index));
 							({x, y} = getPointLabelAnchor($$, ctx, d, x, y));
 						}
 
@@ -2472,20 +2491,35 @@ export default class CanvasRenderer {
 						const r = $$.pointExpandedR?.(d) ?? (baseR * 1.75);
 						const overColor = getCanvasOverColor($$, d);
 						const color = overColor || $$.color(d.id);
+						const fill = overColor ||
+							style.focusPoint.fill ||
+							style.shape.pointFillColor ||
+							color;
+						const stroke = overColor || style.focusPoint.stroke || color;
+						const lineWidth = style.focusPoint.lineWidth;
+						const alpha = getPointOpacity($$, d);
+						const hasStroke = !!stroke && (lineWidth ?? 0) > 0;
+						const mergeSameColorStroke = pointType === "circle" &&
+							hasStroke &&
+							isNumber(alpha) &&
+							alpha < 1 &&
+							fill === stroke;
 
 						if (!isFiniteCanvasCoordinate(x, y)) {
 							return;
 						}
 
-						drawPointPattern(painter, pointType, x, y, r, {
-							fill: overColor ||
-								style.focusPoint.fill ||
-								style.shape.pointFillColor ||
-								color,
-							lineWidth: style.focusPoint.lineWidth,
-							stroke: overColor || style.focusPoint.stroke || color,
-							alpha: getPointOpacity($$, d)
-						}, baseR);
+						drawPointPattern(
+							painter,
+							pointType,
+							x,
+							y,
+							mergeSameColorStroke ? r + (lineWidth || 0) / 2 : r,
+							hasStroke && !mergeSameColorStroke ?
+								{fill, lineWidth, stroke, alpha} :
+								{fill, alpha},
+							baseR
+						);
 					});
 			}
 

--- a/src/module/util/object.ts
+++ b/src/module/util/object.ts
@@ -25,7 +25,7 @@ function _forEachValidItem<T>(items: T[], callback: (item: T, index: number) => 
 	for (let i = 0; i < items.length; i++) {
 		const item = items[i];
 
-		if (item) {
+		if (item !== null && isDefined(item)) {
 			callback(item, i);
 		}
 	}
@@ -224,7 +224,9 @@ function mergeObj(target: object, ...objectN): any {
 			if (!/^(__proto__|constructor|prototype)$/i.test(key)) {
 				const value = source[key];
 
-				if (isObject(value)) {
+				if (value instanceof Date) {
+					target[key] = new Date(value.getTime());
+				} else if (isObject(value)) {
 					!target[key] && (target[key] = {});
 					target[key] = mergeObj(target[key], value);
 				} else {

--- a/src/module/worker.ts
+++ b/src/module/worker.ts
@@ -17,29 +17,35 @@ let messageId = 0;
  * @returns {{key: string, src: string}} Cache key and Object URL
  * @private
  */
-function getOrCreateWorkerResources(fn: Function, depsFn?: Function[]): {key: string, src: string} {
+function getOrCreateWorkerResources(fn: Function, depsFn?: Function[]):
+	| {key: string, src: string}
+	| null {
 	const fnString = fn.toString();
 	// Include depsFn in cache key to handle different dependencies
 	const depsString = depsFn?.map(String).join(";") ?? "";
 	const key = (fnString + depsString).replace(/(function|[\s\W\n])/g, "").substring(0, 30);
 
 	if (!(key in cache)) {
-		// Create Blob and Object URL for Web Worker
-		const blob = new window.Blob([
-			`${depsString}
+		try {
+			// Create Blob and Object URL for Web Worker
+			const blob = new window.Blob([
+				`${depsString}
 
-			self.onmessage=function({data}) {
-				const result = (${fnString}).apply(null, data.args);
-				self.postMessage({id: data.id, result});
-			};`
-		], {
-			type: "text/javascript"
-		});
+				self.onmessage=function({data}) {
+					const result = (${fnString}).apply(null, data.args);
+					self.postMessage({id: data.id, result});
+				};`
+			], {
+				type: "text/javascript"
+			});
 
-		cache[key] = {
-			src: window.URL.createObjectURL(blob),
-			worker: null
-		};
+			cache[key] = {
+				src: window.URL.createObjectURL(blob),
+				worker: null
+			};
+		} catch {
+			return null;
+		}
 	}
 
 	return {key, src: cache[key].src};
@@ -61,7 +67,11 @@ export function getWorker(key: string, src: string): Worker | null {
 	}
 
 	if (!cached.worker) {
-		cached.worker = new window.Worker(src);
+		try {
+			cached.worker = new window.Worker(src);
+		} catch {
+			return null;
+		}
 
 		// handle error
 		if (cached.worker) {
@@ -111,11 +121,11 @@ export function runWorker(
 	};
 
 	if (window.Worker && useWorker) {
-		const {key, src} = getOrCreateWorkerResources(fn, depsFn);
-		const worker = getWorker(key, src);
+		const workerResources = getOrCreateWorkerResources(fn, depsFn);
+		const worker = workerResources && getWorker(workerResources.key, workerResources.src);
 
-		runFn = function(...args: unknown[]) {
-			if (worker) {
+		if (worker) {
+			runFn = function(...args: unknown[]) {
 				// workers are cached and shared: match the response by id so concurrent
 				// callers don't steal each other's result
 				const id = ++messageId;
@@ -129,8 +139,8 @@ export function runWorker(
 
 				worker.addEventListener("message", handler);
 				worker.postMessage({id, args});
-			}
-		};
+			};
+		}
 	}
 
 	return runFn;

--- a/test/esm/canvas-renderer-coverage-spec.ts
+++ b/test/esm/canvas-renderer-coverage-spec.ts
@@ -404,7 +404,9 @@ describe("ESM canvas renderer coverage", () => {
 		renderer.drawCircles(ctx, shape, [ctx.data.targets[2].values[0]]);
 		renderer.drawLabels(ctx, shape);
 		renderer.drawFocus(ctx, [ctx.data.targets[2].values[0]]);
-		expect(renderer.hasExpandedShapeFocus(ctx, [ctx.data.targets[2].values[0]])).to.be.true;
+		expect(renderer.hasExpandedShapeFocus(ctx, [ctx.data.targets[2].values[0]])).to.be.false;
+		expect(renderer.hasExpandedShapeFocus(ctx, [ctx.data.targets[0].values[0]])).to.be.true;
+		expect(renderer.hasExpandedShapeFocus(ctx, [ctx.data.targets[1].values[0]])).to.be.true;
 
 		ctx.config.axis_rotated = true;
 		ctx.config.point_show = false;

--- a/test/esm/canvas-spec.ts
+++ b/test/esm/canvas-spec.ts
@@ -3631,12 +3631,13 @@ describe("ESM canvas", function() {
 				}
 			});
 
-			const canvasEl = container.querySelector(`canvas.${$CANVAS.canvas}`);
-			const rect = canvasEl.getBoundingClientRect();
-			const {margin} = chart.internal.state;
-			const d = chart.internal.data.targets[0].values[0];
+				const canvasEl = container.querySelector(`canvas.${$CANVAS.canvas}`);
+				const rect = canvasEl.getBoundingClientRect();
+				const {margin} = chart.internal.state;
+				const d = chart.internal.data.targets[0].values[0];
+				const expectedExpandedRadius = chart.internal.pointExpandedR(d);
 
-			fillTextRecords.length = 0;
+				fillTextRecords.length = 0;
 			fillRecords.length = 0;
 			arcRecords.length = 0;
 			canvasEl.dispatchEvent(new MouseEvent("mousemove", {
@@ -3648,32 +3649,31 @@ describe("ESM canvas", function() {
 			const focusLabel = fillTextRecords.find(({canvasClass, text}) =>
 				canvasClass.includes($CANVAS.canvas) && text === "20"
 			);
-			const expandedPointFill = fillRecords.find(({canvasClass, fillStyle, lineWidth}) =>
-				canvasClass.includes($CANVAS.canvas) &&
-				fillStyle === "#ffffff" &&
-				lineWidth === chart.internal.canvasTheme.style.focusPoint.lineWidth
-			);
-			const expandedPointArc = arcRecords.find(({canvasClass, r}) =>
-				canvasClass.includes($CANVAS.canvas) &&
-				Math.abs(r - chart.internal.pointExpandedR(d)) < 1e-6
-			);
-			const expandedPointArcs = arcRecords.filter(({canvasClass, lineWidth}) =>
-				canvasClass.includes($CANVAS.canvas) &&
-				lineWidth === chart.internal.canvasTheme.style.focusPoint.lineWidth
-			);
+				const expandedPointFill = fillRecords.find(({canvasClass, fillStyle}) =>
+					canvasClass.includes($CANVAS.canvas) &&
+					fillStyle === "#ffffff"
+				);
+				const expandedPointArc = arcRecords.find(({canvasClass, r}) =>
+					canvasClass.includes($CANVAS.canvas) &&
+					Math.abs(r - expectedExpandedRadius) < 1e-6
+				);
+				const expandedPointArcs = arcRecords.filter(({canvasClass, r}) =>
+					canvasClass.includes($CANVAS.canvas) &&
+					Math.abs(r - expectedExpandedRadius) < 1e-6
+				);
 
-			expect(chart.internal.state.canvasFocusKey).to.contain("data1:0");
-			expect(chart.internal.state.canvasFocusMainRedraw).to.be.true;
-			expect(focusLabel).not.to.be.undefined;
-			expect(focusLabel?.textAlign).to.be.equal("center");
+				expect(chart.internal.state.canvasFocusKey).to.contain("data1:0");
+				expect(chart.internal.state.canvasFocusMainRedraw).to.be.false;
+				expect(focusLabel).not.to.be.undefined;
+				expect(focusLabel?.textAlign).to.be.equal("center");
 			expect(focusLabel?.textBaseline).to.be.equal("middle");
 			expect(focusLabel?.fillStyle).to.be.equal(chart.internal.color("data1"));
 			expect(focusLabel?.globalAlpha).to.be.equal(1);
 			expect(focusLabel?.absoluteY - margin.top)
 				.to.be.closeTo(chart.internal.circleY(d, d.index), 1e-6);
-			expect(expandedPointFill?.globalAlpha).to.be.equal(0.5);
-			expect(expandedPointArc?.globalAlpha).to.be.equal(0.5);
-			expect(expandedPointArcs).to.have.length(1);
+				expect(expandedPointFill?.globalAlpha).to.be.equal(0.5);
+				expect(expandedPointArc?.globalAlpha).to.be.equal(0.5);
+				expect(expandedPointArcs).to.have.length(1);
 			expect(container.querySelector(`canvas.${$CANVAS.overlay}`)).to.be.null;
 			expect(container.querySelectorAll("canvas")).to.have.length(1);
 		} finally {
@@ -3761,24 +3761,25 @@ describe("ESM canvas", function() {
 			}));
 
 			const expectedExpandedRadius = chart.internal.pointExpandedR(d) + focusLineWidth / 2;
-			const expandedPointArcs = arcRecords.filter(({canvasClass, r}) =>
-				canvasClass.includes($CANVAS.canvas) &&
-				Math.abs(r - expectedExpandedRadius) < 1e-6
-			);
-			const expandedPointStroke = strokeRecords.find(({
-				canvasClass,
-				globalAlpha,
-				lineWidth,
+				const expandedPointArcs = arcRecords.filter(({canvasClass, r}) =>
+					canvasClass.includes($CANVAS.canvas) &&
+					Math.abs(r - expectedExpandedRadius) < 1e-6
+				);
+				const expandedPointStroke = strokeRecords.find(({
+					canvasClass,
+					globalAlpha,
+					lineWidth,
 				strokeStyle
 			}) =>
 				canvasClass.includes($CANVAS.canvas) &&
 				strokeStyle === color &&
 				globalAlpha === 0.5 &&
 				lineWidth === focusLineWidth
-			);
+				);
 
-			expect(chart.internal.state.canvasFocusKey).to.contain("data1:0");
-			expect(expandedPointArcs).to.have.length(1);
+				expect(chart.internal.state.canvasFocusKey).to.contain("data1:0");
+				expect(chart.internal.state.canvasFocusMainRedraw).to.be.false;
+				expect(expandedPointArcs).to.have.length(1);
 			expect(expandedPointArcs[0].r)
 				.to.be.closeTo(expectedExpandedRadius, 1e-6);
 			expect(expandedPointArcs[0].globalAlpha).to.be.equal(0.5);

--- a/test/internals/bb-spec.ts
+++ b/test/internals/bb-spec.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 /* eslint-disable */
-import {beforeEach, beforeAll, afterEach, afterAll, describe, expect, it} from "vitest";
+import {beforeEach, beforeAll, afterEach, afterAll, describe, expect, it, vi} from "vitest";
 import sinon from "sinon";
 
 import bb from "../../src";
@@ -322,7 +322,7 @@ describe("Interface & initialization", () => {
 			expect(svg.attr("viewBox")).to.be.equal("0 0 640 480");
 		});
 
-		it("check 'parent' resize", () => {
+		it("check 'parent' resize", () => new Promise(done => {
 			let width = 300;
 
 			container.style.width = `${width}px`;
@@ -353,7 +353,38 @@ describe("Interface & initialization", () => {
 			// should resize on parent element
 			setTimeout(() => {
 				expect(+chart.$.svg.attr("width")).to.be.equal(width);
+				done(1);
 			}, 350);
+		}));
+
+		it("does not throw for parent resize when ResizeObserver is unavailable", () => {
+			const ResizeObserver = (window as any).ResizeObserver;
+			const warn = vi.spyOn(window.console, "warn").mockImplementation(() => {});
+
+			container.innerHTML = '<div id="chartResize"></div>';
+			(window as any).ResizeObserver = undefined;
+
+			try {
+				expect(() => {
+					chart = util.generate({
+						data: {
+							columns: [
+								["data1", 30]
+							]
+						},
+						resize: {
+							auto: "parent"
+						},
+						bindto: "#chartResize"
+					});
+				}).not.to.throw();
+				expect(warn).toHaveBeenCalledWith(
+					"[billboard.js] resize.auto='parent' requires ResizeObserver; falling back to window resize."
+				);
+			} finally {
+				warn.mockRestore();
+				(window as any).ResizeObserver = ResizeObserver;
+			}
 		});
 
 	});

--- a/test/module/module-coverage-spec.ts
+++ b/test/module/module-coverage-spec.ts
@@ -194,6 +194,52 @@ describe("MODULE coverage helpers", () => {
 			})(4);
 		}));
 
+		it("falls back to sync execution when worker resources cannot be created", () => {
+			const OriginalWorker = window.Worker;
+			const originalCreateObjectURL = window.URL.createObjectURL;
+			const values: number[] = [];
+
+			try {
+				window.Worker = class {};
+				window.URL.createObjectURL = () => {
+					throw new Error("CSP blocked");
+				};
+
+				runWorker(true, value => value * 2, value => values.push(value))(5);
+
+				expect(values).to.be.deep.equal([10]);
+			} finally {
+				window.Worker = OriginalWorker;
+				window.URL.createObjectURL = originalCreateObjectURL;
+			}
+		});
+
+		it("falls back to sync execution when Worker construction fails", () => {
+			const OriginalWorker = window.Worker;
+			const originalCreateObjectURL = window.URL.createObjectURL;
+			const originalRevokeObjectURL = window.URL.revokeObjectURL;
+			const values: number[] = [];
+
+			try {
+				window.Worker = class {
+					constructor() {
+						throw new Error("Worker blocked");
+					}
+				};
+				window.URL.createObjectURL = () => "blob:blocked";
+				window.URL.revokeObjectURL = () => {};
+
+				runWorker(true, value => value + 1, value => values.push(value))(5);
+
+				expect(values).to.be.deep.equal([6]);
+			} finally {
+				cleanupWorkers();
+				window.Worker = OriginalWorker;
+				window.URL.createObjectURL = originalCreateObjectURL;
+				window.URL.revokeObjectURL = originalRevokeObjectURL;
+			}
+		});
+
 	});
 
 	describe("geometry and brush helpers", () => {
@@ -325,6 +371,14 @@ describe("MODULE coverage helpers", () => {
 			expect(mergeObj({a: {b: 1}}, {a: {c: 2}, arr: [1]}, {"__proto__": {polluted: true}}))
 				.to.be.deep.equal({a: {b: 1, c: 2}, arr: [1]});
 			expect(({} as any).polluted).to.be.undefined;
+
+			const date = new Date(1234);
+			const merged = mergeObj({}, {date, nested: {date}});
+
+			expect(merged.date).to.be.instanceOf(Date);
+			expect(+merged.date).to.be.equal(+date);
+			expect(merged.date).not.to.be.equal(date);
+			expect(merged.nested.date).to.be.instanceOf(Date);
 		});
 
 		it("gets ranges, min/max values and binary-search indexes", () => {
@@ -353,13 +407,17 @@ describe("MODULE coverage helpers", () => {
 			});
 			expect(parseShorthand("1 2 3")).to.be.deep.equal({top: 1, right: 2, bottom: 3, left: 2});
 			expect(parseShorthand(5)).to.be.deep.equal({top: 5, right: 5, bottom: 5, left: 5});
-			expect(Array.from(toSet([{id: "a"}, null, {id: "b"}], item => item.id)))
-				.to.be.deep.equal(["a", "b"]);
-			expect(Array.from(toMap([{id: "a", value: 1}, null, {id: "b", value: 2}],
-				item => item.id, item => item.value).entries()))
-				.to.be.deep.equal([["a", 1], ["b", 2]]);
+				expect(Array.from(toSet([{id: "a"}, null, {id: "b"}], item => item.id)))
+					.to.be.deep.equal(["a", "b"]);
+				expect(Array.from(toSet(["", 0, false, null, undefined])))
+					.to.be.deep.equal(["", 0, false]);
+				expect(Array.from(toMap([{id: "a", value: 1}, null, {id: "b", value: 2}],
+					item => item.id, item => item.value).entries()))
+					.to.be.deep.equal([["a", 1], ["b", 2]]);
+				expect(Array.from(toMap(["", 0, false, null], item => String(item)).entries()))
+					.to.be.deep.equal([["", ""], ["0", 0], ["false", false]]);
 
-			let ready = false;
+				let ready = false;
 
 			setTimeout(() => {
 				ready = true;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,9 +31,6 @@ export {
 	step,
 	treemap,
 
-	// render modules
-	canvas,
-
 	// interaction modules
 	selection,
 	subchart,


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
- Preserve optional API stubs in ESM builds and align canvas-only type exports.
- Fallback safely when ResizeObserver or worker Blob URLs are unavailable.
- Invalidate shape offsets and event rects when data generation changes.
- Use visible canvas ranges for zoomed paths, labels, gradients, and focus overlays.
- Fix Date merges and preserve falsy values in set/map utilities.