### PR TITLE
refactor(render): optimize resize rendering paths

### DIFF
--- a/CHANGELOG-v4.md
+++ b/CHANGELOG-v4.md
@@ -312,19 +312,23 @@ Canvas drawing internals:
 
 ### Canvas benchmark snapshot
 
-The following numbers are a local benchmark snapshot, not a release guarantee. They were measured in Chromium headless against rebuilt local UMD bundles from the `3.18.0` tag and the current v4 branch with one warmup run and three measured runs on 2026-06-15. Values are median elapsed time in milliseconds.
+The following numbers are a local benchmark snapshot, not a release guarantee. They were measured in
+Chromium headless against rebuilt local UMD bundles from the `3.18.0` tag and the current v4 branch
+with one warmup run and three measured runs on 2026-06-15. Values are median elapsed time in
+milliseconds.
 
-The benchmark uses the public benchmark demo defaults where applicable: `1 x 10,000` data matrix, `transition.duration=0`, `legend.show=false`, `axis.x.tick.show=false`, and `boost.useWorker=false`.
+The benchmark uses the public benchmark demo defaults where applicable: `1 x 10,000` data matrix,
+`transition.duration=0`, `legend.show=false`, `axis.x.tick.show=false`, and `boost.useWorker=false`.
 Line-like charts keep the default point rendering cost, matching the demo behavior rather than a
 path-only micro-benchmark. Canvas-unsupported types are intentionally left blank in the canvas
 column.
 
-Simple averages below use the nine canvas-supported demo types so the SVG and canvas summaries are compared over the same chart set:
+Simple averages below use the nine canvas-supported demo types so the SVG and canvas summaries are
+compared over the same chart set:
 
-- Initial render: 4.0 SVG is **62.8% faster** than 3.18.0; 4.0 canvas is **94.8% faster**.
-- `chart.load()`: 4.0 SVG is **75.9% faster** than 3.18.0; 4.0 canvas is **63.9% faster**.
-- `chart.resize()`: 4.0 SVG is **54.9% slower** than 3.18.0; 4.0 canvas is **125.2% slower**,
-  mainly from the current area-family canvas path.
+- Initial render: 4.0 SVG is **60.4% faster** than 3.18.0; 4.0 canvas is **98.0% faster**.
+- `chart.load()`: 4.0 SVG is **75.7% faster** than 3.18.0; 4.0 canvas is **97.5% faster**.
+- `chart.resize()`: 4.0 SVG is **6.1% faster** than 3.18.0; 4.0 canvas is **87.3% faster**.
 
 #### Initial render
 
