### PR TITLE
fix(bar): prevent invalid SVG arc flags on load() with bar.radius

### DIFF
--- a/src/ChartInternal/shape/bar.ts
+++ b/src/ChartInternal/shape/bar.ts
@@ -3,11 +3,16 @@
  * billboard.js project is licensed under the MIT license
  */
 import {select as d3Select} from "d3-selection";
-import type {d3Selection, DataRow} from "../../../types/types";
+import type {d3Selection, d3Transition, DataRow} from "../../../types/types";
 import {$BAR, $COMMON} from "../../config/classes";
 import {getRandom, isNumber} from "../../module/util";
 import type {IBarData} from "../data/IData";
-import {getBarRadiusInfo, getBarRadiusResolver, getStackingBarRadiusSet} from "./core/barRadius";
+import {
+	getBarPathInterpolator,
+	getBarRadiusInfo,
+	getBarRadiusResolver,
+	getStackingBarRadiusSet
+} from "./core/barRadius";
 import {getShapeColorWithGradient, updateTargetsForShape} from "./shape";
 
 type BarTypeDataRow = DataRow<number | number[]>;
@@ -159,40 +164,62 @@ export default {
 		const {bar} = isSub ? $$.$el.subchart : $$.$el;
 		const barPath: BarConnectLine[] = [];
 		const connectLineCache = new Map<string, string | null>();
+		const getRadius = getBarRadiusResolver($$);
+
+		// Computes the target path string and performs bar.connectLine side-effects.
+		const getBarPath = function(this: SVGPathElement, d, i, arr): string {
+			const path = (isNumber(d.value) || $$.isBarRangeType(d)) && drawFn(d, i);
+
+			// Memoize per series id: config lookup + regex runs once per id, not per bar
+			let connectLineType = connectLineCache.get(d.id);
+
+			if (connectLineType === undefined) {
+				connectLineType = _getConnectLineType.call($$, d.id);
+				connectLineCache.set(d.id, connectLineType);
+			}
+
+			// for bar.connectLine option
+			if (path.length > 1) {
+				barPath.push(path[1] as BarConnectLine);
+			}
+
+			// flush per series even when the last datum is null,
+			// otherwise the accumulated path leaks into the next series
+			if (i === arr.length - 1 && barPath.length) {
+				const barConnectLineNode = $$.$T(
+					d3Select(
+						(this.parentNode as ParentNode).querySelector(`.${$BAR.barConnectLine}`)
+					),
+					withTransition,
+					getRandom()
+				);
+
+				$$.updateConnectLine(barConnectLineNode, connectLineType, barPath);
+				barPath.splice(0);
+			}
+
+			return path[0] as string;
+		};
+
+		const barTransition = $$.$T(bar, withTransition, getRandom());
+
+		// Radius bars are rendered as <path> with arc commands whose flags must
+		// stay integers. d3's default interpolator turns them into fractions
+		// during transitions (ex. chart.load()), producing invalid path syntax
+		// and console parse errors. Use a flag-aware interpolator instead. #4166
+		if (getRadius && typeof (barTransition as d3Transition).attrTween === "function") {
+			(barTransition as d3Transition).attrTween("d",
+				function(this: SVGPathElement, d, i, arr) {
+					const target = getBarPath.call(this, d, i, arr);
+
+					return getBarPathInterpolator(this.getAttribute("d") ?? "", target);
+				});
+		} else {
+			barTransition.attr("d", getBarPath);
+		}
 
 		return [
-			$$.$T(bar, withTransition, getRandom())
-				.attr("d", function(d, i, arr) {
-					const path = (isNumber(d.value) || $$.isBarRangeType(d)) && drawFn(d, i);
-
-					// Memoize per series id: config lookup + regex runs once per id, not per bar
-					let connectLineType = connectLineCache.get(d.id);
-
-					if (connectLineType === undefined) {
-						connectLineType = _getConnectLineType.call($$, d.id);
-						connectLineCache.set(d.id, connectLineType);
-					}
-
-					// for bar.connectLine option
-					if (path.length > 1) {
-						barPath.push(path[1]);
-					}
-
-					// flush per series even when the last datum is null,
-					// otherwise the accumulated path leaks into the next series
-					if (i === arr.length - 1 && barPath.length) {
-						const barConnectLineNode = $$.$T(
-							d3Select(this.parentNode.querySelector(`.${$BAR.barConnectLine}`)),
-							withTransition,
-							getRandom()
-						);
-
-						$$.updateConnectLine(barConnectLineNode, connectLineType, barPath);
-						barPath.splice(0);
-					}
-
-					return path[0];
-				})
+			barTransition
 				.style("fill", $$.generateUpdateBarColor())
 				.style("clip-path", d => d.clipPath)
 				.style("opacity", null)

--- a/src/ChartInternal/shape/core/barRadius.ts
+++ b/src/ChartInternal/shape/core/barRadius.ts
@@ -16,6 +16,135 @@ export type BarRadiusInfo = {
 	pos: number
 };
 
+// d3's default string interpolator (used by transition.attr("d", …)) treats
+// every number in the path as interpolatable. SVG arc commands however carry
+// integer-only flags (x-axis-rotation, large-arc-flag, sweep-flag) which, when
+// interpolated to fractions like "0.00001", produce invalid path syntax and
+// flood the console with parse errors on chart.load(). See #4166.
+const RE_PATH_NUMBER = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g;
+const RE_PATH_TOKEN = /([aAcChHlLmMqQsStTvVzZ])|([-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?)/g;
+
+/**
+ * Collect the ordinal indexes of numeric tokens that are SVG arc-command flags.
+ * Arc parameters repeat in groups of 7: rx ry x-rotation large-arc sweep x y.
+ * Positions 2(x-rotation), 3(large-arc) and 4(sweep) must stay integers.
+ * @param {string} path Path string to scan
+ * @returns {Set} Ordinal indexes (in number order) of arc flag tokens
+ * @private
+ */
+function getArcFlagTokenIndexes(path: string): Set<number> {
+	const flags = new Set<number>();
+	let numIndex = -1;
+	let argIndex = 0;
+	let inArc = false;
+	let token;
+
+	RE_PATH_TOKEN.lastIndex = 0;
+
+	while ((token = RE_PATH_TOKEN.exec(path))) {
+		if (token[1]) {
+			inArc = token[1] === "a" || token[1] === "A";
+			argIndex = 0;
+		} else {
+			numIndex++;
+
+			if (inArc) {
+				const pos = argIndex % 7;
+
+				if (pos === 2 || pos === 3 || pos === 4) {
+					flags.add(numIndex);
+				}
+
+				argIndex++;
+			}
+		}
+	}
+
+	return flags;
+}
+
+/**
+ * Build a path interpolator that behaves like d3's string interpolator but
+ * snaps SVG arc flags to valid integers, preventing malformed paths during
+ * bar transitions (ex. chart.load() with bar.radius). See #4166.
+ * @param {string} a Start path
+ * @param {string} b Target path
+ * @returns {function} Interpolator returning a valid path for progress t
+ * @private
+ */
+export function getBarPathInterpolator(a: string, b: string): (t: number) => string {
+	const flagSet = getArcFlagTokenIndexes(b);
+	const segments: (string | null)[] = [];
+	const interpolators: {index: number, fn: (t: number) => number}[] = [];
+	let bIndex = 0;
+	let segIndex = -1;
+	let numIndex = -1;
+	let am;
+	let bm;
+
+	// append a literal chunk, merging with the previous literal segment
+	const append = (text: string): void => {
+		if (segments[segIndex]) {
+			segments[segIndex] += text;
+		} else {
+			segments[++segIndex] = text;
+		}
+	};
+
+	RE_PATH_NUMBER.lastIndex = 0;
+	const reA = RE_PATH_NUMBER;
+	const reB = new RegExp(RE_PATH_NUMBER.source, "g");
+
+	a += "";
+	b += "";
+
+	while ((am = reA.exec(a)) && (bm = reB.exec(b))) {
+		numIndex++;
+
+		// literal (non-numeric) part of target preceding this number
+		if (bm.index > bIndex) {
+			append(b.slice(bIndex, bm.index));
+		}
+
+		if (am[0] === bm[0]) {
+			append(bm[0]);
+		} else {
+			const from = +am[0];
+			const to = +bm[0];
+			const isFlag = flagSet.has(numIndex);
+
+			segments[++segIndex] = null;
+			interpolators.push({
+				index: segIndex,
+				fn: isFlag ? t => Math.round(from + (to - from) * t) : t => from + (to - from) * t
+			});
+		}
+
+		bIndex = reB.lastIndex;
+	}
+
+	// remaining target literal/numbers stay as-is (already valid)
+	if (bIndex < b.length) {
+		append(b.slice(bIndex));
+	}
+
+	if (!interpolators.length) {
+		const result = segments.join("");
+
+		return () => result;
+	}
+
+	return (t: number) => {
+		for (let i = 0, len = interpolators.length; i < len; i++) {
+			const {index, fn} = interpolators[i];
+
+			segments[index] = String(fn(t));
+		}
+
+		return segments.join("");
+	};
+}
+
 /**
  * Get the configured bar corner radius resolver.
  * @param {object} $$ ChartInternal instance

--- a/test/shape/bar-spec.ts
+++ b/test/shape/bar-spec.ts
@@ -8,6 +8,7 @@ import {beforeEach, beforeAll, describe, expect, it} from "vitest";
 import {select as d3Select} from "d3-selection";
 import util from "../assets/util";
 import {$AXIS, $BAR, $COMMON, $EVENT, $LINE, $SHAPE} from "../../src/config/classes";
+import {getBarPathInterpolator} from "../../src/ChartInternal/shape/core/barRadius";
 
 describe("SHAPE BAR", () => {
 	let chart;
@@ -1051,6 +1052,58 @@ describe("SHAPE BAR", () => {
 			chart.$.bar.bars.each(function() {
 				expect(this.getAttribute("d")).to.be.equal(expected.shift());
 			});
+		});
+	});
+
+	describe("bar radius path interpolation (#4166)", () => {
+		// SVG arc flags (x-rotation, large-arc, sweep) must remain integers.
+		// d3's default string interpolator turned them into fractions during
+		// chart.load() transitions, producing invalid path syntax.
+		const collectArcFlags = (path: string): number[] => {
+			const flags: number[] = [];
+			const re = /a\s*[-\d.eE+]+ [-\d.eE+]+ ([-\d.eE+]+) ([-\d.eE+]+) ([-\d.eE+]+) /g;
+			let m;
+
+			while ((m = re.exec(path))) {
+				flags.push(+m[1], +m[2], +m[3]);
+			}
+
+			return flags;
+		};
+
+		it("arc flags should stay 0 or 1 for every interpolation progress", () => {
+			// negative-direction bar (flags "1 0 0") transitioning to
+			// positive-direction bar (flags "0 0 1") — the exact case that broke
+			const from =
+				"M295,213H112.76666666666665 a63.6 63.6 1 0 0 -63.6,63.6V276.6 a63.6 63.6 1 0 0 63.6,63.6H295z";
+			const to =
+				"M295,85.8H477.23333333333323 a63.6 63.6 0 0 1 63.6,63.6V149.4 a63.6 63.6 0 0 1 -63.6,63.6H295z";
+
+			const interpolate = getBarPathInterpolator(from, to);
+
+			for (let t = 0; t <= 1; t += 0.05) {
+				const path = interpolate(t);
+				const flags = collectArcFlags(path);
+
+				expect(flags.length).to.be.above(0);
+
+				flags.forEach(flag => {
+					expect(flag === 0 || flag === 1).to.be.true;
+				});
+			}
+		});
+
+		it("should reach the exact target path at t=1", () => {
+			const from = "M0,0V10 a5 5 0 0 1 5,5H10z";
+			const to = "M0,0V20 a5 5 0 0 1 5,5H10z";
+
+			expect(getBarPathInterpolator(from, to)(1)).to.be.equal(to);
+		});
+
+		it("should not throw and produce valid output when start path is empty", () => {
+			const to = "M0,0V20 a5 5 0 0 1 5,5H10z";
+
+			expect(getBarPathInterpolator("", to)(0.5)).to.be.equal(to);
 		});
 	});
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4166

## Details
<!-- Detailed description of the change/feature -->
Rounded bars render as `<path>` with arc commands whose flags (x-rotation, large-arc, sweep) must be integers.

During load() transitions d3's default string interpolator interpolated these flags into fractions (ex. "0.00001"), producing invalid path syntax and flooding the console with parse errors.

Add a flag-aware path interpolator that snaps arc flags to valid integers while interpolating coordinates normally, and use it via attrTween in redrawBar only when bar.radius is configured. Canvas mode is unaffected as it recomputes numeric geometry per frame.

<img width="882" height="382" alt="Jul-20-2026 14-37-20" src="https://github.com/user-attachments/assets/91867a97-af79-4ae0-a562-8d260469f6cc" />
