### PR TITLE
feat(canvas): support grid line class selectors

### DIFF
--- a/CANVAS_THEME_SELECTORS.md
+++ b/CANVAS_THEME_SELECTORS.md
@@ -91,12 +91,22 @@ Font longhands are `font-size`, `font-family`, `font-style`, `font-variant`, `fo
 | `.bb-xgrid` | `stroke`, `stroke-width`, `stroke-dasharray` | X grid lines |
 | `.bb-ygrid` | `stroke`, `stroke-width`, `stroke-dasharray` | Y grid lines |
 | `.bb-grid text` | `fill`, `font`, font longhands | Optional grid labels |
+| `.<grid-line-class> line` | `stroke`, `stroke-width`, `stroke-dasharray` | Optional x/y grid line with matching `grid.x.lines[].class` or `grid.y.lines[].class` |
+| `.bb-xgrid-line.<grid-line-class> line` | `stroke`, `stroke-width`, `stroke-dasharray` | Optional x grid line with matching `grid.x.lines[].class` |
+| `.bb-ygrid-line.<grid-line-class> line` | `stroke`, `stroke-width`, `stroke-dasharray` | Optional y grid line with matching `grid.y.lines[].class` |
+| `.<grid-line-class> text` | `fill`, `font`, font longhands | Optional x/y grid label with matching `grid.x.lines[].class` or `grid.y.lines[].class` |
+| `.bb-xgrid-line.<grid-line-class> text` | `fill`, `font`, font longhands | Optional x grid label with matching `grid.x.lines[].class` |
+| `.bb-ygrid-line.<grid-line-class> text` | `fill`, `font`, font longhands | Optional y grid label with matching `grid.y.lines[].class` |
 | `.bb-xgrid-focus line` | `stroke`, `stroke-width`, `stroke-dasharray` | Focus grid line |
 | `.bb-grid .bb-xgrid-focus line` | `stroke`, `stroke-width`, `stroke-dasharray` | Focus grid line |
 | `.bb-grid .bb-xgrid-focus` | `stroke`, `stroke-width`, `stroke-dasharray` | Focus grid line |
 | `.bb-region rect` | `fill`, `opacity`, `fill-opacity` | Regions |
 | `.bb-region` | `fill`, `opacity`, `fill-opacity` | Regions |
 | `.bb-region text` | `fill`, `font`, font longhands | Region labels |
+
+`<grid-line-class>` means a class name supplied through `grid.x.lines[].class` or
+`grid.y.lines[].class`. These selectors are matched against optional grid lines only. They do not
+style generated tick grid lines from `grid.x.show`, `grid.y.show`, or `grid.y.ticks`.
 
 ### Shapes
 
@@ -165,6 +175,12 @@ bb.generate({
         ".bb-grid line": {
           stroke: "#ddd",
           "stroke-width": 1
+        },
+        ".iaq-good line": {
+          stroke: "green"
+        },
+        ".iaq-bad line": {
+          stroke: "red"
         }
       },
       grid: {

--- a/src/canvas/CanvasAxisRenderer.ts
+++ b/src/canvas/CanvasAxisRenderer.ts
@@ -23,11 +23,12 @@ import {
 	type YAxisId
 } from "./axisTicks";
 import CanvasEngine from "./CanvasEngine";
-import CanvasPainter, {CanvasRect} from "./CanvasPainter";
-import CanvasTheme from "./CanvasTheme";
+import CanvasPainter, {CanvasRect, type CanvasStyle} from "./CanvasPainter";
+import CanvasTheme, {type CanvasGridLineThemeStyle} from "./CanvasTheme";
 import {getFontSize} from "./util";
 
 type GridLine = Partial<GridLineOptions>;
+type GridAxis = "x" | "y";
 type AdditionalAxisOptions = {
 	scale: any,
 	ticks: AxisTickValue[],
@@ -58,6 +59,37 @@ function getXTickTextDirection(isRotated: boolean): number {
  */
 function getYTickTextDirection(isRotated: boolean, isY2: boolean): number {
 	return isRotated ? (isY2 ? -1 : 1) : (isY2 ? 1 : -1);
+}
+
+/**
+ * Convert resolved grid line style to painter line style.
+ * @param {object} style Grid line style
+ * @returns {object|undefined} Canvas line style
+ * @private
+ */
+function getGridLineCanvasStyle(style?: CanvasGridLineThemeStyle): CanvasStyle | undefined {
+	return style ?
+		{
+			stroke: style.lineColor,
+			lineWidth: style.lineWidth,
+			lineDash: style.dashArray
+		} :
+		undefined;
+}
+
+/**
+ * Convert resolved grid text style to painter text style.
+ * @param {object} style Grid text style
+ * @returns {object|undefined} Canvas text style
+ * @private
+ */
+function getGridTextCanvasStyle(style?: CanvasGridLineThemeStyle): CanvasStyle | undefined {
+	return style ?
+		{
+			fill: style.labelColor,
+			font: style.labelFont
+		} :
+		undefined;
 }
 
 /**
@@ -1150,16 +1182,32 @@ export default class CanvasAxisRenderer {
 				text: string | undefined,
 				x: number,
 				y: number,
-				rotated = false
+				rotated = false,
+				style?: CanvasStyle
 			): void => {
 				if (!text) {
 					return;
 				}
 
 				painter.text(text, x, y, {
+					...style,
 					angle: rotated ? -90 : 0
 				});
 			};
+
+			const drawLine = (
+				line: GridLine,
+				axisId: GridAxis,
+				draw: () => void
+			): void => {
+				const style = getGridLineCanvasStyle(
+					this.theme.getGridLineStyle(axisId, line, "line")
+				);
+
+				painter.strokePath(draw, style);
+			};
+			const getTextStyle = (axisId: GridAxis, line: GridLine): CanvasStyle | undefined =>
+				getGridTextCanvasStyle(this.theme.getGridLineStyle(axisId, line, "text"));
 
 			const drawXLine = (line: GridLine): void => {
 				if (line.value === undefined || !scale.x) {
@@ -1175,7 +1223,7 @@ export default class CanvasAxisRenderer {
 				if (isRotated) {
 					const y = margin.top + pos;
 
-					painter.strokePath(() => {
+					drawLine(line, "x", () => {
 						painter.traceLine(x1, y, x2, y);
 					});
 					ctx.textAlign = line.position === "start" ?
@@ -1184,12 +1232,14 @@ export default class CanvasAxisRenderer {
 					drawLabel(
 						line.text,
 						getLineTextPosition(line.position, x1, x2),
-						y - 5
+						y - 5,
+						false,
+						getTextStyle("x", line)
 					);
 				} else {
 					const x = margin.left + pos;
 
-					painter.strokePath(() => {
+					drawLine(line, "x", () => {
 						painter.traceLine(x, y1, x, y2);
 					});
 					ctx.textAlign = line.position === "start" ?
@@ -1199,7 +1249,8 @@ export default class CanvasAxisRenderer {
 						line.text,
 						x - 5,
 						getRotatedLineTextPosition(line.position, y1, y2),
-						true
+						true,
+						getTextStyle("x", line)
 					);
 				}
 			};
@@ -1222,7 +1273,7 @@ export default class CanvasAxisRenderer {
 				if (isRotated) {
 					const x = margin.left + pos;
 
-					painter.strokePath(() => {
+					drawLine(line, "y", () => {
 						painter.traceLine(x, y1, x, y2);
 					});
 					ctx.textAlign = line.position === "start" ?
@@ -1232,12 +1283,13 @@ export default class CanvasAxisRenderer {
 						line.text,
 						x - 5,
 						getRotatedLineTextPosition(line.position, y1, y2),
-						true
+						true,
+						getTextStyle("y", line)
 					);
 				} else {
 					const y = margin.top + pos;
 
-					painter.strokePath(() => {
+					drawLine(line, "y", () => {
 						painter.traceLine(x1, y, x2, y);
 					});
 					ctx.textAlign = line.position === "start" ?
@@ -1246,7 +1298,9 @@ export default class CanvasAxisRenderer {
 					drawLabel(
 						line.text,
 						getLineTextPosition(line.position, x1, x2),
-						y - 5
+						y - 5,
+						false,
+						getTextStyle("y", line)
 					);
 				}
 			};

--- a/src/canvas/CanvasTheme.ts
+++ b/src/canvas/CanvasTheme.ts
@@ -83,6 +83,14 @@ export type CanvasThemeSelectorMap = Record<string, CanvasThemeSelectorStyle>;
 export type CanvasThemeOverride = CanvasThemeDeepPartial<CanvasThemeStyle> & {
 	selectors?: CanvasThemeSelectorMap
 };
+export type CanvasGridLineThemeStyle = Partial<CanvasThemeStyle["grid"]>;
+
+type CanvasGridLineSelectorTarget = "line" | "text";
+type CanvasGridLineSelectorOverride = {
+	selector: string,
+	target: CanvasGridLineSelectorTarget,
+	style: CanvasGridLineThemeStyle
+};
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -370,6 +378,156 @@ function normalizeThemeSelectors(selector: string): string[] {
 				.replace(/(^|\s)(?:g|path|rect|line|text|circle)\./g, "$1.")
 		)
 		.filter(Boolean);
+}
+
+/**
+ * Get own keys from a style object whose values are set.
+ * @param {object} values Style values
+ * @returns {Array} Defined keys
+ * @private
+ */
+function getDefinedKeys<T extends Record<string, any>>(values: T): Array<keyof T> {
+	return Object.keys(values).filter(key => values[key] !== undefined) as Array<keyof T>;
+}
+
+/**
+ * Check whether a selector is simple enough for virtual optional grid line matching.
+ * @param {string} selector Normalized SVG selector
+ * @returns {boolean} Whether selector can be matched
+ * @private
+ */
+function isSimpleGridLineSelector(selector: string): boolean {
+	const tokens = selector.split(" ");
+
+	return tokens.every((token, index) =>
+		(token === "line" || token === "text") ?
+			index === tokens.length - 1 :
+			/^(\.[A-Za-z_-][\w-]*)+$/.test(token)
+	);
+}
+
+/**
+ * Get optional grid line selector target.
+ * @param {string} selector Normalized SVG selector
+ * @returns {string|null} Selector target
+ * @private
+ */
+function getGridLineSelectorTarget(
+	selector: string
+): CanvasGridLineSelectorTarget | null {
+	const target = selector.split(" ").at(-1);
+
+	return target === "line" || target === "text" ? target : null;
+}
+
+/**
+ * Split custom class value.
+ * @param {string} className Custom class value
+ * @returns {Array} Class names
+ * @private
+ */
+function getClassNames(className?: string): string[] {
+	return (className || "").split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Read optional grid line or label style from selector style declaration.
+ * @param {object} style Style declaration object
+ * @param {string} target Selector target
+ * @returns {object} Grid line style
+ * @private
+ */
+function getGridLineSelectorStyle(
+	style: CanvasThemeSelectorStyle,
+	target: CanvasGridLineSelectorTarget
+): CanvasGridLineThemeStyle {
+	const values: CanvasGridLineThemeStyle = target === "text" ?
+		{
+			labelColor: readColorValue(style, "fill"),
+			labelFont: readFontValue(style)
+		} :
+		{
+			lineColor: readColorValue(style, "stroke"),
+			lineWidth: readNumberValue(style, "stroke-width"),
+			dashArray: readDashArrayValue(style)
+		};
+
+	return getDefinedKeys(values).reduce((acc, key) => {
+		acc[key] = values[key];
+		return acc;
+	}, {} as CanvasGridLineThemeStyle);
+}
+
+/**
+ * Convert selector based optional grid line overrides to ordered matcher entries.
+ * @param {object} selectors Selector style declarations
+ * @returns {Array} Optional grid line selector overrides
+ * @private
+ */
+function getGridLineSelectorOverrides(
+	selectors?: CanvasThemeSelectorMap
+): CanvasGridLineSelectorOverride[] {
+	const overrides: CanvasGridLineSelectorOverride[] = [];
+
+	Object.keys(selectors ?? {}).forEach(selector => {
+		normalizeThemeSelectors(selector).forEach(normalizedSelector => {
+			const target = getGridLineSelectorTarget(normalizedSelector) || "line";
+			const style = getGridLineSelectorStyle(selectors![selector], target);
+
+			if (isSimpleGridLineSelector(normalizedSelector) && getDefinedKeys(style).length) {
+				overrides.push({selector: normalizedSelector, target, style});
+			}
+		});
+	});
+
+	return overrides;
+}
+
+/**
+ * Check whether a virtual optional grid line selector matches a grid line config.
+ * @param {string} selector Normalized SVG selector
+ * @param {string} axis Grid axis
+ * @param {string} className Grid line custom class
+ * @param {string} target Draw target
+ * @returns {boolean} Whether selector matches
+ * @private
+ */
+function matchesGridLineSelector(
+	selector: string,
+	axis: "x" | "y",
+	className: string | undefined,
+	target: CanvasGridLineSelectorTarget
+): boolean {
+	if (!isSimpleGridLineSelector(selector)) {
+		return false;
+	}
+
+	const selectorTarget = getGridLineSelectorTarget(selector);
+
+	if (selectorTarget && selectorTarget !== target) {
+		return false;
+	} else if (!selectorTarget && target === "text") {
+		return false;
+	}
+
+	const customClasses = getClassNames(className);
+	const axisLineClass = `bb-${axis}grid-line`;
+	const availableClasses = new Set([
+		"bb-grid",
+		"bb-grid-lines",
+		`bb-${axis}grid-lines`,
+		axisLineClass,
+		...customClasses
+	]);
+	const selectorClasses = Array.from(selector.matchAll(/\.([A-Za-z_-][\w-]*)/g))
+		.map(match => match[1]);
+
+	return !!selectorClasses.length &&
+		selectorClasses.every(cls => availableClasses.has(cls)) &&
+		(
+			selectorClasses.includes(axisLineClass) ||
+			customClasses.some(cls => selectorClasses.includes(cls))
+		);
 }
 
 /**
@@ -697,6 +855,8 @@ export default class CanvasTheme {
 	public style!: CanvasThemeStyle;
 	private cacheContainer: HTMLElement | null = null;
 	private cacheKey: string | null = null;
+	private gridLineSelectorOverrides: CanvasGridLineSelectorOverride[] = [];
+	private directGridOverrideKeys = new Set<keyof CanvasThemeStyle["grid"]>();
 
 	/**
 	 * Read theme values from temporary SVG probes.
@@ -706,6 +866,11 @@ export default class CanvasTheme {
 	 */
 	load(container: HTMLElement, userOverride?: CanvasThemeOverride): void {
 		const svg = document.createElementNS(SVG_NS, "svg");
+
+		this.gridLineSelectorOverrides = getGridLineSelectorOverrides(userOverride?.selectors);
+		this.directGridOverrideKeys = new Set(
+			Object.keys(userOverride?.grid ?? {})
+		) as Set<keyof CanvasThemeStyle["grid"]>;
 
 		svg.setAttribute("class", "bb");
 		svg.style.cssText =
@@ -1162,5 +1327,36 @@ export default class CanvasTheme {
 		}
 
 		this.load(container, userOverride);
+	}
+
+	/**
+	 * Resolve selector based style for one configured optional grid line.
+	 * @param {string} axis Grid axis
+	 * @param {object} line Grid line options
+	 * @param {string} line.class Grid line custom class
+	 * @param {string} target Draw target
+	 * @returns {object|undefined} Grid line style override
+	 * @private
+	 */
+	getGridLineStyle(
+		axis: "x" | "y",
+		line: {class?: string} = {},
+		target: CanvasGridLineSelectorTarget = "line"
+	): CanvasGridLineThemeStyle | undefined {
+		const style: CanvasGridLineThemeStyle = {};
+
+		for (const override of this.gridLineSelectorOverrides) {
+			if (!matchesGridLineSelector(override.selector, axis, line.class, target)) {
+				continue;
+			}
+
+			for (const key of getDefinedKeys(override.style)) {
+				if (!this.directGridOverrideKeys.has(key)) {
+					style[key] = override.style[key];
+				}
+			}
+		}
+
+		return getDefinedKeys(style).length ? style : undefined;
 	}
 }

--- a/test/esm/canvas-axis-renderer-coverage-spec.ts
+++ b/test/esm/canvas-axis-renderer-coverage-spec.ts
@@ -92,7 +92,7 @@ function makeAxisRenderer() {
 	};
 
 	return {
-		renderer: new CanvasAxisRenderer(engine, {style})
+		renderer: new CanvasAxisRenderer(engine, {style, getGridLineStyle: () => undefined})
 	};
 }
 

--- a/test/esm/canvas-helper-coverage-spec.ts
+++ b/test/esm/canvas-helper-coverage-spec.ts
@@ -932,6 +932,64 @@ describe("ESM canvas helper coverage", () => {
 			container.remove();
 		});
 
+		it("maps optional grid line class selectors to per-line canvas styles", () => {
+			const container = document.createElement("div");
+			const theme = new CanvasTheme();
+
+			document.body.appendChild(container);
+			theme.load(container, {
+				selectors: {
+					".bb-grid line": {stroke: "#999999", "stroke-width": 9},
+					".iaq-good line": {
+						stroke: "#00aa00",
+						"stroke-width": 2,
+						"stroke-dasharray": "4 2"
+					},
+					".bb-xgrid-line.iaq-good line": {
+						stroke: "#0000ff"
+					},
+					".bb-ygrid-line.iaq-good text": {
+						fill: "#111111",
+						font: "13px serif"
+					},
+					".bb-ygrid line": {
+						stroke: "#ff0000"
+					}
+				}
+			});
+
+			expect(theme.getGridLineStyle("y", {class: "iaq-good"})).to.deep.include({
+				lineColor: "#00aa00",
+				lineWidth: 2
+			});
+			expect(theme.getGridLineStyle("y", {class: "iaq-good"})!.dashArray)
+				.to.deep.equal([4, 2]);
+			expect(theme.getGridLineStyle("y", {class: "iaq-good"}, "text")).to.deep.include({
+				labelColor: "#111111",
+				labelFont: "13px serif"
+			});
+			expect(theme.getGridLineStyle("x", {class: "iaq-good"})!.lineColor)
+				.to.be.equal("#0000ff");
+			expect(theme.getGridLineStyle("y", {class: "iaq-bad"})).to.be.undefined;
+
+			theme.load(container, {
+				selectors: {
+					".iaq-good line": {
+						stroke: "#00aa00",
+						"stroke-width": 2
+					}
+				},
+				grid: {
+					lineWidth: 7
+				}
+			});
+			expect(theme.getGridLineStyle("y", {class: "iaq-good"})).to.deep.equal({
+				lineColor: "#00aa00"
+			});
+
+			container.remove();
+		});
+
 		it("normalizes theme override fallbacks and composed font selector values", () => {
 			const container = document.createElement("div");
 			const theme = new CanvasTheme();

--- a/test/esm/canvas-spec.ts
+++ b/test/esm/canvas-spec.ts
@@ -5913,63 +5913,156 @@ describe("ESM canvas", function() {
 		}
 	});
 
-	it("should draw explicit canvas grid lines with solid stroke", () => {
-		const style = document.createElement("style");
-		const dashRecords: number[][] = [];
-		const originalSetLineDash = CanvasRenderingContext2D.prototype.setLineDash;
-		const setLineDash = vi.spyOn(CanvasRenderingContext2D.prototype, "setLineDash")
-			.mockImplementation(function(this: CanvasRenderingContext2D, segments: Iterable<number>) {
-				dashRecords.push(Array.from(segments));
+		it("should draw explicit canvas grid lines with solid stroke", () => {
+			const style = document.createElement("style");
+			const dashRecords: number[][] = [];
+			const originalSetLineDash = CanvasRenderingContext2D.prototype.setLineDash;
+			const setLineDash = vi.spyOn(CanvasRenderingContext2D.prototype, "setLineDash")
+				.mockImplementation(function(this: CanvasRenderingContext2D, segments: Iterable<number>) {
+					dashRecords.push(Array.from(segments));
 
-				return originalSetLineDash.call(this, segments);
-			});
+					return originalSetLineDash.call(this, segments);
+				});
 
-		style.textContent = `
-			.bb-ygrid {
-				stroke-dasharray: 3 3;
-			}
-		`;
-		document.head.appendChild(style);
-
-		try {
-			generateWithOptions({
-				data: {
-					columns: [
-						["data1", 30, -200, -100, 400, 150, 250],
-						["data2", -50, 150, -150, 150, -50, -150],
-						["data3", -100, 100, -40, 100, -150, -50]
-					],
-					groups: [
-						["data1", "data2"]
-					],
-					type: bar(),
-					labels: true
-				},
-				grid: {
-					y: {
-						show: true,
-						lines: [{value: 0}]
-					}
+			style.textContent = `
+				.bb-ygrid {
+					stroke-dasharray: 3 3;
 				}
