### PR TITLE
fix(tooltip): fix focus point and tooltip for single x-axis

### DIFF
--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -450,15 +450,15 @@ export default {
 					.classed($COMMON.EXPANDED, true)
 					.style("cursor", isSelectable ? "pointer" : null);
 
-				$$.showTooltip(closestData, context);
-				$$.showGridFocus?.(closestData);
+				$$.showTooltip([closest], context);
+				$$.showGridFocus?.([closest]);
 				$$.unexpandCircles?.();
 
 				$$.setExpand(index, closest.id, true);
 
 				if (
 					isSelectionEnabled &&
-					(isSelectionGrouped || isSelectable?.bind($$.api)(closestData))
+					(isSelectionGrouped || isSelectable?.bind($$.api)(closest))
 				) {
 					context.style.cursor = "pointer";
 				}

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -380,7 +380,7 @@ export default {
 	 */
 	selectRectForSingle(context: SVGRectElement, index: number): void {
 		const $$ = this;
-		const {config, $el: {main, circle}} = $$;
+		const {config, state, $el: {main, circle}} = $$;
 		const isSelectionEnabled = config.data_selection_enabled;
 		const isSelectionGrouped = config.data_selection_grouped;
 		const isSelectable = config.data_selection_isselectable;
@@ -403,39 +403,71 @@ export default {
 				false
 			);
 
-		const shapeAtIndex = main.selectAll(`.${$SHAPE.shape}-${index}`)
-			.classed($COMMON.EXPANDED, true)
-			.style("cursor", isSelectable ? "pointer" : null)
-			.filter(function(d) {
-				return $$.isWithinShape(this, d);
+		if (isTooltipGrouped) {
+			const shapeAtIndex = main.selectAll(`.${$SHAPE.shape}-${index}`)
+				.classed($COMMON.EXPANDED, true)
+				.style("cursor", isSelectable ? "pointer" : null)
+				.filter(function(d) {
+					return $$.isWithinShape(this, d);
+				});
+
+			shapeAtIndex
+				.call(selected => {
+					const d = selected.data();
+
+					if (
+						isSelectionEnabled &&
+						(isSelectionGrouped || isSelectable?.bind($$.api)(d))
+					) {
+						context.style.cursor = "pointer";
+					}
+				});
+		} else {
+			const mouse = getPointer(state.event, context);
+			const closestData = selectedData.filter(d => {
+				if ($$.isTargetToShow(d.id)) {
+					const dist = $$.dist(d, mouse);
+					return dist < $$.getPointSensitivity(d);
+				}
+				return false;
 			});
 
-		if (shapeAtIndex.empty() && !isTooltipGrouped && config.interaction_onout) {
-			$$.hideGridFocus?.();
-			$$.hideTooltip();
+			if (closestData.length > 0) {
+				let closest = closestData[0];
+				let minDist = $$.dist(closest, mouse);
 
-			!isSelectionGrouped && $$.setExpand(index);
-		}
+				for (let i = 1; i < closestData.length; i++) {
+					const d = closestData[i];
+					const dist = $$.dist(d, mouse);
 
-		shapeAtIndex
-			.call(selected => {
-				const d = selected.data();
+					if (dist < minDist) {
+						minDist = dist;
+						closest = d;
+					}
+				}
+
+				main.selectAll(`.${$SHAPE.shape}-${index}`)
+					.classed($COMMON.EXPANDED, true)
+					.style("cursor", isSelectable ? "pointer" : null);
+
+				$$.showTooltip(closestData, context);
+				$$.showGridFocus?.(closestData);
+				$$.unexpandCircles?.();
+
+				$$.setExpand(index, closest.id, true);
 
 				if (
 					isSelectionEnabled &&
-					(isSelectionGrouped || isSelectable?.bind($$.api)(d))
+					(isSelectionGrouped || isSelectable?.bind($$.api)(closestData))
 				) {
 					context.style.cursor = "pointer";
 				}
-
-				if (!isTooltipGrouped) {
-					$$.showTooltip(d, context);
-					$$.showGridFocus?.(d);
-					$$.unexpandCircles?.();
-
-					selected.each(d => $$.setExpand(index, d.id));
-				}
-			});
+			} else if (config.interaction_onout) {
+				$$.hideGridFocus?.();
+				$$.hideTooltip();
+				!isSelectionGrouped && $$.setExpand(index);
+			}
+		}
 	},
 
 	/**

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -403,26 +403,36 @@ export default {
 				false
 			);
 
-		if (isTooltipGrouped) {
-			const shapeAtIndex = main.selectAll(`.${$SHAPE.shape}-${index}`)
-				.classed($COMMON.EXPANDED, true)
-				.style("cursor", isSelectable ? "pointer" : null)
-				.filter(function(d) {
-					return $$.isWithinShape(this, d);
-				});
+		const shapeAtIndex = main.selectAll(`.${$SHAPE.shape}-${index}`)
+			.classed($COMMON.EXPANDED, true)
+			.style("cursor", isSelectable ? "pointer" : null)
+			.filter(function(d) {
+				return $$.isWithinShape(this, d);
+			});
 
-			shapeAtIndex
-				.call(selected => {
-					const d = selected.data();
+		shapeAtIndex
+			.call(selected => {
+				const d = selected.data();
 
-					if (
-						isSelectionEnabled &&
-						(isSelectionGrouped || isSelectable?.bind($$.api)(d))
-					) {
-						context.style.cursor = "pointer";
-					}
-				});
-		} else {
+				if (
+					isSelectionEnabled &&
+					(isSelectionGrouped || isSelectable?.bind($$.api)(d))
+				) {
+					context.style.cursor = "pointer";
+				}
+
+				if (!isTooltipGrouped) {
+					$$.showTooltip(d, context);
+					$$.showGridFocus?.(d);
+					$$.unexpandCircles?.();
+
+					selected.each(d => $$.setExpand(index, d.id));
+				}
+			});
+
+		if (!isTooltipGrouped && shapeAtIndex.empty()) {
+			// `point.focus.only` can render focus points away from the hovered data point.
+			// Fall back to data distance so ungrouped tooltips can still focus the intended point.
 			const mouse = getPointer(state.event, context);
 			const closestData = selectedData.filter(d => {
 				if ($$.isTargetToShow(d.id)) {
@@ -450,8 +460,8 @@ export default {
 					.classed($COMMON.EXPANDED, true)
 					.style("cursor", isSelectable ? "pointer" : null);
 
-				$$.showTooltip([closest], context);
-				$$.showGridFocus?.([closest]);
+				$$.showTooltip(closestData, context);
+				$$.showGridFocus?.(closestData);
 				$$.unexpandCircles?.();
 
 				$$.setExpand(index, closest.id, true);
@@ -465,6 +475,7 @@ export default {
 			} else if (config.interaction_onout) {
 				$$.hideGridFocus?.();
 				$$.hideTooltip();
+
 				!isSelectionGrouped && $$.setExpand(index);
 			}
 		}

--- a/test/internals/tooltip-spec.ts
+++ b/test/internals/tooltip-spec.ts
@@ -11,7 +11,7 @@ import {
 	namespaces as d3Namespaces
 } from "d3-selection";
 import util from "../assets/util";
-import {$COMMON, $EVENT, $TOOLTIP} from "../../src/config/classes";
+import {$COMMON, $TOOLTIP} from "../../src/config/classes";
 import {isNumber, isUndefined, isString} from "../../src/module/util";
 
 describe("TOOLTIP", function() {
@@ -1685,6 +1685,11 @@ describe("TOOLTIP", function() {
 					},
 					tooltip: {
 						grouped: false
+					},
+					point: {
+						focus: {
+							only: true
+						}
 					}
 				};
 			});

--- a/test/internals/tooltip-spec.ts
+++ b/test/internals/tooltip-spec.ts
@@ -11,7 +11,7 @@ import {
 	namespaces as d3Namespaces
 } from "d3-selection";
 import util from "../assets/util";
-import {$TOOLTIP} from "../../src/config/classes";
+import {$COMMON, $EVENT, $TOOLTIP} from "../../src/config/classes";
 import {isNumber, isUndefined, isString} from "../../src/module/util";
 
 describe("TOOLTIP", function() {
@@ -1671,6 +1671,40 @@ describe("TOOLTIP", function() {
 				expect(tooltipHtml).to.not.include("<iframe");
 				expect(tooltipHtml).to.include("&lt;iframe");
 				expect(tooltipHtml).to.include("Title");
+			});
+		});
+
+		describe("tooltip.grouped = false with single X-axis focus", () => {
+			beforeAll(() => {
+				args = {
+					data: {
+						columns: [
+							["data1", 30, 200, 100],
+							["data2", 130, 100, 140]
+						]
+					},
+					tooltip: {
+						grouped: false
+					}
+				};
+			});
+
+			it("should show tooltip and focus point when tooltip.show is called", () => {
+				chart.tooltip.show({
+					data: {
+						index: 1,
+						id: "data2",
+						value: 100
+					}
+				});
+
+				expect(chart.$.tooltip.selectAll(".name").size()).to.be.equal(1);
+				expect(chart.$.tooltip.select(".name").text()).to.be.equal("data2");
+				expect(+chart.$.tooltip.select(".value").text()).to.be.equal(100);
+
+				const expandedPoints = chart.$.svg.selectAll(`.${$COMMON.EXPANDED}`);
+				expect(expandedPoints.size()).to.be.equal(1);
+				expect(expandedPoints.datum().id).to.be.equal("data2");
 			});
 		});
 	});

--- a/test/shape/bar-spec.ts
+++ b/test/shape/bar-spec.ts
@@ -1518,7 +1518,7 @@ describe("SHAPE BAR", () => {
 				data: {x: 1, value: 3}
 			});
 
-			expect(chart.$.tooltip.selectAll(".name").size()).to.be.equal(2);
+			expect(chart.$.tooltip.selectAll(".name").size()).to.be.equal(1);
 		});
 
 		it("set options point.sensitivity=3", () => {

--- a/test/shape/bar-spec.ts
+++ b/test/shape/bar-spec.ts
@@ -1518,7 +1518,7 @@ describe("SHAPE BAR", () => {
 				data: {x: 1, value: 3}
 			});
 
-			expect(chart.$.tooltip.selectAll(".name").size()).to.be.equal(1);
+			expect(chart.$.tooltip.selectAll(".name").size()).to.be.equal(2);
 		});
 
 		it("set options point.sensitivity=3", () => {


### PR DESCRIPTION
Fixes an issue where showing points on focus does not work when using a single x-axis with tooltip.grouped = false. See #3968 for more details.