### PR TITLE
docs(gauge): clarify enforceMinMax limitation for stacked layout

### DIFF
--- a/src/config/Options/shape/gauge.ts
+++ b/src/config/Options/shape/gauge.ts
@@ -233,6 +233,8 @@ export default {
 		} | null)
 		| undefined
 	>undefined,
+	// NOTE: enforceMinMax currently applies only to unstacked/multi gauges. Does not support stacked categories.
+
 	gauge_enforceMinMax: false,
 	gauge_min: 0,
 	gauge_max: 100,


### PR DESCRIPTION
Added a clarifying inline documentation note for enforceMinMax under the gauge shape options, explicitly highlighting that this option currently only applies to unstacked or multi-gauge configurations and does not function when gauges are configured as stacked.
Closes #3918