-			});
+			`;
+			document.head.appendChild(style);
 
-			const gridDashIndex = dashRecords.findIndex(dash => dash.length > 0);
-			const solidGridLineIndex = dashRecords.findIndex((dash, index) =>
-				index > gridDashIndex && dash.length === 0
-			);
+			try {
+				generateWithOptions({
+					data: {
+						columns: [
+							["data1", 30, -200, -100, 400, 150, 250],
+							["data2", -50, 150, -150, 150, -50, -150],
+							["data3", -100, 100, -40, 100, -150, -50]
+						],
+						groups: [
+							["data1", "data2"]
+						],
+						type: bar(),
+						labels: true
+					},
+					grid: {
+						y: {
+							show: true,
+							lines: [{value: 0}]
+						}
+					}
+				});
 
-			expect(chart.internal.canvasTheme.style.grid.dashArray).to.deep.equal([3, 3]);
-			expect(gridDashIndex).not.to.be.equal(-1);
-			expect(solidGridLineIndex).not.to.be.equal(-1);
-		} finally {
-			style.remove();
-			setLineDash.mockRestore();
-		}
-	});
+				const gridDashIndex = dashRecords.findIndex(dash => dash.length > 0);
+				const solidGridLineIndex = dashRecords.findIndex((dash, index) =>
+					index > gridDashIndex && dash.length === 0
+				);
 
-	it("should keep optional canvas y grid line coordinates like SVG", () => {
-		const lineTos: Array<{x: number, y: number}> = [];
-		const originalLineTo = CanvasRenderingContext2D.prototype.lineTo;
+				expect(chart.internal.canvasTheme.style.grid.dashArray).to.deep.equal([3, 3]);
+				expect(gridDashIndex).not.to.be.equal(-1);
+				expect(solidGridLineIndex).not.to.be.equal(-1);
+			} finally {
+				style.remove();
+				setLineDash.mockRestore();
+			}
+		});
+
+		it("should apply canvas selector styles for optional grid line classes", () => {
+			const strokeRecords: Array<{dash: number[], lineWidth: number, strokeStyle: string}> = [];
+			const textRecords: Array<{fillStyle: string, font: string, text: string}> = [];
+			const originalStroke = CanvasRenderingContext2D.prototype.stroke;
+			const originalFillText = CanvasRenderingContext2D.prototype.fillText;
+			const stroke = vi.spyOn(CanvasRenderingContext2D.prototype, "stroke")
+				.mockImplementation(function(this: CanvasRenderingContext2D) {
+					strokeRecords.push({
+						dash: this.getLineDash(),
+						lineWidth: this.lineWidth,
+						strokeStyle: String(this.strokeStyle)
+					});
+
+					return originalStroke.call(this);
+				});
+			const fillText = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText")
+				.mockImplementation(function(
+					this: CanvasRenderingContext2D,
+					text: string,
+					x: number,
+					y: number,
+					maxWidth?: number
+				) {
+					textRecords.push({
+						fillStyle: String(this.fillStyle),
+						font: this.font,
+						text: String(text)
+					});
+
+					return maxWidth === undefined ?
+						originalFillText.call(this, text, x, y) :
+						originalFillText.call(this, text, x, y, maxWidth);
+				});
+
+			try {
+				generateWithOptions({
+					data: {
+						columns: [
+							["data1", 30, 200, 100, 400]
+						],
+						type: line()
+					},
+					grid: {
+						y: {
+							lines: [
+								{value: 50, text: "Good", class: "iaq-good"},
+								{value: 150, text: "Bad", class: "iaq-bad"}
+							]
+						}
+					},
+					canvas: {
+						theme: {
+							selectors: {
+								".iaq-good line": {
+									stroke: "#123456",
+									"stroke-width": 3,
+									"stroke-dasharray": "5 2"
+								},
+								".iaq-bad line": {
+									stroke: "#654321",
+									"stroke-width": 4
+								},
+								".iaq-bad text": {
+									fill: "#abcdef",
+									font: "15px serif"
+								}
+							}
+						}
+					}
+				});
+
+				expect(strokeRecords.some(({dash, lineWidth, strokeStyle}) =>
+					strokeStyle === "#123456" &&
+					lineWidth === 3 &&
+					dash[0] === 5 &&
+					dash[1] === 2
+				)).to.be.true;
+				expect(strokeRecords.some(({dash, lineWidth, strokeStyle}) =>
+					strokeStyle === "#654321" &&
+					lineWidth === 4 &&
+					dash.length === 0
+				)).to.be.true;
+				expect(textRecords.some(({fillStyle, font, text}) =>
+					text === "Bad" &&
+					fillStyle === "#abcdef" &&
+					font.indexOf("15px") > -1
+				)).to.be.true;
+			} finally {
+				stroke.mockRestore();
+				fillText.mockRestore();
+			}
+		});
+
+		it("should keep optional canvas y grid line coordinates like SVG", () => {
+			const lineTos: Array<{x: number, y: number}> = [];
+			const originalLineTo = CanvasRenderingContext2D.prototype.lineTo;
 		const lineTo = vi.spyOn(CanvasRenderingContext2D.prototype, "lineTo")
 			.mockImplementation(function(this: CanvasRenderingContext2D, x: number, y: number) {
 				lineTos.push({x, y});


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4164

## Details
<!-- Detailed description of the change/feature -->
Add `canvas.theme.selectors` mapping SVG selectors to canvas draw styles, resolved by `CanvasTheme.getGridLineStyle()` per axis/line/target; direct `canvas.theme` keys still take precedence.


### New chart generation options

Canvas mode has no SVG DOM, so CSS-based styling was not possible. This PR adds `canvas.theme.selectors`, which maps familiar billboard.js SVG selectors to canvas drawing styles.

#### Basic usage

```js
bb.generate({
  render: { mode: "canvas" },
  canvas: {
    theme: {
      // Map SVG selectors to canvas styles (recommended)
      selectors: {
        ".bb-grid line":       { stroke: "#ddd", "stroke-width": 1, "stroke-dasharray": "2 2" },
        ".bb-axis .tick text": { fill: "#555", font: "12px sans-serif" },
        ".bb-bar":             { stroke: "#fff", "stroke-width": 1 }
      }
    }
  }
});
```

- Property names accept both kebab-case and camelCase (`"stroke-width"` = `strokeWidth`)
- Comma-separated selector groups are supported; unsupported selectors are ignored
- When `selectors` and direct keys overlap, **direct keys take precedence**

#### Supported selectors (by category)

| Category | Example selectors | Supported properties |
| --- | --- | --- |
| **Axis** | `.bb-axis[-x/-y/-y2] .domain` / `line` / `text` / `-label`, `.tick._active_ text` | `stroke`, `stroke-width`, `fill`, `font` (+ longhands) |
| **Grid** | `.bb-grid line`, `.bb-xgrid`, `.bb-ygrid`, `.bb-xgrid-focus line`, `.bb-grid text` | `stroke`, `stroke-width`, `stroke-dasharray`, `fill`, `font` |
| **Region** | `.bb-region rect`, `.bb-region text` | `fill`, `opacity`, `fill-opacity`, `font` |
| **Shapes** | `.bb-bar`, `.bb-candlestick`, `.bb-line`, `.bb-area`, `.bb-circle`, `.bb-chart-treemaps rect` (+ `._expanded_` / `.bb-focused` variants) | `stroke`, `stroke-width`, `opacity`, `fill`, `fill-opacity` |
| **Brush / Text** | `.bb-zoom-brush`, `.bb-brush .extent/.selection/.handle--custom`, `.bb-text`, `.bb-title`, `.bb-empty` | `fill`, `opacity`, `stroke`, `stroke-width`, `font` |

> Font longhands: `font-size`, `font-family`, `font-style`, `font-variant`, `font-weight`, `line-height`

#### Low-level direct override keys (advanced)

Canvas-specific slots for when `selectors` is not granular enough:

`axis`, `grid`, `focusGrid`, `region`, `shape`, `selectedPoint`, `focusPoint`, `zoomBrush`, `subchartBrush`, `treemap`, `emptyLabel`, `label`, `title`

```js
canvas: {
  theme: {
    selectors: { ".bb-grid line": { stroke: "#ddd", "stroke-width": 1 } },
    grid: { lineWidth: 2 }   // direct key wins over the selector-mapped value
  }
}
```

See [`CANVAS_THEME_SELECTORS.md`](https://github.com/netil/billboard.js/blob/b15e9fbae9e6c6df0ad885de6cff5acd6987c4ad/CANVAS_THEME_SELECTORS.md)  for the full reference.