@@ -332,19 +336,19 @@ Initial render is measured from `bb.generate()` start through the first `onrende
 
 | type | data matrix | 3.18.0 | 4.0 (svg) | 4.0 (canvas) |
 | --- | ---: | ---: | ---: | ---: |
-| `area` | 1 x 10,000 | 1109.6 ms | 402.0 ms | 108.5 ms |
-| `area-spline` | 1 x 10,000 | 1096.3 ms | 414.1 ms | 130.7 ms |
-| `area-step` | 1 x 10,000 | 1134.1 ms | 424.8 ms | 109.3 ms |
-| `bar` | 1 x 10,000 | 1146.4 ms | 460.9 ms | 53.3 ms |
-| `bubble` | 1 x 10,000 | 1322.9 ms | 449.7 ms | 57.1 ms |
-| `donut` | 1 x 10,000 | 10.3 ms | 11.0 ms |  |
-| `gauge` | 1 x 10,000 | 13.9 ms | 14.0 ms |  |
-| `line` | 1 x 10,000 | 1090.6 ms | 390.0 ms | 19.3 ms |
-| `pie` | 1 x 10,000 | 14.4 ms | 11.2 ms |  |
-| `radar` | 1 x 10,000 | 6810.3 ms | 5376.7 ms |  |
-| `scatter` | 1 x 10,000 | 1277.4 ms | 483.1 ms | 25.4 ms |
-| `spline` | 1 x 10,000 | 1081.7 ms | 412.0 ms | 20.2 ms |
-| `step` | 1 x 10,000 | 1095.7 ms | 411.9 ms | 19.0 ms |
+| `area` | 1 x 10,000 | 1138.1 ms | 439.5 ms | 25.1 ms |
+| `area-spline` | 1 x 10,000 | 1103.6 ms | 417.5 ms | 22.7 ms |
+| `area-step` | 1 x 10,000 | 1080.2 ms | 432.8 ms | 21.9 ms |
+| `bar` | 1 x 10,000 | 1152.4 ms | 458.3 ms | 44.4 ms |
+| `bubble` | 1 x 10,000 | 1330.8 ms | 511.9 ms | 20.1 ms |
+| `donut` | 1 x 10,000 | 14.6 ms | 11.9 ms |  |
+| `gauge` | 1 x 10,000 | 13.9 ms | 13.9 ms |  |
+| `line` | 1 x 10,000 | 1098.3 ms | 447.4 ms | 16.7 ms |
+| `pie` | 1 x 10,000 | 9.4 ms | 13.6 ms |  |
+| `radar` | 1 x 10,000 | 5472.8 ms | 5333.5 ms |  |
+| `scatter` | 1 x 10,000 | 1156.6 ms | 494.8 ms | 16.4 ms |
+| `spline` | 1 x 10,000 | 1068.1 ms | 415.7 ms | 17.0 ms |
+| `step` | 1 x 10,000 | 1069.0 ms | 422.2 ms | 17.0 ms |
 
 #### Data loading
 
@@ -352,19 +356,19 @@ Initial render is measured from `bb.generate()` start through the first `onrende
 
 | type | data matrix | 3.18.0 | 4.0 (svg) | 4.0 (canvas) |
 | --- | ---: | ---: | ---: | ---: |
-| `area` | 1 x 10,000 | 812.4 ms | 203.8 ms | 878.6 ms |
-| `area-spline` | 1 x 10,000 | 810.8 ms | 204.1 ms | 774.5 ms |
-| `area-step` | 1 x 10,000 | 804.9 ms | 202.2 ms | 840.4 ms |
-| `bar` | 1 x 10,000 | 848.3 ms | 229.5 ms | 51.2 ms |
-| `bubble` | 1 x 10,000 | 912.5 ms | 195.8 ms | 54.9 ms |
-| `donut` | 1 x 10,000 | 1.7 ms | 1.8 ms |  |
-| `gauge` | 1 x 10,000 | 2.0 ms | 2.0 ms |  |
-| `line` | 1 x 10,000 | 830.5 ms | 201.1 ms | 22.3 ms |
-| `pie` | 1 x 10,000 | 1.8 ms | 1.8 ms |  |
-| `radar` | 1 x 10,000 | 141.7 ms | 157.5 ms |  |
-| `scatter` | 1 x 10,000 | 865.5 ms | 192.7 ms | 24.0 ms |
-| `spline` | 1 x 10,000 | 790.3 ms | 178.7 ms | 28.6 ms |
-| `step` | 1 x 10,000 | 780.9 ms | 191.1 ms | 19.9 ms |
+| `area` | 1 x 10,000 | 801.5 ms | 187.7 ms | 21.2 ms |
+| `area-spline` | 1 x 10,000 | 795.5 ms | 206.7 ms | 21.1 ms |
+| `area-step` | 1 x 10,000 | 827.1 ms | 205.6 ms | 20.3 ms |
+| `bar` | 1 x 10,000 | 857.5 ms | 235.0 ms | 41.8 ms |
+| `bubble` | 1 x 10,000 | 899.6 ms | 222.0 ms | 16.8 ms |
+| `donut` | 1 x 10,000 | 1.9 ms | 1.9 ms |  |
+| `gauge` | 1 x 10,000 | 1.9 ms | 2.0 ms |  |
+| `line` | 1 x 10,000 | 808.0 ms | 197.2 ms | 15.3 ms |
+| `pie` | 1 x 10,000 | 2.0 ms | 2.0 ms |  |
+| `radar` | 1 x 10,000 | 135.5 ms | 132.3 ms |  |
+| `scatter` | 1 x 10,000 | 885.0 ms | 202.6 ms | 17.0 ms |
+| `spline` | 1 x 10,000 | 804.7 ms | 192.4 ms | 15.6 ms |
+| `step` | 1 x 10,000 | 817.7 ms | 175.5 ms | 15.2 ms |
 
 #### Resize
 
