### PR TITLE
feat(plugin-tableview): validate constructor options and throw on invalid input

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4535,9 +4535,13 @@ d3.select(".chart_area")
 				},
 				_plugins: [{
 					tableview: {
-						title: "My Yearly Data List",
+						title: "My Yearly Taxes List",
 						categoryTitle: "Year",
-						style: true
+						style: true,
+						numberFormat: function(v) {
+							// optional, for example this formats number to German locale with 2 decimal places and adds Euro sign
+							return isNaN(v) ? v : v.toLocaleString('de-DE', {minimumFractionDigits: 2, maximumFractionDigits: 2}) + " €";
+						}
 					}
 				}]
 			}

--- a/src/Plugin/tableview/index.ts
+++ b/src/Plugin/tableview/index.ts
@@ -2,10 +2,71 @@
  * Copyright (c) 2021 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {isNumber, tplProcess} from "../../module/util";
+import {
+	isArray,
+	isBoolean,
+	isFunction,
+	isNumber,
+	isObjectType,
+	isString,
+	tplProcess
+} from "../../module/util";
 import Plugin from "../Plugin";
 import {defaultStyle, tpl} from "./const";
 import Options from "./Options";
+
+export interface TableViewOptions {
+	selector?: string;
+	categoryTitle?: string;
+	categoryFormat?: (v: Date | number | string) => string;
+	class?: string;
+	style?: boolean;
+	title?: string;
+	updateOnToggle?: boolean;
+	nullString?: string;
+	numberFormat?: (v: number | string) => string;
+}
+
+/**
+ * Expected value type for each supported option, used to validate user input.
+ * Acts as the single source of truth for the set of allowed option keys.
+ * @private
+ */
+const optionValidators: { [key in keyof Required<TableViewOptions>]: (v: unknown) => boolean } = {
+	selector: isString,
+	categoryTitle: isString,
+	categoryFormat: isFunction,
+	class: isString,
+	style: isBoolean,
+	title: isString,
+	updateOnToggle: isBoolean,
+	nullString: isString,
+	numberFormat: isFunction
+};
+
+/**
+ * Check whether the given value is a valid TableView options object.
+ * An empty object is valid (every option falls back to its default) and
+ * unknown keys are ignored, so only a known option holding a value of the
+ * wrong type makes the object invalid. An explicit `undefined` value is
+ * allowed so a consumer can opt out of an option and let it fall back to
+ * the default.
+ * @param {unknown} options Value given to the TableView constructor
+ * @returns {boolean} `true` when `options` is a valid TableView options object
+ * @private
+ */
+export function isValidTableViewOptions(options: unknown): options is TableViewOptions {
+	if (!isObjectType(options) || isArray(options) || options === null) {
+		return false;
+	}
+
+	return Object.entries(options).every(([key, value]) => {
+		const validate = optionValidators[key];
+
+		// unknown keys are ignored; known keys must match their expected type
+		return !isFunction(validate) || value === undefined || validate(value);
+	});
+}
 
 /**
  * Table view plugin.<br>
@@ -36,7 +97,18 @@ import Options from "./Options";
  *          style: true,
  *          title: "My Data List",
  *          updateOnToggle: false,
- *          nullString: "N/A"
+ *          nullString: "N/A",
+ *          numberFormat: function(v) {
+ *              // do some transformation like number formatting
+ *              // return typeof v === "number" ? v.toFixed(2) : v;
+ *              // or use d3.format
+ *              // return typeof v === "number" ? d3.format(".2f")(v) : v;
+ *              // or use Intl.NumberFormat
+ *              // return typeof v === "number" ? new Intl.NumberFormat("en-US", {minimumFractionDigits: 2, maximumFractionDigits: 2}).format(v) : v;
+ *              // or any other number formatting library
+ *              ...
+ *              return v;
+ *          }
  *        }),
  *     ]
  *  });
@@ -54,8 +126,11 @@ import Options from "./Options";
 export default class TableView extends Plugin {
 	private element;
 
-	constructor(options) {
+	constructor(options: TableViewOptions = {}) {
 		super(options);
+		if (!isValidTableViewOptions(options)) {
+			throw new Error("Invalid options for TableView plugin " + JSON.stringify(options));
+		}
 		this.config = new Options();
 
 		return this;

--- a/test/plugin/tableview/tableview-spec.ts
+++ b/test/plugin/tableview/tableview-spec.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 import {beforeEach, beforeAll, afterAll, describe, expect, it} from "vitest";
 import sinon from "sinon";
-import TableView from "../../../src/Plugin/tableview";
+import TableView, {isValidTableViewOptions} from "../../../src/Plugin/tableview";
 import {defaultStyle} from "../../../src/Plugin/tableview/const";
 import util from "../../assets/util";
 import {toArray} from "../../../src/module/util";
@@ -328,6 +328,77 @@ describe("PLUGIN: TABLE-VIEW", () => {
 					expect(v.querySelectorAll("td")[x === "2026" ? 1 : 0].textContent).to.be.equal("N/A");
 				}
 			});
+		});
+	});
+
+	describe("isValidTableViewOptions", () => {
+		it("should treat an empty object as valid (all options fall back to defaults)", () => {
+			expect(isValidTableViewOptions({})).to.be.true;
+		});
+
+		it("should accept an object with every supported option of the correct type", () => {
+			expect(isValidTableViewOptions({
+				selector: "#holder",
+				categoryTitle: "Category",
+				categoryFormat: v => `${v}`,
+				class: "my-class",
+				style: false,
+				title: "My Table",
+				updateOnToggle: true,
+				nullString: "N/A",
+				numberFormat: v => `${v}`
+			})).to.be.true;
+		});
+
+		it("should accept a partial object with a subset of supported options", () => {
+			expect(isValidTableViewOptions({title: "My Table"})).to.be.true;
+			expect(isValidTableViewOptions({style: true, nullString: "-"})).to.be.true;
+		});
+
+		it("should allow an explicit 'undefined' value for a supported option", () => {
+			expect(isValidTableViewOptions({numberFormat: undefined})).to.be.true;
+			expect(isValidTableViewOptions({selector: undefined, class: undefined})).to.be.true;
+		});
+
+		it("should ignore unknown keys", () => {
+			expect(isValidTableViewOptions({unknownOption: true})).to.be.true;
+			expect(isValidTableViewOptions({title: "ok", typoOption: 1})).to.be.true;
+		});
+
+		it("should reject a supported option holding a value of the wrong type", () => {
+			expect(isValidTableViewOptions({style: "true"})).to.be.false;
+			expect(isValidTableViewOptions({title: 123})).to.be.false;
+			expect(isValidTableViewOptions({numberFormat: "not a function"})).to.be.false;
+			expect(isValidTableViewOptions({updateOnToggle: 1})).to.be.false;
+		});
+
+		it("should reject non-object values", () => {
+			expect(isValidTableViewOptions(null)).to.be.false;
+			expect(isValidTableViewOptions(undefined)).to.be.false;
+			expect(isValidTableViewOptions("string")).to.be.false;
+			expect(isValidTableViewOptions(42)).to.be.false;
+			expect(isValidTableViewOptions(true)).to.be.false;
+		});
+
+		it("should reject arrays", () => {
+			expect(isValidTableViewOptions([])).to.be.false;
+			expect(isValidTableViewOptions(["selector"])).to.be.false;
+		});
+
+		it("constructor should throw when given invalid options", () => {
+			// supported option with a value of the wrong type
+			expect(() => new TableView({style: "true"} as any)).to.throw();
+			// non-object value
+			expect(() => new TableView("nope" as any)).to.throw();
+		});
+
+		it("constructor should not throw when given an unknown option", () => {
+			expect(() => new TableView({unknownOption: true} as any)).not.to.throw();
+		});
+
+		it("constructor should not throw for valid options", () => {
+			expect(() => new TableView()).to.not.throw();
+			expect(() => new TableView({title: "My Table"})).to.not.throw();
 		});
 	});
 


### PR DESCRIPTION
## Issue
Related to https://github.com/naver/billboard.js/issues/4140

## Details
- docs(plugin-tableview): demonstrate numberFormat usage in demo
- feat(plugin-tableview): validate constructor options and throw on invalid input


Main change is the parameter of TableView.constructor, instead of `any` type now it can be checked in compile time and in runtime. I don't know if this must be treated as a breaking change as it throws an exception if the parameter is not valid.

Another change is in demo, added an example of how to use the numberFormat parameter.