### PR TITLE
fix(selection): honor multiple=false and point.focus.only in select API

### DIFF
--- a/src/Chart/api/selection.ts
+++ b/src/Chart/api/selection.ts
@@ -8,6 +8,79 @@ import {$AREA, $LINE, $SELECT, $SHAPE} from "../../config/classes";
 import {isDefined} from "../../module/util";
 
 /**
+ * Toggler function to select or unselect when point.focus.only=true.<br><br>
+ * In this mode only a single shared circle element is rendered per series, so
+ * selection can't rely on per-index shape elements existing in the DOM. Iterate
+ * over the data instead and draw/remove the selected-circle elements directly.
+ * @param {boolean} isSelection Weather select or unselect
+ * @param {Array} ids Target ids
+ * @param {Array} indices Indices number
+ * @param {boolean} resetOther Weather reset other selected points (only for selection)
+ * @private
+ */
+function setSelectionForFocusOnly(
+	isSelection: boolean,
+	ids?: string | string[],
+	indices?: number[],
+	resetOther?: boolean
+): void {
+	const $$ = this;
+	const {config, $el: {main}} = $$;
+	const selectionGrouped = config.data_selection_grouped;
+	const isSelectable = config.data_selection_isselectable.bind($$.api);
+	const targetIds = isDefined(ids) ? ([] as string[]).concat(ids as string | string[]) : null;
+	const singleSelection = isSelection && !config.data_selection_multiple;
+	let resetDone = !singleSelection;
+
+	// Remove the selected-circle synchronously. The shape's selection state is
+	// represented solely by these elements in focus.only mode, so relying on
+	// unselectPoint's transitioned removal would let rapid API calls interrupt
+	// each other's transition and leave orphaned circles behind.
+	const unselect = (circle, d, index) => {
+		$$.unselectPoint(circle, d, index);
+		circle.interrupt().remove();
+	};
+
+	$$.getTargetsToShow().forEach(target => {
+		const {id} = target;
+		const isTargetId = selectionGrouped || !targetIds || targetIds.indexOf(id) >= 0;
+		const selectedCircles = main.select(
+			`.${$SELECT.selectedCircles}${$$.getTargetSelectorSuffix(id)}`
+		);
+
+		target.values.forEach(d => {
+			const {index} = d;
+			const isTargetIndex = !indices || indices.indexOf(index) >= 0;
+			const circle = selectedCircles.selectAll(`.${$SELECT.selectedCircle}-${index}`);
+			const isSelected = !circle.empty();
+
+			if (isSelection) {
+				if (
+					isTargetId && isTargetIndex && isSelectable(d) &&
+					(!isSelected || singleSelection)
+				) {
+					if (!resetDone) {
+						setSelectionForFocusOnly.call($$, false);
+						resetDone = true;
+					}
+
+					$$.selectPoint(null, d, index);
+				} else if (
+					(!singleSelection || resetDone) &&
+					isDefined(resetOther) &&
+					resetOther &&
+					isSelected
+				) {
+					unselect(circle, d, index);
+				}
+			} else if (isTargetId && isTargetIndex && isSelected) {
+				unselect(circle, d, index);
+			}
+		});
+	});
+}
+
+/**
  * Toggler function to select or unselect
  * @param {boolean} isSelection Weather select or unselect
  * @param {Array} ids Target ids
@@ -25,8 +98,32 @@ function setSelection(
 	const {config, $el: {main}} = $$;
 	const selectionGrouped = config.data_selection_grouped;
 	const isSelectable = config.data_selection_isselectable.bind($$.api);
+	const singleSelection = isSelection && !config.data_selection_multiple;
+	let resetDone = !singleSelection;
 
 	if (!config.data_selection_enabled) {
+		return;
+	}
+
+	// When multiple selection is disabled, only one data point (or one x-index
+	// group when 'grouped' is enabled) can hold the selected state at a time.
+	// Clear any current selection only when the narrowed request can select a point.
+	if (singleSelection) {
+		indices = indices?.length ? [indices[0]] : [0];
+
+		// non-grouped single selection targets exactly one point, so narrow to a
+		// single id (the first requested, or the first shown when none given).
+		if (!selectionGrouped) {
+			const targetIds = isDefined(ids) ?
+				([] as string[]).concat(ids as string | string[]) :
+				$$.getTargetsToShow().map(t => t.id);
+
+			ids = targetIds.slice(0, 1);
+		}
+	}
+
+	if ($$.isPointFocusOnly?.()) {
+		setSelectionForFocusOnly.call($$, isSelection, ids, indices, resetOther);
 		return;
 	}
 
@@ -35,20 +132,37 @@ function setSelection(
 		.each(function(d) {
 			const shape = d3Select(this);
 			const {id, index} = d.data ? d.data : d;
-			const toggle = $$.getToggle(this, d).bind($$);
 			const isTargetId = selectionGrouped || !ids || ids.indexOf(id) >= 0;
 			const isTargetIndex = !indices || indices.indexOf(index) >= 0;
-			const isSelected = shape.classed($SELECT.SELECTED);
 
 			// line/area selection not supported yet
 			if (shape.classed($LINE.line) || shape.classed($AREA.area)) {
 				return;
 			}
 
+			const toggle = $$.getToggle(this, d).bind($$);
+			const isSelected = shape.classed($SELECT.SELECTED);
+
 			if (isSelection) {
-				if (isTargetId && isTargetIndex && isSelectable(d) && !isSelected) {
-					toggle(true, shape.classed($SELECT.SELECTED, true), d, index);
-				} else if (isDefined(resetOther) && resetOther && isSelected) {
+				if (
+					isTargetId &&
+					isTargetIndex &&
+					isSelectable(d) &&
+					(!isSelected || singleSelection)
+				) {
+					if (!resetDone) {
+						setSelection.call($$, false);
+						resetDone = true;
+					}
+
+					!shape.classed($SELECT.SELECTED) &&
+						toggle(true, shape.classed($SELECT.SELECTED, true), d, index);
+				} else if (
+					(!singleSelection || resetDone) &&
+					isDefined(resetOther) &&
+					resetOther &&
+					isSelected
+				) {
 					toggle(false, shape.classed($SELECT.SELECTED, false), d, index);
 				}
 			} else {
@@ -82,6 +196,17 @@ export default {
 
 		if ($$.state.isCanvasMode) {
 			return $$.getCanvasSelectedData?.(targetId) || dataPoint;
+		}
+
+		// point.focus.only=true renders no per-index shape, so the selected-circle
+		// elements are the source of truth for the selection state.
+		if ($$.isPointFocusOnly?.()) {
+			$$.$el.main
+				.selectAll(`.${$SELECT.selectedCircles + $$.getTargetSelectorSuffix(targetId)}`)
+				.selectAll(`.${$SELECT.selectedCircle}`)
+				.each(d => dataPoint.push(d));
+
+			return dataPoint;
 		}
 
 		$$.$el.main.selectAll(`.${$SHAPE.shapes + $$.getTargetSelectorSuffix(targetId)}`)

--- a/src/ChartInternal/internals/selection.ts
+++ b/src/ChartInternal/internals/selection.ts
@@ -25,7 +25,7 @@ export default {
 		const cy = (isRotated ? $$.circleX : $$.circleY).bind($$);
 		const r = $$.pointSelectR.bind($$);
 
-		callFn(config.data_onselected, $$.api, d, target.node());
+		callFn(config.data_onselected, $$.api, d, target?.node());
 
 		// add selected-circle on low layer g
 		$T(main.select(`.${$SELECT.selectedCircles}${$$.getTargetSelectorSuffix(d.id)}`)

--- a/src/canvas/CanvasRenderer.ts
+++ b/src/canvas/CanvasRenderer.ts
@@ -2043,11 +2043,17 @@ export default class CanvasRenderer {
 						lineWidth: style.selectedPoint.lineWidth,
 						stroke: style.selectedPoint.stroke || color
 					});
-					drawPointPattern(painter, pointType, x, y, r, {
-						fill: style.shape.pointFillColor || color,
-						stroke: style.shape.pointStrokeColor || color,
-						lineWidth: style.shape.pointLineWidth ?? 1
-					});
+
+					// with point.focus.only, the data point is rendered only while it's
+					// focused, so a selected-but-unfocused point shows just the selection
+					// ring (matching SVG). Skip drawing the data point itself here.
+					if (!$$.isPointFocusOnly?.()) {
+						drawPointPattern(painter, pointType, x, y, r, {
+							fill: style.shape.pointFillColor || color,
+							stroke: style.shape.pointStrokeColor || color,
+							lineWidth: style.shape.pointLineWidth ?? 1
+						});
+					}
 				}
 			});
 

--- a/src/config/resolver/canvas.ts
+++ b/src/config/resolver/canvas.ts
@@ -2036,11 +2036,32 @@ const canvasInternal = {
 		const {config, state} = $$;
 		const selected = state.canvasSelection;
 		const selectionGrouped = config.data_selection_grouped;
-		const targetIds = getCanvasSelectionIds(ids);
+		let targetIds = getCanvasSelectionIds(ids);
 		let changed = false;
+		const singleSelection = isSelection && !config.data_selection_multiple;
+		let resetDone = !singleSelection;
 
 		if (!config.data_selection_enabled) {
 			return;
+		}
+
+		// When multiple selection is disabled, only one data point (or one x-index
+		// group when 'grouped' is enabled) can hold the selected state at a time.
+		// Clear any current selection only when the narrowed request can select a point.
+		if (singleSelection) {
+			indices = indices?.length ? [indices[0]] : [0];
+
+			// non-grouped single selection targets exactly one point, so narrow to a
+			// single id (the first requested, or the first shown when none given).
+			if (!selectionGrouped) {
+				if (targetIds) {
+					targetIds = targetIds.slice(0, 1);
+				} else {
+					const [firstTarget] = $$.filterTargetsToShow($$.data.targets);
+
+					targetIds = firstTarget ? [firstTarget.id] : [];
+				}
+			}
 		}
 
 		eachCanvasSelectableData($$, d => {
@@ -2050,11 +2071,20 @@ const canvasInternal = {
 			const isSelected = selected.has(key);
 
 			if (isSelection) {
-				if (isTargetId && isTargetIndex && !isSelected) {
+				if (isTargetId && isTargetIndex && (!isSelected || singleSelection)) {
+					if (!resetDone) {
+						$$.setCanvasSelection(false);
+						resetDone = true;
+					}
+
+					if (selected.has(key)) {
+						return;
+					}
+
 					selected.add(key);
 					callFn(config.data_onselected, $$.api, d, $$.canvasEngine.canvas);
 					changed = true;
-				} else if (resetOther && isSelected) {
+				} else if ((!singleSelection || resetDone) && resetOther && isSelected) {
 					selected.delete(key);
 					callFn(config.data_onunselected, $$.api, d, $$.canvasEngine.canvas);
 					changed = true;

--- a/test/api/canvas-spec.ts
+++ b/test/api/canvas-spec.ts
@@ -400,6 +400,91 @@ describe("API canvas", () => {
 		expect(chart.internal.state.canvasSelection.size).to.be.equal(0);
 	});
 
+	it("canvas select() API respects data.selection.multiple=false", () => {
+		generateWithOptions({
+			data: {
+				columns,
+				type: line(),
+				selection: {
+					enabled: true,
+					multiple: false
+				}
+			}
+		});
+
+		// only the latest selection survives
+		chart.select("data1", [2]);
+		chart.select("data2", [3]);
+		expect(chart.selected().map(d => `${d.id}:${d.index}`)).to.deep.equal(["data2:3"]);
+
+		// batch/no-arg selection also collapses to a single point
+		chart.select("data1", [0, 1, 3]);
+		expect(chart.selected().length).to.be.equal(1);
+
+		chart.select("missing", [0]);
+		expect(chart.selected().map(d => `${d.id}:${d.index}`)).to.deep.equal(["data1:0"]);
+
+		chart.select("data1", [99]);
+		expect(chart.selected().map(d => `${d.id}:${d.index}`)).to.deep.equal(["data1:0"]);
+
+		chart.unselect();
+		chart.select();
+		expect(chart.selected().length).to.be.equal(1);
+	});
+
+	it("canvas grouped select() API keeps only one x-index group when multiple=false", () => {
+		generateWithOptions({
+			data: {
+				columns,
+				type: line(),
+				selection: {
+					enabled: true,
+					grouped: true,
+					multiple: false
+				}
+			}
+		});
+
+		chart.select("data1", [1]);
+		chart.select("data2", [3]);
+
+		const selected = chart.selected();
+
+		expect(selected.length).to.be.equal(2);
+		expect(selected.every(d => d.index === 3)).to.be.true;
+	});
+
+	it("canvas select()/unselect() APIs work with point.focus.only=true", () => {
+		generateWithOptions({
+			data: {
+				columns,
+				type: line(),
+				selection: {
+					enabled: true
+				}
+			},
+			point: {
+				focus: {
+					only: true
+				}
+			}
+		});
+
+		// focus.only renders a single shared point per series, but canvas selection
+		// is data-key based, so the selection APIs remain unaffected
+		chart.select("data1", [1, 3], true);
+		expect(chart.selected().map(d => `${d.id}:${d.index}`)).to.deep.equal([
+			"data1:1",
+			"data1:3"
+		]);
+
+		chart.unselect("data1", [1]);
+		expect(chart.selected().map(d => `${d.id}:${d.index}`)).to.deep.equal(["data1:3"]);
+
+		chart.unselect();
+		expect(chart.selected()).to.deep.equal([]);
+	});
+
 	it("shows and hides canvas tooltip through tooltip APIs", () => {
 		generateWithOptions({
 			data: {

--- a/test/esm/canvas-renderer-coverage-spec.ts
+++ b/test/esm/canvas-renderer-coverage-spec.ts
@@ -177,6 +177,28 @@ describe("ESM canvas renderer coverage", () => {
 		expect(renderer.ctx).to.not.be.null;
 	});
 
+	it("draws only the selection ring for point shapes when point.focus.only=true", () => {
+		const {renderer} = makeRenderer();
+		const ctx = makeContext();
+		const shape = {indices: {}, pos: {}};
+		const pointSpy = vi.spyOn(renderer.painter, "point");
+
+		// default (focus.only off): selected point draws both ring and data point
+		ctx.isPointFocusOnly = () => false;
+		renderer.drawSelections(ctx, shape);
+		const normalCalls = pointSpy.mock.calls.length;
+
+		pointSpy.mockClear();
+
+		// focus.only on: the data point is hidden, so only the ring is drawn
+		ctx.isPointFocusOnly = () => true;
+		renderer.drawSelections(ctx, shape);
+		const focusOnlyCalls = pointSpy.mock.calls.length;
+
+		expect(focusOnlyCalls).to.be.greaterThan(0);
+		expect(focusOnlyCalls).to.be.lessThan(normalCalls);
+	});
+
 	it("covers rotated subchart brush and early return branches", () => {
 		const {renderer} = makeRenderer();
 		const ctx = makeContext();

--- a/test/internals/selection-spec.ts
+++ b/test/internals/selection-spec.ts
@@ -191,4 +191,151 @@ describe("SELECTION", () => {
 			}, 350);
 		}));
 	});
+
+	describe("API selection with data.selection.multiple=false", () => {
+		beforeAll(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 230, 280, 320, 218, 250, 150]
+					],
+					type: "line",
+					selection: {
+						enabled: true,
+						grouped: false,
+						multiple: false
+					}
+				}
+			};
+		});
+
+		it("select() API should keep only one selection at a time", () => {
+			chart.select(["data1"], [2]);
+			chart.select(["data2"], [4]);
+
+			const selected = chart.selected();
+
+			expect(selected.length).to.be.equal(1);
+			expect(selected[0].id).to.be.equal("data2");
+			expect(selected[0].index).to.be.equal(4);
+		});
+
+		it("select() API with multiple indices should keep only one selection", () => {
+			chart.select(["data1"], [0, 2, 4]);
+
+			expect(chart.selected().length).to.be.equal(1);
+		});
+
+		it("select() API with no arguments should keep only one selection", () => {
+			chart.select();
+
+			expect(chart.selected().length).to.be.equal(1);
+		});
+
+		it("select() API with no selectable match should preserve current selection", () => {
+			chart.select(["data1"], [2]);
+			chart.select(["unknown"], [0]);
+
+			const selected = chart.selected();
+
+			expect(selected.length).to.be.equal(1);
+			expect(selected[0].id).to.be.equal("data1");
+			expect(selected[0].index).to.be.equal(2);
+		});
+
+		it("set options selection.grouped = true", () => {
+			args.data.selection.grouped = true;
+		});
+
+		it("grouped select() API should keep only one x-index group", () => {
+			chart.select(["data1"], [2]);
+			chart.select(["data2"], [4]);
+
+			const selected = chart.selected();
+
+			// grouped: both series at the single selected index remain
+			expect(selected.length).to.be.equal(2);
+			expect(selected.every(d => d.index === 4)).to.be.true;
+		});
+	});
+
+	describe("API selection with point.focus.only=true", () => {
+		beforeAll(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250]
+					],
+					type: "line",
+					selection: {
+						enabled: true,
+						grouped: true,
+						multiple: false
+					}
+				},
+				point: {
+					focus: {
+						only: true
+					}
+				}
+			};
+		});
+
+		it("select()/selected() should work with focus.only", () => {
+			chart.select(["data1"], [3], true);
+
+			const selected = chart.selected();
+
+			expect(selected.length).to.be.equal(1);
+			expect(selected[0].index).to.be.equal(3);
+			expect(chart.$.main.selectAll(`.${$SELECT.selectedCircle}`).size()).to.be.equal(1);
+		});
+
+		it("select() w/resetOther should move the single selection", () => new Promise(done => {
+			chart.select(["data1"], [1], true);
+			chart.select(["data1"], [5], true);
+
+			setTimeout(() => {
+				const selected = chart.selected();
+
+				expect(selected.length).to.be.equal(1);
+				expect(selected[0].index).to.be.equal(5);
+
+				done(1);
+			}, 500);
+		}));
+
+		it("rapid successive select() must not leave orphaned selected circles", () => {
+			[0, 4, 2, 5].forEach(index => chart.select(["data1"], [index], true));
+
+			// selected-circle removal is synchronous, so no accumulation even when
+			// consecutive calls happen within a transition duration
+			expect(chart.selected().length).to.be.equal(1);
+			expect(chart.selected()[0].index).to.be.equal(5);
+			expect(chart.$.main.selectAll(`.${$SELECT.selectedCircle}`).size()).to.be.equal(1);
+		});
+
+		it("select() with no selectable match should preserve focus.only selection", () => {
+			chart.select(["data1"], [2], true);
+			chart.select(["data1"], [99], true);
+
+			const selected = chart.selected();
+
+			expect(selected.length).to.be.equal(1);
+			expect(selected[0].index).to.be.equal(2);
+			expect(chart.$.main.selectAll(`.${$SELECT.selectedCircle}`).size()).to.be.equal(1);
+		});
+
+		it("unselect() should work with focus.only", () => new Promise(done => {
+			chart.select(["data1"], [2], true);
+			chart.unselect(["data1"], [2]);
+
+			setTimeout(() => {
+				expect(chart.selected().length).to.be.equal(0);
+
+				done(1);
+			}, 500);
+		}));
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#3034

## Details
<!-- Detailed description of the change/feature -->
- Enforce data.selection.multiple=false in select()/setCanvasSelection API (SVG & canvas), keeping only a single point or one x-index group selected
- Support point.focus.only=true in the SVG select()/selected() API by operating on data and selected-circle elements instead of per-index shapes, with synchronous removal to avoid orphaned circles on rapid calls
- Render only the selection ring (not the data point) for selected-but- unfocused points in canvas focus.only mode, matching SVG