@@ -373,25 +377,25 @@ disabled.
 
 | type | data matrix | 3.18.0 | 4.0 (svg) | 4.0 (canvas) |
 | --- | ---: | ---: | ---: | ---: |
-| `area` | 1 x 10,000 | 100.9 ms | 174.8 ms | 773.3 ms |
-| `area-spline` | 1 x 10,000 | 99.3 ms | 199.8 ms | 619.9 ms |
-| `area-step` | 1 x 10,000 | 98.5 ms | 166.8 ms | 774.4 ms |
-| `bar` | 1 x 10,000 | 129.6 ms | 203.9 ms | 43.0 ms |
-| `bubble` | 1 x 10,000 | 194.7 ms | 203.6 ms | 49.6 ms |
-| `donut` | 1 x 10,000 | 0.2 ms | 0.2 ms |  |
-| `gauge` | 1 x 10,000 | 0.2 ms | 0.2 ms |  |
-| `line` | 1 x 10,000 | 89.8 ms | 160.8 ms | 16.0 ms |
-| `pie` | 1 x 10,000 | 0.2 ms | 0.1 ms |  |
-| `radar` | 1 x 10,000 | 140.0 ms | 135.6 ms |  |
-| `scatter` | 1 x 10,000 | 146.4 ms | 179.8 ms | 18.8 ms |
-| `spline` | 1 x 10,000 | 83.8 ms | 156.5 ms | 21.9 ms |
-| `step` | 1 x 10,000 | 92.0 ms | 156.8 ms | 13.5 ms |
+| `area` | 1 x 10,000 | 94.0 ms | 124.2 ms | 13.8 ms |
+| `area-spline` | 1 x 10,000 | 105.5 ms | 116.0 ms | 14.4 ms |
+| `area-step` | 1 x 10,000 | 97.5 ms | 105.0 ms | 13.6 ms |
+| `bar` | 1 x 10,000 | 132.7 ms | 96.6 ms | 34.8 ms |
+| `bubble` | 1 x 10,000 | 165.6 ms | 88.8 ms | 10.3 ms |
+| `donut` | 1 x 10,000 | 0.3 ms | 0.3 ms |  |
+| `gauge` | 1 x 10,000 | 0.2 ms | 0.5 ms |  |
+| `line` | 1 x 10,000 | 84.9 ms | 105.5 ms | 9.9 ms |
+| `pie` | 1 x 10,000 | 0.2 ms | 0.3 ms |  |
+| `radar` | 1 x 10,000 | 128.6 ms | 209.1 ms |  |
+| `scatter` | 1 x 10,000 | 146.6 ms | 89.4 ms | 10.2 ms |
+| `spline` | 1 x 10,000 | 86.6 ms | 107.4 ms | 9.9 ms |
+| `step` | 1 x 10,000 | 85.7 ms | 105.1 ms | 9.9 ms |
 
 The result shows two separate effects. The v4 SVG path is substantially faster than 3.18.0 for
-node-heavy axis charts in initial render and `chart.load()`. Canvas then gives another large gain
-for line, spline, step, bar, bubble, and scatter because those charts avoid per-point or per-shape
-SVG nodes. The current area-family canvas path is faster for initial render, but `chart.load()` and
-resize are still optimization candidates.
+node-heavy axis charts in initial render and `chart.load()`, while resize is also faster after
+reusing unchanged SVG tick nodes and tick text during resize-only redraws. Canvas then gives another
+large gain for supported high-density axis charts because those charts avoid per-point or per-shape
+SVG nodes and defer clean-frame bitmap copies until an overlay is actually needed.
 
 Canvas parity scope:
 
@@ -414,8 +418,8 @@ Current SVG parity backlog and implementation plan:
   - Current canvas behavior: canvas is faster for many node-heavy shapes, but some paths still
     redraw more than necessary. Bar/candlestick focus currently redraws the focused frame so
     expanded opacity matches SVG.
