### PR TITLE
fix(canvas): align candlestick labels with wick endpoints

### DIFF
--- a/src/canvas/CanvasRenderer.ts
+++ b/src/canvas/CanvasRenderer.ts
@@ -2175,20 +2175,21 @@ export default class CanvasRenderer {
 								continue;
 							}
 
-							const {body} = geometry;
+							const {wickEnd, wickStart} = geometry;
+							const isInverted = $$.config[`axis_${$$.axis?.getId(d.id)}_inverted`];
 
 							x = $$.config.axis_rotated ?
-								(isUp ? body.x + body.w + 4 : body.x - 4) :
-								body.x + body.w / 2;
+								(isUp ? wickEnd[0] + 4 : wickStart[0] - 4) :
+								wickStart[0];
 							y = $$.config.axis_rotated ?
-								body.y + body.h / 2 :
-								(isUp ? body.y - 4 : body.y + body.h + 13);
+								wickStart[1] + 3 :
+								(isUp ? wickEnd[1] - 3 : wickStart[1] + 12);
+							!$$.config.axis_rotated && isInverted &&
+								(y += 15 * (isUp ? 1 : -1));
 							ctx.textAlign = $$.config.axis_rotated ?
 								(isUp ? "left" : "right") :
 								"center";
-							ctx.textBaseline = $$.config.axis_rotated ?
-								"middle" :
-								(isUp ? "bottom" : "top");
+							ctx.textBaseline = "alphabetic";
 						} else if (cx && cy) {
 							({x, y} = getShapePoint(shape.pos, d, d.index));
 							({x, y} = getPointLabelAnchor($$, ctx, d, x, y));

--- a/test/esm/canvas-spec.ts
+++ b/test/esm/canvas-spec.ts
@@ -3459,6 +3459,69 @@ describe("ESM canvas", function() {
 		fillText.mockRestore();
 	});
 
+	it("should position canvas candlestick data labels from wick endpoints", () => {
+		const records: Array<{
+			text: string,
+			textAlign: CanvasTextAlign,
+			textBaseline: CanvasTextBaseline,
+			x: number,
+			y: number
+		}> = [];
+		const fillText = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText")
+			.mockImplementation(function(this: CanvasRenderingContext2D, text: string) {
+				const transform = this.getTransform();
+
+				records.push({
+					text: String(text),
+					textAlign: this.textAlign,
+					textBaseline: this.textBaseline,
+					x: transform.e,
+					y: transform.f
+				});
+			});
+
+		try {
+			generateWithOptions({
+				data: {
+					columns: [
+						["data1",
+							[1300, 1369, 1200, 1339],
+							[1348, 1371, 1271, 1320]
+						]
+					],
+					type: candlestick(),
+					labels: {
+						format: (value, id, index) => `${id}:${index}:${value}`
+					}
+				}
+			});
+
+			const shape = chart.internal.state.canvasShape || chart.internal.getDrawShape();
+			const getPoints = chart.internal.generateGetCandlestickPoints(
+				shape.indices[TYPE.CANDLESTICK],
+				false
+			);
+			const {margin} = chart.internal.state;
+			const up = chart.internal.data.targets[0].values[0];
+			const down = chart.internal.data.targets[0].values[1];
+			const upPoints = getPoints(up, up.index);
+			const downPoints = getPoints(down, down.index);
+			const upLabel = records.find(({text}) => text === "data1:0:1339");
+			const downLabel = records.find(({text}) => text === "data1:1:1320");
+
+			expect(upLabel?.textAlign).to.be.equal("center");
+			expect(upLabel?.textBaseline).to.be.equal("alphabetic");
+			expect(upLabel?.x).to.be.closeTo(margin.left + upPoints[2][0], 0.1);
+			expect(upLabel?.y).to.be.closeTo(margin.top + upPoints[2][2] - 3, 0.1);
+			expect(downLabel?.textAlign).to.be.equal("center");
+			expect(downLabel?.textBaseline).to.be.equal("alphabetic");
+			expect(downLabel?.x).to.be.closeTo(margin.left + downPoints[2][0], 0.1);
+			expect(downLabel?.y).to.be.closeTo(margin.top + downPoints[2][1] + 12, 0.1);
+		} finally {
+			fillText.mockRestore();
+		}
+	});
+
 	it("should render category bubble ticks and centered labels on canvas", () => {
 		const records: Array<{
 			text: string,


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
Fix candlestick data label position in canvas rendering