-  - Implementation plan: profile `area`, `treemap`, dense tick generation, and focused bar redraws.
-    Add optimizations only after SVG parity and regression tests are in place.
+  - Implementation plan: profile `treemap`, dense tick generation, and focused bar redraws. Add
+    optimizations only after SVG parity and regression tests are in place.
 
 Each completed parity item should remove the corresponding `warnUnsupportedCanvasOptions()` warning,
 update the canvas ESM exports when API surface changes, and add SVG-vs-canvas regression coverage.

--- a/src/ChartInternal/Axis/AxisRenderer.ts
+++ b/src/ChartInternal/Axis/AxisRenderer.ts
@@ -17,6 +17,56 @@ export default class AxisRenderer {
 	private g;
 	private generatedTicks: (Date | number)[] = [];
 
+	private canReuseTickTextOnResize(isLeftRight: boolean): boolean {
+		const {config, params} = this;
+		const {config: chartConfig, id, owner} = params;
+		const isX = /^(x|subX)$/.test(id);
+		const type = id === "subX" ? "x" : id;
+		const customTickFormat = id === "subX" ?
+			chartConfig.subchart_axis_x_tick_format || chartConfig.axis_x_tick_format :
+			chartConfig[`axis_${type}_tick_format`];
+		const categoryAutoWrap = params.tickMultiline && params.isCategory && !isLeftRight &&
+			!(params.tickWidth > 0);
+
+		return !!(
+			owner.state.resizing &&
+			!owner.state.flowing &&
+			!isFunction(chartConfig.axis_evalTextSize) &&
+			!customTickFormat &&
+			!params.tickTitle &&
+			!(isX && chartConfig.axis_x_tick_autorotate) &&
+			!categoryAutoWrap &&
+			config.withoutTransition
+		);
+	}
+
+	private canReuseTickNodesOnResize(tickNodes: d3Selection, ticks, isLeftRight: boolean,
+		tickShow): boolean {
+		if (
+			tickShow.tick || !tickShow.text || !this.canReuseTickTextOnResize(isLeftRight) ||
+			tickNodes.size() !== ticks.length
+		) {
+			return false;
+		}
+
+		const nodes = tickNodes.nodes();
+
+		for (let i = 0; i < ticks.length; i++) {
+			const current = (nodes[i] as any).__data__;
+			const next = ticks[i];
+
+			if (current instanceof Date || next instanceof Date) {
+				if (+current !== +next) {
+					return false;
+				}
+			} else if (current !== next) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	constructor(params: any = {}) {
 		const config = {
 			innerTickSize: AXIS_TICK_SIZE,
@@ -122,133 +172,157 @@ export default class AxisRenderer {
 				ctx.generatedTicks = ticks;
 
 				// update selection
-				let tick: d3Selection = g.selectAll(".tick")
-					.data(ticks, scale1);
+				let tick: d3Selection = g.selectAll(".tick");
+				const canReuseTickNodes = ctx.canReuseTickNodesOnResize(
+					tick,
+					ticks,
+					isLeftRight || params.config.axis_rotated,
+					tickShow
+				);
 
-				// enter selection
-				const tickEnter = tick
-					.enter()
-					.insert("g", ".domain")
-					.attr("class", "tick");
+				if (canReuseTickNodes) {
+					tickTransform(tick, scale1);
+				} else {
+					tick = tick.data(ticks, scale1);
 
-				// MEMO: No exit transition. The reason is this transition affects max tick width calculation because old tick will be included in the ticks.
-				const tickExit = tick.exit().remove();
+					// enter selection
+					const tickEnter = tick
+						.enter()
+						.insert("g", ".domain")
+						.attr("class", "tick");
 
-				// enter + update selection
-				tick = tickEnter.merge(tick);
+					// MEMO: No exit transition. The reason is this transition affects max tick width calculation because old tick will be included in the ticks.
+					const tickExit = tick.exit().remove();
 
-				tickShow.tick && tickEnter.append("line");
-				tickShow.text && tickEnter.append("text");
+					// enter + update selection
+					tick = tickEnter.merge(tick);
 
-				const tickText = tick.select("text");
-				const counts: number[] = [];
-				let sizeFor1Char = {w: 0, h: 0};
+					tickShow.tick && tickEnter.append("line");
+					tickShow.text && tickEnter.append("text");
 
-				if (isFunction(evalTextSize)) {
-					// set evalTextSize to dummy axis element to be used in .getMaxTickSize()
-					sizeFor1Char = evalTextSize.bind(ctx.params.owner.api)(tickText.node(), id);
+					const hasTickChange = !tickEnter.empty() || !tickExit.empty();
+					const reuseTickText = tickShow.text && !hasTickChange &&
+						ctx.canReuseTickTextOnResize(isLeftRight || params.config.axis_rotated);
+					let sizeFor1Char = {w: 0, h: 0};
+					let textUpdate = tick.selectAll("text.__bb-empty");
 
-					if (this.classList.contains($COMMON.dummy)) {
-						this.sizeFor1Char = sizeFor1Char;
-					}
-				}
+					if (tickShow.text && !reuseTickText) {
+						const tickText = tick.select("text");
+						const counts: number[] = [];
 
-				if (!sizeFor1Char || sizeFor1Char.w === 0 || sizeFor1Char.h === 0) {
-					sizeFor1Char = ctx.helper.getSizeFor1Char(orient, tickText, !!evalTextSize);
-				}
+						textUpdate = tickText;
 
-				let tspan: d3Selection = tickText
-					.selectAll("tspan")
-					.data((d, index) => {
-						let split;
+						if (isFunction(evalTextSize)) {
+							// set evalTextSize to dummy axis element to be used in .getMaxTickSize()
+							sizeFor1Char = evalTextSize.bind(ctx.params.owner.api)(tickText.node(),
+								id);
 
-						if (params.tickMultiline) {
-							split = splitTickText(d, scale1, ticks, isLeftRight, sizeFor1Char.w);
-						} else {
-							const formatted = helper.textFormatted(d);
-
-							split = isArray(formatted) ? formatted.concat() : [formatted];
-						}
-
-						counts[index] = split.length;
-
-						return split.map(splitted => ({index, splitted}));
-					});
-
-				tspan.exit().remove();
-
-				tspan = tspan
-					.enter()
-					.append("tspan")
-					.merge(tspan)
-					.text(d => d.splitted);
-
-				// set <tspan>'s position
-				tspan
-					.attr("x", isTopBottom ? 0 : tickLength * sign)
-					.attr("dx", (() => {
-						let dx = 0;
-
-						if (/(top|bottom)/.test(orient) && rotate) {
-							dx = 8 * Math.sin(Math.PI * (rotate / 180)) *
-								(orient === "top" ? -1 : 1);
-						}
-
-						return dx + (tickTextPos.x || 0);
-					})())
-					.attr("dy", (d, i) => {
-						const defValue = ".71em";
-						let dy: number | string = 0;
-
-						if (orient !== "top") {
-							dy = sizeFor1Char.h;
-
-							if (i === 0) {
-								dy = isLeftRight ?
-									-((counts[d.index] - 1) * (sizeFor1Char.h / 2) - 3) :
-									(tickTextPos.y === 0 ? defValue : 0);
+							if (this.classList.contains($COMMON.dummy)) {
+								this.sizeFor1Char = sizeFor1Char;
 							}
 						}
 
-						return isNumber(dy) && tickTextPos.y ? dy + tickTextPos.y : dy || defValue;
-					});
+						if (!sizeFor1Char || sizeFor1Char.w === 0 || sizeFor1Char.h === 0) {
+							sizeFor1Char = ctx.helper.getSizeFor1Char(orient, tickText,
+								!!evalTextSize);
+						}
 
-				const lineUpdate = tick.select("line");
-				const textUpdate = tick.select("text");
+						let tspan: d3Selection = tickText
+							.selectAll("tspan")
+							.data((d, index) => {
+								let split;
 
-				tickEnter.select("line").attr(`${axisPx}2`, innerTickSize * sign);
-				tickEnter.select("text").attr(axisPx, tickLength * sign);
+								if (params.tickMultiline) {
+									split = splitTickText(d, scale1, ticks, isLeftRight,
+										sizeFor1Char.w);
+								} else {
+									const formatted = helper.textFormatted(d);
 
-				ctx.setTickLineTextPosition(lineUpdate, textUpdate, sizeFor1Char);
+									split = isArray(formatted) ? formatted.concat() : [formatted];
+								}
 
-				// Append <title> for tooltip display
-				if (params.tickTitle) {
-					const title = textUpdate.select("title");
+								counts[index] = split.length;
 
-					(title.empty() ? textUpdate.append("title") : title)
-						.text(index => params.tickTitle[index]);
+								return split.map(splitted => ({index, splitted}));
+							});
+
+						tspan.exit().remove();
+
+						tspan = tspan
+							.enter()
+							.append("tspan")
+							.merge(tspan)
+							.text(d => d.splitted);
+
+						// set <tspan>'s position
+						tspan
+							.attr("x", isTopBottom ? 0 : tickLength * sign)
+							.attr("dx", (() => {
+								let dx = 0;
+
+								if (/(top|bottom)/.test(orient) && rotate) {
+									dx = 8 * Math.sin(Math.PI * (rotate / 180)) *
+										(orient === "top" ? -1 : 1);
+								}
+
+								return dx + (tickTextPos.x || 0);
+							})())
+							.attr("dy", (d, i) => {
+								const defValue = ".71em";
+								let dy: number | string = 0;
+
+								if (orient !== "top") {
+									dy = sizeFor1Char.h;
+
+									if (i === 0) {
+										dy = isLeftRight ?
+											-((counts[d.index] - 1) * (sizeFor1Char.h / 2) - 3) :
+											(tickTextPos.y === 0 ? defValue : 0);
+									}
+								}
+
+								return isNumber(dy) && tickTextPos.y ?
+									dy + tickTextPos.y :
+									dy || defValue;
+							});
+					}
+
+					const lineUpdate = tick.select("line");
+
+					tickEnter.select("line").attr(`${axisPx}2`, innerTickSize * sign);
+					tickEnter.select("text").attr(axisPx, tickLength * sign);
+
+					ctx.setTickLineTextPosition(lineUpdate, textUpdate, sizeFor1Char);
+
+					// Append <title> for tooltip display
+					if (params.tickTitle) {
+						const title = textUpdate.select("title");
+
+						(title.empty() ? textUpdate.append("title") : title)
+							.text(index => params.tickTitle[index]);
+					}
+
+					if (scale1.bandwidth) {
+						const x = scale1;
+						const dx = x.bandwidth() / 2;
+
+						scale0 = d => x(d) + dx;
+						scale1 = scale0;
+					} else if (scale0.bandwidth) {
+						scale0 = scale1;
+					} else {
+						tickTransform(tickExit, scale1);
+					}
+
+					// when .flow(), it should follow flow's transition config
+					// otherwise make to use ChartInternals.$T()
+					tick = params.owner.state.flowing ?
+						helper.transitionise(tick) :
+						params.owner.$T(tick);
+
+					tickTransform(tickEnter, scale0);
+					tickTransform(tick.style("opacity", null), scale1);
 				}
-
-				if (scale1.bandwidth) {
-					const x = scale1;
-					const dx = x.bandwidth() / 2;
-
-					scale0 = d => x(d) + dx;
-					scale1 = scale0;
-				} else if (scale0.bandwidth) {
-					scale0 = scale1;
-				} else {
-					tickTransform(tickExit, scale1);
-				}
-
-				// when .flow(), it should follow flow's transition config
-				// otherwise make to use ChartInternals.$T()
-				tick = params.owner.state.flowing ?
-					helper.transitionise(tick) :
-					params.owner.$T(tick);
-
-				tickTransform(tickEnter, scale0);
-				tickTransform(tick.style("opacity", null), scale1);
 			}
 		});
 
@@ -360,7 +434,6 @@ export default class AxisRenderer {
 				textUpdate
 					.attr("x", 0)
 					.attr("y", yForText(rotate))
-					.style("text-anchor", textAnchorForText(rotate))
 					.style("text-anchor", (d, i, {length}) => {
 						if (!isRotated && i === 0 && (inner === true || inner.first)) {
 							return "start";

--- a/src/canvas/CanvasEngine.ts
+++ b/src/canvas/CanvasEngine.ts
@@ -16,6 +16,7 @@ export default class CanvasEngine {
 	private dpr = 1;
 	private frame: HTMLCanvasElement | null = null;
 	private frameCtx: CanvasRenderingContext2D | null = null;
+	private frameValid = false;
 
 	/**
 	 * Create and attach the canvas element.
@@ -56,6 +57,7 @@ export default class CanvasEngine {
 		this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
 		this.frame = null;
 		this.frameCtx = null;
+		this.frameValid = false;
 	}
 
 	/**
@@ -63,7 +65,7 @@ export default class CanvasEngine {
 	 * @private
 	 */
 	clearOverlay(): void {
-		this.restoreFrame();
+		this.frameValid && this.restoreFrame();
 	}
 
 	/**
@@ -73,8 +75,15 @@ export default class CanvasEngine {
 	 */
 	withOverlay(draw: (ctx: CanvasRenderingContext2D) => void): void {
 		const {ctx} = this;
+		const hasFrame = this.frameValid;
 
-		this.clearOverlay();
+		if (hasFrame) {
+			this.clearOverlay();
+		} else {
+			// Copy the clean frame only when an overlay is actually requested.
+			// Large filled charts make eager full-canvas copies expensive.
+			this.captureFrame();
+		}
 		ctx.save();
 		ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
 		try {
@@ -93,6 +102,7 @@ export default class CanvasEngine {
 	beginFrame(w: number, h: number): void {
 		const {ctx} = this;
 
+		this.frameValid = false;
 		ctx.save();
 		ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
 		ctx.clearRect(0, 0, w, h);
@@ -104,7 +114,6 @@ export default class CanvasEngine {
 	 */
 	endFrame(): void {
 		this.ctx.restore();
-		this.captureFrame();
 	}
 
 	/**
@@ -113,6 +122,8 @@ export default class CanvasEngine {
 	 */
 	captureFrame(): void {
 		const {canvas} = this;
+
+		this.frameValid = false;
 
 		if (canvas.width && canvas.height) {
 			let {frame, frameCtx} = this;
@@ -142,6 +153,7 @@ export default class CanvasEngine {
 			}
 
 			frameCtx.drawImage(canvas, 0, 0);
+			this.frameValid = true;
 		}
 	}
 
@@ -150,7 +162,7 @@ export default class CanvasEngine {
 	 * @private
 	 */
 	restoreFrame(): void {
-		if (!this.frame || !this.frameCtx) {
+		if (!this.frameValid || !this.frame || !this.frameCtx) {
 			return;
 		}
 
@@ -172,5 +184,6 @@ export default class CanvasEngine {
 		this.canvas?.remove();
 		this.frame = null;
 		this.frameCtx = null;
+		this.frameValid = false;
 	}
 }

--- a/test/esm/canvas-spec.ts
+++ b/test/esm/canvas-spec.ts
@@ -2803,38 +2803,48 @@ describe("ESM canvas", function() {
 	});
 
 	it("should keep one canvas and restore the cached frame after hover overlays", () => {
-		generateWithOptions({
-			data: {
-				columns,
-				type: line()
-			},
-			point: {
-				focus: {
-					only: true
+		const drawImage = vi.spyOn(CanvasRenderingContext2D.prototype, "drawImage");
+
+		try {
+			generateWithOptions({
+				data: {
+					columns,
+					type: line()
+				},
+				point: {
+					focus: {
+						only: true
+					}
 				}
-			}
-		});
+			});
 
-		const {margin} = chart.internal.state;
-		const d = chart.internal.data.targets[0].values[1];
-		const canvasEl = container.querySelector(`canvas.${$CANVAS.canvas}`);
-		const before = countCanvasAlphaPixels(canvasEl);
-		const x = margin.left + chart.internal.scale.x(d.x);
-		const y = margin.top + chart.internal.scale.y(d.value);
+			const {margin} = chart.internal.state;
+			const d = chart.internal.data.targets[0].values[1];
+			const canvasEl = container.querySelector(`canvas.${$CANVAS.canvas}`);
+			const before = countCanvasAlphaPixels(canvasEl);
+			const x = margin.left + chart.internal.scale.x(d.x);
+			const y = margin.top + chart.internal.scale.y(d.value);
 
-		canvasEl.dispatchEvent(new MouseEvent("mousemove", {
-			bubbles: true,
-			clientX: x,
-			clientY: y
-		}));
+			expect(drawImage).not.toHaveBeenCalled();
 
-		expect(container.querySelector(`canvas.${$CANVAS.overlay}`)).to.be.null;
-		expect(container.querySelectorAll("canvas")).to.have.length(1);
-		expect(countCanvasAlphaPixels(canvasEl)).to.be.greaterThan(before);
+			canvasEl.dispatchEvent(new MouseEvent("mousemove", {
+				bubbles: true,
+				clientX: x,
+				clientY: y
+			}));
 
-		canvasEl.dispatchEvent(new MouseEvent("mouseout", {bubbles: true}));
+			expect(container.querySelector(`canvas.${$CANVAS.overlay}`)).to.be.null;
+			expect(container.querySelectorAll("canvas")).to.have.length(1);
+			expect(countCanvasAlphaPixels(canvasEl)).to.be.greaterThan(before);
+			expect(drawImage).toHaveBeenCalledTimes(1);
 
-		expect(countCanvasAlphaPixels(canvasEl)).to.be.equal(before);
+			canvasEl.dispatchEvent(new MouseEvent("mouseout", {bubbles: true}));
+
+			expect(countCanvasAlphaPixels(canvasEl)).to.be.equal(before);
+			expect(drawImage).toHaveBeenCalledTimes(2);
+		} finally {
+			drawImage.mockRestore();
+		}
 	});
 
 	it("should cull dense canvas x ticks", () => {

--- a/test/internals/axis-resize-spec.ts
+++ b/test/internals/axis-resize-spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+// @ts-nocheck
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {$AXIS} from "../../src/config/classes";
+import util from "../assets/util";
+
+describe("axis resize", () => {
+	let chart;
+
+	afterEach(() => {
+		chart?.destroy();
+		chart = null;
+	});
+
+	const generate = axis => util.generate({
+		data: {
+			columns: [
+				["data1", 30, 200, 100, 400, 150, 250]
+			]
+		},
+		axis: {
+			x: {
+				tick: {
+					culling: false,
+					show: false,
+					...axis?.x?.tick
+				}
+			}
+		},
+		transition: {
+			duration: 0
+		}
+	});
+
+	it("reuses unchanged x tick text on resize", () => {
+		chart = generate();
+		const beforeTicks = chart.internal.$el.axis.x.selectAll(".tick").nodes();
+		const beforeTransform = beforeTicks[1].getAttribute("transform");
+
+		const descriptor = Object.getOwnPropertyDescriptor(Node.prototype, "textContent");
+		const setTickText = vi.fn();
+
+		Object.defineProperty(Node.prototype, "textContent", {
+			configurable: true,
+			get: descriptor.get,
+			set(value) {
+				if (this.nodeName === "tspan" && this.closest?.(`.${$AXIS.axisX}`)) {
+					setTickText(value);
+				}
+
+				return descriptor.set.call(this, value);
+			}
+		});
+
+		try {
+			chart.resize({width: 500, height: 360});
+		} finally {
+			Object.defineProperty(Node.prototype, "textContent", descriptor);
+		}
+
+		const afterTicks = chart.internal.$el.axis.x.selectAll(".tick").nodes();
+
+		expect(afterTicks).to.deep.equal(beforeTicks);
+		expect(afterTicks[1].getAttribute("transform")).not.to.be.equal(beforeTransform);
+		expect(setTickText).not.toHaveBeenCalled();
+	});
+
+	it("keeps custom x tick formatter active on resize", () => {
+		const format = vi.fn(v => `tick-${v}`);
+
+		chart = generate({
+			x: {
+				tick: {
+					format
+				}
+			}
+		});
+		format.mockClear();
+
+		chart.resize({width: 500, height: 360});
+
+		expect(format).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
Reuse unchanged SVG tick nodes and tick text during resize-only redraws.
Capture canvas clean frames lazily for overlay restores.
Update the v4 benchmark snapshot and add resize regression coverage.