### PR TITLE
feat(subchart): support configurable subchart rendering

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3914,6 +3914,215 @@ var demos = {
 		}
 	},
 
+	SubChart: {
+		BasicSubChart: {
+			description: "Drag over the subchart area to zoom the main chart.<br>When zoomed, try dragging the zoom selection element or expand it by dragging each edge (left/right)",
+			options: {
+				data: {
+					columns: [
+						["sample", 30, 200, 100, 400, 150, 250]
+					],
+					type: "line"
+				},
+				subchart: {
+					show: "subchart()",
+					showHandle: true
+				}
+			}
+		},
+		SubchartType: {
+			description: "Use a different chart type in the subchart overview.",
+			options: {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 130, 100, 140, 200, 150, 50]
+					],
+					type: "line"
+				},
+				subchart: {
+					show: "subchart()",
+					type: "bar",
+					showHandle: true
+				}
+			}
+		},
+		SubchartTypes: {
+			description: "Specify chart types per data series in the subchart.",
+			options: {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 130, 100, 140, 200, 150, 50]
+					],
+					type: "line"
+				},
+				subchart: {
+					show: "subchart()",
+					type: "bar",
+					types: {
+						data2: "area"
+					},
+					showHandle: true
+				}
+			}
+		},
+		SubchartAxis: {
+			description: "Render y/y2 axes and tick options in the subchart.",
+			options: {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 130, 100, 140, 200, 150, 50]
+					],
+					axes: {
+						data2: "y2"
+					},
+					type: "line"
+				},
+				subchart: {
+					show: "subchart()",
+					axis: {
+						y: {
+							show: true,
+							tick: {
+								count: 3
+							}
+						},
+						y2: {
+							show: true,
+							tick: {
+								count: 3
+							}
+						}
+					}
+				},
+				axis: {
+					y2: {
+						show: true
+					}
+				}
+			}
+		},
+		ContinuousFocusGrid: {
+			description: "Disable brush interaction and render one continuous x focus grid line across main chart and subchart.",
+			options: {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250],
+						["data2", 130, 100, 140, 200, 150, 50]
+					],
+					type: "line"
+				},
+				subchart: {
+					show: "subchart()",
+					brush: {
+						enabled: false
+					},
+					grid: {
+						focus: {
+							continuous: true
+						}
+					}
+				}
+			}
+		},
+		CandlestickSubchartBar: {
+			description: "Render the main chart as candlestick and the subchart overview as zero-based body value bars.",
+			options: {
+				data: {
+					x: "x",
+					columns: [
+						["x", "2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-06", "2024-01-07", "2024-01-08", "2024-01-09", "2024-01-10", "2024-01-11", "2024-01-12", "2024-01-13", "2024-01-14", "2024-01-15", "2024-01-16", "2024-01-17", "2024-01-18", "2024-01-19", "2024-01-20", "2024-01-21", "2024-01-22", "2024-01-23", "2024-01-24", "2024-01-25", "2024-01-26", "2024-01-27", "2024-01-28", "2024-01-29", "2024-01-30", "2024-01-31", "2024-02-01", "2024-02-02", "2024-02-03", "2024-02-04", "2024-02-05", "2024-02-06", "2024-02-07", "2024-02-08", "2024-02-09"],
+						["data1",
+							// open, high, low, close
+							[1327, 1369, 1289, 1348],
+							[1348, 1371, 1314, 1320],
+							[1320, 1412, 1314, 1394],
+							[1394, 1458, 1393, 1453],
+							[1453, 1501, 1448, 1500],
+							[1500, 1510, 1492, 1496],
+							[1496, 1496, 1448, 1448],
+							[1448, 1490, 1433, 1490],
+							[1490, 1544, 1490, 1537],
+							[1537, 1563, 1534, 1544],
+							[1544, 1550, 1511, 1525],
+							[1525, 1609, 1517, 1604],
+							[1604, 1614, 1585, 1592],
+							[1592, 1632, 1586, 1620],
+							[1620, 1633, 1609, 1622],
+							[1622, 1697, 1620, 1687],
+							[1687, 1691, 1624, 1648],
+							[1648, 1689, 1640, 1671],
+							[1671, 1702, 1671, 1695],
+							[1695, 1727, 1689, 1724],
+							[1724, 1733, 1691, 1696],
+							[1696, 1733, 1696, 1731],
+							[1731, 1756, 1716, 1748],
+							[1748, 1769, 1734, 1762],
+							[1762, 1792, 1752, 1778],
+							[1778, 1783, 1763, 1769],
+							[1769, 1791, 1740, 1755],
+							[1755, 1755, 1711, 1725],
+							[1725, 1739, 1683, 1701],
+							[1701, 1731, 1694, 1730],
+							[1730, 1739, 1703, 1715],
+							[1715, 1745, 1710, 1731],
+							[1731, 1732, 1643, 1643],
+							[1643, 1662, 1608, 1615],
+							[1615, 1667, 1615, 1665],
+							[1665, 1689, 1663, 1671],
+							[1671, 1671, 1587, 1588],
+							[1588, 1599, 1521, 1533],
+							[1533, 1554, 1476, 1490],
+							[1490, 1494, 1432, 1443]
+						]
+					],
+					type: "candlestick",
+					colors: {
+						data1: "green"
+					}
+				},
+				candlestick: {
+					color: {
+						down: "red"
+					},
+					width: {
+						ratio: 0.6
+					}
+				},
+				subchart: {
+					show: "subchart()",
+					type: "bar",
+					brush: {
+						enabled: false
+					},
+					grid: {
+						focus: {
+							continuous: true
+						}
+					},
+					axis: {
+						y: {
+							show: true,
+							tick: {
+								count: 3
+							}
+						}
+					}
+				},
+				axis: {
+					x: {
+						type: "timeseries",
+						tick: {
+							format: "%Y-%m-%d"
+						}
+					}
+				}
+			}
+		}
+	},
+
 	Interaction: {
 		PreventScrollOnTouch: {
 			options: {
@@ -3932,21 +4141,6 @@ var demos = {
 							preventDefault: true
 						}
 					}
-				}
-			}
-		},
-		SubChart: {
-			description: "Drag over the subchart area to zoom the main chart.<br>When zoomed, try dragging the zoom selection element or expand it by dragging each edge (left/right)",
-			options: {
-				data: {
-					columns: [
-						["sample", 30, 200, 100, 400, 150, 250]
-					],
-					type: "line"
-				},
-				subchart: {
-					show: "subchart()",
-					showHandle: true
 				}
 			}
 		},

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -32,6 +32,45 @@ import {getScale} from "../internals/scale";
 import AxisRenderer from "./AxisRenderer";
 
 /**
+ * Get the corresponding main axis id for subchart axis ids.
+ * @param {string} id Axis id
+ * @returns {string} Base axis id
+ * @private
+ */
+function getBaseAxisId(id: string): string {
+	return id === "subX" ? "x" : (
+		id === "subY" ? "y" : (
+			id === "subY2" ? "y2" : id
+		)
+	);
+}
+
+/**
+ * Check whether the axis id belongs to subchart.
+ * @param {string} id Axis id
+ * @returns {boolean} Whether id is a subchart axis
+ * @private
+ */
+function isSubAxis(id: string): boolean {
+	return /^sub/.test(id);
+}
+
+/**
+ * Get tick option value for main/subchart axis.
+ * @param {object} config Chart config
+ * @param {string} id Axis id
+ * @param {string} key Tick option key
+ * @returns {boolean|number|string|Array|object|function|null|undefined} Tick option value
+ * @private
+ */
+function getAxisTickOption(config, id: string, key: string) {
+	const type = getBaseAxisId(id);
+	const subValue = config[`subchart_axis_${type}_tick_${key}`];
+
+	return isSubAxis(id) && subValue !== undefined ? subValue : config[`axis_${type}_tick_${key}`];
+}
+
+/**
  * Sample representative tick nodes to avoid N forced reflows in getMaxTickSize
  * @param {SVGTextElement[]} nodes All tick text nodes
  * @returns {SVGTextElement[]} Sampled subset: first, last, longest, and middle nodes
@@ -416,6 +455,8 @@ class Axis {
 
 	public x;
 	public subX;
+	public subY;
+	public subY2;
 	public y;
 	public y2;
 
@@ -430,7 +471,9 @@ class Axis {
 		x: "bottom",
 		y: "left",
 		y2: "right",
-		subX: "bottom"
+		subX: "bottom",
+		subY: "left",
+		subY2: "right"
 	};
 
 	constructor(owner) {
@@ -553,7 +596,9 @@ class Axis {
 			x: isRotated ? "left" : "bottom",
 			y: isRotated ? (yInner ? "top" : "bottom") : (yInner ? "right" : "left"),
 			y2: isRotated ? (y2Inner ? "bottom" : "top") : (y2Inner ? "left" : "right"),
-			subX: isRotated ? "left" : "bottom"
+			subX: isRotated ? "left" : "bottom",
+			subY: isRotated ? (yInner ? "top" : "bottom") : (yInner ? "right" : "left"),
+			subY2: isRotated ? (y2Inner ? "bottom" : "top") : (y2Inner ? "left" : "right")
 		};
 	}
 
@@ -653,9 +698,10 @@ class Axis {
 	 */
 	setAxis(id, scale, outerTick, noTransition): void {
 		const $$ = this.owner;
+		const type = getBaseAxisId(id);
 
-		if (id !== "subX") {
-			this.tick[id] = this.getTickValues(id);
+		if (!isSubAxis(id)) {
+			this.tick[type] = this.getTickValues(type);
 		}
 
 		// @ts-ignore
@@ -676,7 +722,7 @@ class Axis {
 		const $$ = this.owner;
 		const {config} = $$;
 		const isX = /^(x|subX)$/.test(id);
-		const type = isX ? "x" : id;
+		const type = getBaseAxisId(id);
 		const isCategory = isX && this.isCategorized();
 		const orient = this.orient[id];
 		const tickTextRotate = noTickTextRotate ? 0 : $$.getAxisTickRotate(type);
@@ -685,14 +731,16 @@ class Axis {
 		if (isX) {
 			tickFormat = (id === "subX") ? $$.format.subXAxisTick : $$.format.xAxisTick;
 		} else {
-			const fn = config[`axis_${id}_tick_format`];
+			const fn = isSubAxis(id) ?
+				config[`subchart_axis_${type}_tick_format`] || config[`axis_${type}_tick_format`] :
+				config[`axis_${type}_tick_format`];
 
 			if (isFunction(fn)) {
 				tickFormat = fn.bind($$.api);
 			}
 		}
 
-		let tickValues = this.tick[type];
+		let tickValues = isSubAxis(id) ? this.getTickValues(type, true) : this.tick[type];
 
 		const axisParams = mergeObj({
 			outerTick,
@@ -733,7 +781,8 @@ class Axis {
 		// Set tick
 		axis.tickFormat(
 			tickFormat || (
-				!isX && ($$.isStackNormalized() && $$.hasAxisGroupedData(id) && (x => `${x}%`))
+				!isX && ($$.isStackNormalized() && $$.hasAxisGroupedData(type) &&
+					(x => `${x}%`))
 			)
 		);
 
@@ -745,7 +794,7 @@ class Axis {
 			}
 		}
 
-		const tickCount = config[`axis_${type}_tick_count`];
+		const tickCount = getAxisTickOption(config, id, "count");
 
 		tickCount && axis.ticks(tickCount);
 
@@ -756,29 +805,40 @@ class Axis {
 		const $$ = this.owner;
 		const {config} = $$;
 		const fit = config.axis_x_tick_fit;
-		let count = config.axis_x_tick_count;
-		let values;
+		const generateValues = (countOption = config.axis_x_tick_count) => {
+			let count = countOption;
+			let values;
 
-		if (fit) {
-			values = $$.mapTargetsToUniqueXs(targets);
+			if (fit) {
+				values = $$.mapTargetsToUniqueXs(targets);
 
-			// if given count is greater than the value length, then limit the count.
-			if (this.isCategorized() && count > values.length) {
-				count = values.length;
+				// if given count is greater than the value length, then limit the count.
+				if (this.isCategorized() && count > values.length) {
+					count = values.length;
+				}
+
+				values = this.generateTickValues(
+					values,
+					count,
+					this.isTimeSeries()
+				);
 			}
 
-			values = this.generateTickValues(
-				values,
-				count,
-				this.isTimeSeries()
-			);
-		}
+			return values;
+		};
+		const values = generateValues();
 
 		if (axis) {
 			axis.tickValues(values);
 		} else if (this.x) {
+			const subTickValues = this.getTickValues("x", true);
+			const subTickCount = getAxisTickOption(config, "subX", "count");
+			const subValues = subTickValues ?? (
+				subTickCount !== config.axis_x_tick_count ? generateValues(subTickCount) : values
+			);
+
 			this.x.tickValues(values);
-			this.subX?.tickValues(values);
+			this.subX?.tickValues(subValues);
 		}
 
 		return values;
@@ -824,13 +884,15 @@ class Axis {
 			currFormat;
 	}
 
-	getTickValues(id: string) {
+	getTickValues(id: string, isSub = false) {
 		const $$ = this.owner;
-		const tickValues = $$.config[`axis_${id}_tick_values`];
+		const tickValues = isSub ?
+			getAxisTickOption($$.config, `sub${capitalize(id)}`, "values") :
+			$$.config[`axis_${id}_tick_values`];
+		const values = isFunction(tickValues) ? tickValues.call($$.api) : tickValues;
 		const axis = $$[`${id}Axis`];
 
-		return (isFunction(tickValues) ? tickValues.call($$.api) : tickValues) ||
-			(axis ? axis.tickValues() : undefined);
+		return isSub ? values ?? undefined : values || (axis ? axis.tickValues() : undefined);
 	}
 
 	getLabelOptionByAxisId(id: string) {
@@ -1442,10 +1504,17 @@ class Axis {
 		const $$ = this.owner;
 		const {$el: {axis}, $T} = $$;
 
-		const [axisX, axisY, axisY2, axisSubX] = ["x", "y", "y2", "subX"]
+		const [axisX, axisY, axisY2, axisSubX, axisSubY, axisSubY2] = [
+			"x",
+			"y",
+			"y2",
+			"subX",
+			"subY",
+			"subY2"
+		]
 			.map(v => $T(axis[v], withTransition));
 
-		return {axisX, axisY, axisY2, axisSubX};
+		return {axisX, axisY, axisY2, axisSubX, axisSubY, axisSubY2};
 	}
 
 	redraw(transitions, isHidden, isInit) {
@@ -1453,7 +1522,7 @@ class Axis {
 		const {config, state, $el} = $$;
 		const opacity = isHidden ? "0" : null;
 
-		["x", "y", "y2", "subX"].forEach(id => {
+		["x", "y", "y2", "subX", "subY", "subY2"].forEach(id => {
 			const axis = this[id];
 			const $axis = $el.axis[id];
 
@@ -1532,8 +1601,34 @@ class Axis {
 
 		// Update sub domain
 		if (wth.Y) {
-			scale.subY?.domain($$.getYDomain(targetsToShow, "y"));
-			scale.subY2?.domain($$.getYDomain(targetsToShow, "y2"));
+			const updateSubDomain = () => {
+				scale.subY?.domain($$.getYDomain(targetsToShow, "y"));
+				scale.subY2?.domain($$.getYDomain(targetsToShow, "y2"));
+
+				(["y", "y2"] as const).forEach(key => {
+					const subAxisId = key === "y2" ? "subY2" : "subY";
+					const axisScale = scale[subAxisId];
+					const axis = $$.axis[subAxisId];
+					const tickValues = this.getTickValues(key, true);
+					const tickCount = getAxisTickOption(config, subAxisId, "count");
+
+					if (!axisScale || !axis || tickValues || !tickCount) {
+						return;
+					}
+
+					const domain = axisScale.domain();
+
+					axis.tickValues(
+						this.generateTickValues(
+							domain,
+							domain.every(v => v === 0) ? 1 : tickCount,
+							this.isTimeSeriesY()
+						)
+					);
+				});
+			};
+
+			config.subchart_show ? $$.withSubchartTypeContext(updateSubDomain) : updateSubDomain();
 		}
 	}
 
@@ -1571,22 +1666,18 @@ class Axis {
 		const $$ = this.owner;
 		const {config, state: {clip, current}, $el} = $$;
 
-		["subX", "x", "y", "y2"].forEach(type => {
+		["subX", "x", "y", "y2", "subY", "subY2"].forEach(type => {
 			const axis = $el.axis[type];
 
-			// subchart x axis should be aligned with x axis culling
-			const id = type === "subX" ? "x" : type;
-
-			const cullingOptionPrefix = `axis_${id}_tick_culling`;
-			const toCull = config[cullingOptionPrefix];
+			const toCull = getAxisTickOption(config, type, "culling");
 
 			if (axis && toCull) {
 				const tickNodes = axis.selectAll(".tick");
 				const tickValues = sortValue(tickNodes.data(),
-					!config[`${cullingOptionPrefix}_reverse`]);
+					!getAxisTickOption(config, type, "culling_reverse"));
 				const tickSize = tickValues.length;
-				const cullingMax = config[`${cullingOptionPrefix}_max`];
-				const lines = config[`${cullingOptionPrefix}_lines`];
+				const cullingMax = getAxisTickOption(config, type, "culling_max");
+				const lines = getAxisTickOption(config, type, "culling_lines");
 				const cullTickLine = !lines || _hasOverlappedTickLineIntervals(
 					this[type],
 					tickValues,

--- a/src/ChartInternal/Axis/AxisRenderer.ts
+++ b/src/ChartInternal/Axis/AxisRenderer.ts
@@ -10,6 +10,32 @@ import {AXIS_TICK_LENGTH, AXIS_TICK_PADDING, AXIS_TICK_SIZE} from "../../config/
 import {isArray, isFunction, isNumber, isString, toArray} from "../../module/util";
 import Helper from "./AxisRendererHelper";
 
+/**
+ * Get the corresponding main axis id for subchart axis ids.
+ * @param {string} id Axis id
+ * @returns {string} Base axis id
+ * @private
+ */
+function getBaseAxisId(id: string): string {
+	return id === "subX" ? "x" : (
+		id === "subY" ? "y" : (
+			id === "subY2" ? "y2" : id
+		)
+	);
+}
+
+/**
+ * Get config option prefix for an axis id.
+ * @param {string} id Axis id
+ * @returns {string} Option prefix
+ * @private
+ */
+function getAxisOptionPrefix(id: string): string {
+	const type = getBaseAxisId(id);
+
+	return /^sub/.test(id) ? `subchart_axis_${type}` : `axis_${type}`;
+}
+
 export default class AxisRenderer {
 	private helper;
 	private config;
@@ -21,9 +47,10 @@ export default class AxisRenderer {
 		const {config, params} = this;
 		const {config: chartConfig, id, owner} = params;
 		const isX = /^(x|subX)$/.test(id);
-		const type = id === "subX" ? "x" : id;
-		const customTickFormat = id === "subX" ?
-			chartConfig.subchart_axis_x_tick_format || chartConfig.axis_x_tick_format :
+		const type = getBaseAxisId(id);
+		const customTickFormat = /^sub/.test(id) ?
+			chartConfig[`subchart_axis_${type}_tick_format`] ||
+			chartConfig[`axis_${type}_tick_format`] :
 			chartConfig[`axis_${type}_tick_format`];
 		const categoryAutoWrap = params.tickMultiline && params.isCategory && !isLeftRight &&
 			!(params.tickWidth > 0);
@@ -122,12 +149,13 @@ export default class AxisRenderer {
 
 		// // get the axis' tick position configuration
 		const id = params.id;
-		const tickTextPos = id && /^(x|y|y2)$/.test(id) ?
-			params.config[`axis_${id}_tick_text_position`] :
+		const type = getBaseAxisId(id);
+		const tickTextPos = type && /^(x|y|y2)$/.test(type) ?
+			params.config[`axis_${type}_tick_text_position`] :
 			{x: 0, y: 0};
 
 		// tick visiblity
-		const prefix = id === "subX" ? `subchart_axis_x` : `axis_${id}`;
+		const prefix = getAxisOptionPrefix(id);
 		const axisShow = params.config[`${prefix}_show`];
 		const tickShow = {
 			tick: axisShow ? params.config[`${prefix}_tick_show`] : false,
@@ -423,7 +451,7 @@ export default class AxisRenderer {
 			}
 		} = this.params.owner;
 
-		const tickLineInner = this.params.config[`axis_${axisId}_tick_inner`];
+		const tickLineInner = this.params.config[`axis_${getBaseAxisId(axisId)}_tick_inner`];
 
 		switch (orient) {
 			case "bottom":

--- a/src/ChartInternal/data/data.ts
+++ b/src/ChartInternal/data/data.ts
@@ -4,6 +4,7 @@
  */
 import {select as d3Select} from "d3-selection";
 import {$BAR, $CANDLESTICK, $COMMON} from "../../config/classes";
+import {TYPE} from "../../config/const";
 import {KEY} from "../../module/Cache";
 import {
 	findIndex,
@@ -1458,7 +1459,9 @@ export default {
 		const $$ = this;
 		const {value} = d;
 
-		return $$.isBarType(d) && isArray(value) && value.length >= 2 &&
+		return $$.isBarType(d) &&
+			!$$.isSubchartSourceTypeOf?.(d, TYPE.CANDLESTICK) &&
+			isArray(value) && value.length >= 2 &&
 			value.every(isNumber);
 	},
 

--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -390,6 +390,7 @@ export default {
 		if (isTooltipGrouped) {
 			$$.showTooltip(selectedData, context);
 			$$.showGridFocus?.(selectedData);
+			$$.showSubchartGridFocus?.(selectedData);
 
 			if (!isSelectionEnabled || isSelectionGrouped) {
 				return;
@@ -424,6 +425,7 @@ export default {
 				if (!isTooltipGrouped) {
 					$$.showTooltip(d, context);
 					$$.showGridFocus?.(d);
+					$$.showSubchartGridFocus?.(d);
 					$$.unexpandCircles?.();
 
 					selected.each(d => $$.setExpand(index, d.id));
@@ -458,6 +460,7 @@ export default {
 
 				$$.showTooltip([closest], context);
 				$$.showGridFocus?.([closest]);
+				$$.showSubchartGridFocus?.([closest]);
 				$$.unexpandCircles?.();
 
 				$$.setExpand(index, closest.id, true);
@@ -470,6 +473,7 @@ export default {
 				}
 			} else if (config.interaction_onout) {
 				$$.hideGridFocus?.();
+				$$.hideSubchartGridFocus?.();
 				$$.hideTooltip();
 
 				!isSelectionGrouped && $$.setExpand(index);
@@ -522,6 +526,7 @@ export default {
 
 		// Show xgrid focus line (optional module — grid resolver)
 		$$.showGridFocus?.(selectedData);
+		$$.showSubchartGridFocus?.(selectedData);
 
 		const dist = $$.dist(closest, mouse);
 
@@ -560,6 +565,7 @@ export default {
 
 		$$.$el.eventRect?.style("cursor", null);
 		$$.hideGridFocus?.();
+		$$.hideSubchartGridFocus?.();
 
 		if (tooltip) {
 			$$.hideTooltip();

--- a/src/ChartInternal/interactions/subchart.ts
+++ b/src/ChartInternal/interactions/subchart.ts
@@ -6,9 +6,231 @@ import {brushSelection as d3BrushSelection, brushX as d3BrushX, brushY as d3Brus
 import {select as d3Select} from "d3-selection";
 import CLASS from "../../config/classes";
 import {SUBCHART_BRUSH_HANDLE_PATH} from "../../config/const";
-import {brushEmpty, capitalize, isArray} from "../../module/util";
+import {window} from "../../module/browser";
+import {
+	brushEmpty,
+	capitalize,
+	emulateEvent,
+	getBoundingRect,
+	getPointer,
+	isArray
+} from "../../module/util";
+import {
+	getMainCoordFromSubchartCoord,
+	isContinuousGridFocusEnabled
+} from "../internals/subchart.util";
+
+const SUBCHART_TYPES = ["bar", "line", "bubble", "candlestick", "scatter"];
+const FOCUS_GRID_STYLE_PROPS = [
+	"opacity",
+	"stroke",
+	"stroke-dasharray",
+	"stroke-dashoffset",
+	"stroke-linecap",
+	"stroke-linejoin",
+	"stroke-miterlimit",
+	"stroke-opacity",
+	"stroke-width"
+];
+
+/**
+ * Copy main focus grid computed styles to the subchart focus grid line.
+ * @param {object} $$ ChartInternal instance
+ * @param {object} line Subchart focus grid line selection
+ * @private
+ */
+function syncSubchartGridFocusStyle($$, line): void {
+	const source = $$.$el.grid?.main?.select(`line.${CLASS.xgridFocus}`).node();
+
+	if (!source || !window.getComputedStyle) {
+		return;
+	}
+
+	const style = window.getComputedStyle(source);
+
+	FOCUS_GRID_STYLE_PROPS.forEach(prop => {
+		const value = style.getPropertyValue(prop);
+
+		value && line.style(prop, value);
+	});
+}
+
+/**
+ * Convert an SVG attr value to finite number with fallback.
+ * @param {string|null} value Attribute value
+ * @param {number} fallback Fallback value
+ * @returns {number} Numeric value
+ * @private
+ */
+function getFiniteAttr(value: string | null, fallback: number): number {
+	const parsed = Number(value);
+
+	return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/**
+ * Show a single clipped-free x focus grid line spanning main chart and subchart.
+ * @param {object} $$ ChartInternal instance
+ * @returns {boolean} Whether continuous focus line was rendered
+ * @private
+ */
+function showContinuousSubchartGridFocus($$): boolean {
+	if (!isContinuousGridFocusEnabled($$)) {
+		return false;
+	}
+
+	const {config, state, $el} = $$;
+	const mainLine = $el.grid?.main?.select(
+		`line.${CLASS.xgridFocus}:not(.${CLASS.xgridFocusContinuous})`
+	);
+	const line = $el.main.select(`line.${CLASS.xgridFocusContinuous}`);
+
+	if (!mainLine?.node() || !line.node()) {
+		return false;
+	}
+
+	const x2 = state.margin2.left - state.margin.left + state.width2;
+	const y2 = state.margin2.top - state.margin.top + state.height2;
+
+	syncSubchartGridFocusStyle($$, line);
+
+	config.axis_rotated ?
+		line
+			.attr("x1", getFiniteAttr(mainLine.attr("x1"), 0))
+			.attr("x2", x2)
+			.attr("y1", getFiniteAttr(mainLine.attr("y1"), -10))
+			.attr("y2", getFiniteAttr(mainLine.attr("y2"), -10)) :
+		line
+			.attr("x1", getFiniteAttr(mainLine.attr("x1"), -10))
+			.attr("x2", getFiniteAttr(mainLine.attr("x2"), -10))
+			.attr("y1", getFiniteAttr(mainLine.attr("y1"), 0))
+			.attr("y2", y2);
+
+	line.style("visibility", null);
+	mainLine.style("visibility", "hidden");
+
+	return true;
+}
+
+/**
+ * Hide continuous subchart focus grid line.
+ * @param {object} $$ ChartInternal instance
+ * @private
+ */
+function hideContinuousSubchartGridFocus($$): void {
+	$$.$el.main
+		?.select(`line.${CLASS.xgridFocusContinuous}`)
+		.style("visibility", "hidden");
+}
+
+/**
+ * Get main chart pointer coordinates that correspond to a subchart pointer event.
+ * @param {object} $$ ChartInternal instance
+ * @param {Event} event Input event
+ * @param {SVGElement} context Subchart event rect
+ * @returns {Array|null} Main chart local coordinates
+ * @private
+ */
+function getMainPointFromSubchartEvent($$, event, context): [number, number] | null {
+	const {config, state} = $$;
+	const [x, y] = getPointer(event, context);
+	const mainCoord = getMainCoordFromSubchartCoord($$, config.axis_rotated ? y : x);
+
+	if (mainCoord === null) {
+		return null;
+	}
+
+	return config.axis_rotated ? [state.width / 2, mainCoord] : [mainCoord, state.height / 2];
+}
+
+/**
+ * Dispatch a subchart pointer event through the main chart event rect.
+ * @param {object} $$ ChartInternal instance
+ * @param {string} type Event type
+ * @param {Event} event Input event
+ * @param {SVGElement} context Subchart event rect
+ * @private
+ */
+function dispatchSubchartEvent($$, type: string, event, context): void {
+	const mainEventRect = $$.$el.eventRect?.node?.();
+
+	if (!mainEventRect) {
+		return;
+	}
+
+	const point = getMainPointFromSubchartEvent($$, event, context) || [0, 0];
+	const rect = getBoundingRect(mainEventRect, true);
+	const clientX = rect.left + point[0];
+	const clientY = rect.top + point[1];
+	const params = {
+		bubbles: true,
+		cancelable: true,
+		screenX: clientX,
+		screenY: clientY,
+		clientX,
+		clientY
+	};
+
+	/^touch/.test(type) ?
+		emulateEvent.touch(mainEventRect, type, params) :
+		emulateEvent.mouse(mainEventRect, type, params);
+}
 
 export default {
+	/**
+	 * Whether subchart brush interaction is enabled.
+	 * @returns {boolean}
+	 * @private
+	 */
+	isSubchartBrushEnabled(): boolean {
+		const {config} = this;
+
+		return config.subchart_show && config.subchart_brush_enabled !== false;
+	},
+
+	/**
+	 * Bind event rect handlers for subchart hover interactions.
+	 * @param {d3Selection} eventRect Subchart event rect selection
+	 * @private
+	 */
+	bindSubchartEventRect(eventRect): void {
+		const $$ = this;
+		const {config, state} = $$;
+
+		eventRect.on("mouseover mousemove mouseout touchstart touchmove touchend", null);
+
+		if (!config.interaction_enabled) {
+			return;
+		}
+
+		if (state.inputType === "mouse") {
+			eventRect
+				.on("mouseover mousemove", function(event) {
+					if ($$.isSubchartBrushEnabled()) {
+						return;
+					}
+
+					dispatchSubchartEvent($$, event.type, event, this);
+				})
+				.on("mouseout", function(event) {
+					if ($$.isSubchartBrushEnabled()) {
+						return;
+					}
+
+					dispatchSubchartEvent($$, "mouseout", event, this);
+				});
+		} else if (state.inputType === "touch") {
+			eventRect
+				.on("touchstart touchmove touchend", function(event) {
+					if ($$.isSubchartBrushEnabled() || event.touches?.length > 1) {
+						return;
+					}
+
+					dispatchSubchartEvent($$, event.type, event, this);
+				});
+		}
+	},
+
 	/**
 	 * Initialize the brush.
 	 * @private
@@ -149,29 +371,51 @@ export default {
 			.attr("clip-path", clipPath)
 			.attr("class", CLASS.chart);
 
-		// Define g for chart types area
-		["bar", "line", "bubble", "candlestick", "scatter"].forEach(v => {
-			const type = capitalize(/^(bubble|scatter)$/.test(v) ? "circle" : v);
+		$$.withSubchartTypeContext(() => {
+			// Define g for chart types area
+			SUBCHART_TYPES.forEach(v => {
+				const type = capitalize(/^(bubble|scatter)$/.test(v) ? "circle" : v);
 
-			if ($$.hasType(v) || $$.hasTypeOf(type)) {
-				const chart = main.select(`.${CLASS.chart}`);
-				const chartClassName = CLASS[`chart${type}s`];
+				if ($$.hasType(v) || $$.hasTypeOf(type)) {
+					const chart = main.select(`.${CLASS.chart}`);
+					const chartClassName = CLASS[`chart${type}s`];
 
-				if (chart.select(`.${chartClassName}`).empty()) {
-					chart
-						.append("g")
-						.attr("class", chartClassName);
+					if (chart.select(`.${chartClassName}`).empty()) {
+						chart
+							.append("g")
+							.attr("class", chartClassName);
+					}
 				}
-			}
+			});
 		});
 
 		// Add extent rect for Brush
 		const brush = main.append("g")
 			.attr("clip-path", clipPath)
 			.attr("class", CLASS.brush)
+			.style("pointer-events", $$.isSubchartBrushEnabled() ? null : "none")
 			.call($$.brush);
 
 		config.subchart_showHandle && $$.addBrushHandle(brush);
+
+		subchart.eventRect = main.append("g")
+			.attr("clip-path", clipPath)
+			.attr("class", `${CLASS.eventRects} ${CLASS.eventRects}-subchart`)
+			.style("fill-opacity", "0")
+			.style("pointer-events", $$.isSubchartBrushEnabled() ? "none" : "all")
+			.append("rect")
+			.attr("class", `${CLASS.eventRect} ${CLASS.eventRect}-subchart`)
+			.attr("width", $$.state.width2)
+			.attr("height", $$.state.height2);
+
+		$$.bindSubchartEventRect(subchart.eventRect);
+
+		main.append("g")
+			.attr("clip-path", clipPath)
+			.attr("class", CLASS.xgridFocus)
+			.append("line")
+			.attr("class", CLASS.xgridFocus)
+			.style("visibility", "hidden");
 
 		// ATTENTION: This must be called AFTER chart added
 		// Add Axis
@@ -180,6 +424,16 @@ export default {
 			.attr("transform", $$.getTranslate("subX"))
 			.attr("clip-path", config.axis_rotated ? "" : clip.pathXAxis)
 			.style("visibility", config.subchart_axis_x_show ? visibility : "hidden");
+
+		axis.subY = main.append("g")
+			.attr("class", CLASS.axisY)
+			.attr("transform", $$.getTranslate("subY"))
+			.style("visibility", config.subchart_axis_y_show ? visibility : "hidden");
+
+		axis.subY2 = main.append("g")
+			.attr("class", CLASS.axisY2)
+			.attr("transform", $$.getTranslate("subY2"))
+			.style("visibility", config.subchart_axis_y2_show ? visibility : "hidden");
 	},
 
 	/**
@@ -217,51 +471,72 @@ export default {
 		const {config, state, $el: {subchart: {main}}} = $$;
 
 		if (config.subchart_show) {
-			["bar", "line", "bubble", "candlestick", "scatter"]
-				.filter(v => $$.hasType(v) || $$.hasTypeOf(capitalize(v)))
-				.forEach(v => {
-					const isPointType = /^(bubble|scatter)$/.test(v);
-					const name = capitalize(isPointType ? "circle" : v);
-					const chartClass = $$.getChartClass(name, true);
-					const shapeClass = $$.getClass(isPointType ? "circles" : `${v}s`, true);
+			$$.withSubchartTypeContext(() => {
+				SUBCHART_TYPES
+					.filter(v => $$.hasType(v) || $$.hasTypeOf(capitalize(v)))
+					.forEach(v => {
+						const isPointType = /^(bubble|scatter)$/.test(v);
+						const name = capitalize(isPointType ? "circle" : v);
+						const chartClass = $$.getChartClass(name, true);
+						const shapeClass = $$.getClass(isPointType ? "circles" : `${v}s`, true);
 
-					const shapeChart = main.select(`.${CLASS[`chart${`${name}s`}`]}`);
+						const shapeChart = main.select(`.${CLASS[`chart${`${name}s`}`]}`);
 
-					if (isPointType) {
-						const circle = shapeChart
-							.selectAll(`.${CLASS.circles}`)
-							.data(targets.filter($$[`is${capitalize(v)}Type`].bind($$)))
-							.attr("class", shapeClass);
+						if (isPointType) {
+							const circle = shapeChart
+								.selectAll(`.${CLASS.circles}`)
+								.data(targets.filter($$[`is${capitalize(v)}Type`].bind($$)))
+								.attr("class", shapeClass);
 
-						circle.exit().remove();
-						circle.enter().append("g")
-							.attr("class", shapeClass);
-					} else {
-						const shapeUpdate = shapeChart
-							.selectAll(`.${CLASS[`chart${name}`]}`)
-							.attr("class", chartClass)
-							.data(targets.filter($$[`is${name}Type`].bind($$)));
+							circle.exit().remove();
+							circle.enter().append("g")
+								.attr("class", shapeClass);
+						} else {
+							const shapeUpdate = shapeChart
+								.selectAll(`.${CLASS[`chart${name}`]}`)
+								.attr("class", chartClass)
+								.data(targets.filter($$[`is${name}Type`].bind($$)));
 
-						const shapeEnter = shapeUpdate.enter()
-							.append("g")
-							.style("opacity", "0")
-							.attr("class", chartClass)
-							.append("g")
-							.attr("class", shapeClass);
+							const shapeEnter = shapeUpdate.enter()
+								.append("g")
+								.style("opacity", "0")
+								.attr("class", chartClass)
+								.append("g")
+								.attr("class", shapeClass);
 
-						shapeUpdate.exit().remove();
+							shapeUpdate.exit().remove();
 
-						// Area
-						v === "line" && $$.hasTypeOf("Area") &&
-							shapeEnter.append("g").attr("class", $$.getClass("areas", true));
-					}
-				});
+							// Area
+							v === "line" && $$.hasTypeOf("Area") &&
+								shapeEnter.append("g").attr("class", $$.getClass("areas", true));
+						}
+					});
+			});
 
 			// -- Brush --//
 			main.selectAll(`.${CLASS.brush} rect`)
 				.attr(config.axis_rotated ? "width" : "height",
 					config.axis_rotated ? state.width2 : state.height2);
+
+			$$.$el.subchart.eventRect
+				?.attr("width", state.width2)
+				.attr("height", state.height2)
+				.style("pointer-events", $$.isSubchartBrushEnabled() ? "none" : "all");
 		}
+	},
+
+	/**
+	 * Update subchart y domains using subchart type options.
+	 * @param {object} targets Targets to show
+	 * @private
+	 */
+	updateSubchartYDomain(targets): void {
+		const $$ = this;
+		const {scale} = $$;
+		const targetsToShow = targets || $$.filterTargetsToShow($$.data.targets);
+
+		scale.subY?.domain($$.getYDomain(targetsToShow, "y"));
+		scale.subY2?.domain($$.getYDomain(targetsToShow, "y2"));
 	},
 
 	/**
@@ -269,14 +544,21 @@ export default {
 	 * @private
 	 * @param {boolean} withSubchart whether or not to show subchart
 	 * @param {number} duration duration
-	 * @param {object} shape Shape's info
 	 */
-	redrawSubchart(withSubchart: boolean, duration: number, shape): void {
+	redrawSubchart(withSubchart: boolean, duration: number): void {
 		const $$ = this;
 		const {config, $el: {subchart: {main}}, state} = $$;
 		const withTransition = !!duration;
 
 		main.style("visibility", config.subchart_show ? null : "hidden");
+		main.select(`.${CLASS.brush}`)
+			.style("pointer-events", $$.isSubchartBrushEnabled() ? null : "none");
+		$$.$el.subchart.eventRect
+			?.style("pointer-events", $$.isSubchartBrushEnabled() ? "none" : "all");
+		$$.$el.axis.subY
+			?.style("visibility", config.subchart_axis_y_show ? null : "hidden");
+		$$.$el.axis.subY2
+			?.style("visibility", config.subchart_axis_y2_show ? null : "hidden");
 
 		// subchart
 		if (config.subchart_show) {
@@ -292,22 +574,31 @@ export default {
 				// extent rect
 				!brushEmpty($$) && $$.brush.update();
 
-				Object.keys(shape.type).forEach(v => {
-					const name = capitalize(v);
-					const drawFn = $$[`generateDraw${name}`](shape.indices[v], true);
+				$$.withSubchartTypeContext(() => {
+					const targetsToShow = state._targetsToShow ||
+						$$.filterTargetsToShow($$.data.targets);
 
-					// call shape's update & redraw method
-					$$[`update${name}`](withTransition, true);
-					$$[`redraw${name}`](drawFn, withTransition, true);
+					$$.updateSubchartYDomain(targetsToShow);
+
+					const subchartShape = $$.getDrawShape();
+
+					Object.keys(subchartShape.type).forEach(v => {
+						const name = capitalize(v);
+						const drawFn = $$[`generateDraw${name}`](subchartShape.indices[v], true);
+
+						// call shape's update & redraw method
+						$$[`update${name}`](withTransition, true);
+						$$[`redraw${name}`](drawFn, withTransition, true);
+					});
+
+					if ($$.hasType("bubble") || $$.hasType("scatter")) {
+						const {cx} = subchartShape.pos;
+						const cy = $$.updateCircleY(true);
+
+						$$.updateCircle(true);
+						$$.redrawCircle(cx, cy, withTransition, undefined, true);
+					}
 				});
-
-				if ($$.hasType("bubble") || $$.hasType("scatter")) {
-					const {cx} = shape.pos;
-					const cy = $$.updateCircleY(true);
-
-					$$.updateCircle(true);
-					$$.redrawCircle(cx, cy, withTransition, undefined, true);
-				}
 
 				if (!state.rendered && initRange) {
 					state.domain = initRange;
@@ -319,6 +610,77 @@ export default {
 				}
 			}
 		}
+	},
+
+	/**
+	 * Show a focus grid line on subchart following main chart focus.
+	 * @param {Array} data Selected data
+	 * @private
+	 */
+	showSubchartGridFocus(data): void {
+		const $$ = this;
+		const {config, state, $el: {subchart: {main}}} = $$;
+
+		if (
+			!main ||
+			!config.subchart_show ||
+			$$.isSubchartBrushEnabled() ||
+			config.grid_focus_show === false ||
+			!config.tooltip_show ||
+			config.axis_tooltip
+		) {
+			return;
+		}
+
+		const focusData = Array.isArray(data) ? data : [data];
+		const focus = focusData.find(d => d && $$.getBaseValue(d) != null);
+
+		if (!focus) {
+			$$.hideSubchartGridFocus();
+			return;
+		}
+
+		const pos = $$.scale.subX(focus.x);
+
+		if (!Number.isFinite(pos)) {
+			$$.hideSubchartGridFocus();
+			return;
+		}
+
+		const line = main.select(`g.${CLASS.xgridFocus} line.${CLASS.xgridFocus}`);
+
+		if (showContinuousSubchartGridFocus($$)) {
+			line.style("visibility", "hidden");
+			return;
+		}
+
+		syncSubchartGridFocusStyle($$, line);
+
+		config.axis_rotated ?
+			line
+				.attr("x1", 0)
+				.attr("x2", state.width2)
+				.attr("y1", pos)
+				.attr("y2", pos) :
+			line
+				.attr("x1", pos)
+				.attr("x2", pos)
+				.attr("y1", 0)
+				.attr("y2", state.height2);
+
+		line.style("visibility", null);
+	},
+
+	/**
+	 * Hide subchart focus grid line.
+	 * @private
+	 */
+	hideSubchartGridFocus(): void {
+		hideContinuousSubchartGridFocus(this);
+
+		this.$el.subchart.main
+			?.select(`g.${CLASS.xgridFocus} line.${CLASS.xgridFocus}`)
+			.style("visibility", "hidden");
 	},
 
 	/**
@@ -362,8 +724,16 @@ export default {
 		const subXAxis = transitions?.axisSubX ?
 			transitions.axisSubX :
 			$T(subchart.main.select(`.${CLASS.axisX}`), withTransition);
+		const subYAxis = transitions?.axisSubY ?
+			transitions.axisSubY :
+			$T(subchart.main.select(`.${CLASS.axisY}`), withTransition);
+		const subY2Axis = transitions?.axisSubY2 ?
+			transitions.axisSubY2 :
+			$T(subchart.main.select(`.${CLASS.axisY2}`), withTransition);
 
 		subchart.main.attr("transform", $$.getTranslate("context"));
 		subXAxis.attr("transform", $$.getTranslate("subX"));
+		subYAxis.attr("transform", $$.getTranslate("subY"));
+		subY2Axis.attr("transform", $$.getTranslate("subY2"));
 	}
 };

--- a/src/ChartInternal/internals/domain.ts
+++ b/src/ChartInternal/internals/domain.ts
@@ -37,8 +37,10 @@ function getTargetDomainCacheKey($$, targets: IData[]): string {
 		const last = values[values.length - 1];
 		const firstX = first ? $$.getXCacheKey?.(first.x) ?? first.x : "";
 		const lastX = last ? $$.getXCacheKey?.(last.x) ?? last.x : "";
+		const targetType = $$.getTargetType?.(target) ?? "";
+		const sourceType = $$.state?.subchartSourceTypes?.[target.id] ?? "";
 
-		return `${target.id}:${values.length}:${firstX}:${lastX}`;
+		return `${target.id}:${targetType}:${sourceType}:${values.length}:${firstX}:${lastX}`;
 	}).join("|");
 }
 
@@ -113,7 +115,8 @@ function getTargetValueMinMax($$, targets: IData[]): DomainMinMax {
 
 	for (let i = 0; i < targets.length; i++) {
 		const target = targets[i];
-		const isCandlestick = $$.isCandlestickType?.(target);
+		const isCandlestick = $$.isCandlestickType?.(target) ||
+			$$.isSubchartSourceTypeOf?.(target, TYPE.CANDLESTICK);
 		const {values} = target;
 
 		for (let j = 0; j < values.length; j++) {
@@ -124,7 +127,11 @@ function getTargetValueMinMax($$, targets: IData[]): DomainMinMax {
 				continue;
 			}
 
-			if (value !== null && isCandlestick) {
+			const subchartCandlestickValue = $$.getSubchartCandlestickShapeValue?.(row, true);
+
+			if (isNumber(subchartCandlestickValue)) {
+				value = subchartCandlestickValue;
+			} else if (value !== null && isCandlestick) {
 				value = Array.isArray(value) ?
 					value.slice(0, 4) :
 					[value.open, value.high, value.low, value.close];

--- a/src/ChartInternal/internals/grid.ts
+++ b/src/ChartInternal/internals/grid.ts
@@ -10,7 +10,8 @@ import {getPointer, isArray, isValue} from "../../module/util";
 import type {IDataRow} from "../data/IData";
 
 // Grid position and text anchor helpers
-const GRID_FOCUS_SELECTOR = `line.${$FOCUS.xgridFocus}, line.${$FOCUS.ygridFocus}`;
+const GRID_FOCUS_SELECTOR = `line.${$FOCUS.xgridFocus}:not(.${$FOCUS.xgridFocusContinuous}), ` +
+	`line.${$FOCUS.ygridFocus}`;
 const _getGridTextAnchor = d => isValue(d.position) || "end";
 const _getGridTextDx = d => (d.position === "start" ? 4 : (d.position === "middle" ? 0 : -4));
 
@@ -29,6 +30,16 @@ function _getGridFocusEl($$): d3Selection {
 	return cachedNodes.length && cachedNodes.every(node => mainNode?.contains(node)) ?
 		cached :
 		(state._gridFocusEl = main.selectAll(GRID_FOCUS_SELECTOR));
+}
+
+/**
+ * Hide continuous subchart focus grid line.
+ * @param {object} $$ ChartInternal context
+ * @private
+ */
+function _hideContinuousGridFocus($$): void {
+	$$.$el.main.select(`line.${$FOCUS.xgridFocusContinuous}`)
+		.style("visibility", "hidden");
 }
 
 /**
@@ -342,6 +353,12 @@ export default {
 					.append("line")
 					.attr("class", $FOCUS.ygridFocus);
 			}
+
+			config.subchart_grid_focus_continuous && $el.main.insert("g", className)
+				.attr("class", $FOCUS.xgridFocusContinuous)
+				.append("line")
+				.attr("class", `${$FOCUS.xgridFocus} ${$FOCUS.xgridFocusContinuous}`)
+				.style("visibility", "hidden");
 		}
 	},
 
@@ -492,6 +509,7 @@ export default {
 			const focusEl = _getGridFocusEl($$);
 
 			focusEl.style("visibility", "hidden");
+			_hideContinuousGridFocus($$);
 			$$.hideCircleFocus?.();
 		}
 	},
@@ -515,6 +533,7 @@ export default {
 				.attr("x2", isRotated ? width : -10)
 				.attr("y1", isRotated ? -10 : 0)
 				.attr("y2", isRotated ? -10 : height);
+			_hideContinuousGridFocus($$);
 		}
 
 		// need to return 'true' as of being pushed to the redraw list

--- a/src/ChartInternal/internals/scale.ts
+++ b/src/ChartInternal/internals/scale.ts
@@ -211,7 +211,8 @@ export default {
 			axis.setAxis("x", scale.x, config.axis_x_tick_outer, isInit);
 
 			if (config.subchart_show) {
-				axis.setAxis("subX", scale.subX, config.axis_x_tick_outer, isInit);
+				axis.setAxis("subX", scale.subX,
+					config.subchart_axis_x_tick_outer ?? config.axis_x_tick_outer, isInit);
 			}
 
 			// y Axis
@@ -226,9 +227,12 @@ export default {
 			);
 
 			axis.setAxis("y", scale.y, config.axis_y_tick_outer, isInit);
+			config.subchart_show && config.subchart_axis_y_show &&
+				axis.setAxis("subY", scale.subY,
+					config.subchart_axis_y_tick_outer ?? config.axis_y_tick_outer, isInit);
 
 			// y2 Axis
-			if (config.axis_y2_show) {
+			if (config.axis_y2_show || config.subchart_axis_y2_show) {
 				scale.y2 = $$.getYScale("y2", min.y, max.y,
 					scale.y2 ? scale.y2.domain() : config.axis_y2_default, scale.y2);
 				scale.subY2 = $$.getYScale(
@@ -240,6 +244,9 @@ export default {
 				);
 
 				axis.setAxis("y2", scale.y2, config.axis_y2_tick_outer, isInit);
+				config.subchart_show && config.subchart_axis_y2_show &&
+					axis.setAxis("subY2", scale.subY2,
+						config.subchart_axis_y2_tick_outer ?? config.axis_y2_tick_outer, isInit);
 			}
 		} else if (hasTreemap) {
 			const padding = $$.getCurrentPadding();

--- a/src/ChartInternal/internals/subchart.util.ts
+++ b/src/ChartInternal/internals/subchart.util.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+
+/**
+ * Check whether the x focus grid should be rendered as one continuous line
+ * spanning both the main chart and the subchart.
+ * Shared by the SVG and canvas renderers, so both stay in sync.
+ * @param {object} $$ ChartInternal instance
+ * @returns {boolean} Whether continuous focus line is enabled
+ * @private
+ */
+export function isContinuousGridFocusEnabled($$): boolean {
+	const {config, state} = $$;
+
+	return !!(
+		config.subchart_grid_focus_continuous &&
+		config.subchart_show &&
+		config.subchart_brush_enabled === false &&
+		state.width2 > 0 &&
+		state.height2 > 0
+	);
+}
+
+/**
+ * Convert a subchart local index axis coordinate to the matching main chart coordinate.
+ * Falls back to a proportional mapping when the x scale can't invert the coordinate
+ * (ex. category/ordinal scales) and clamps the result to the main plot length.
+ * @param {object} $$ ChartInternal instance
+ * @param {number} subCoord Subchart local coordinate on the index axis
+ * @returns {number|null} Main chart local coordinate, or null when not resolvable
+ * @private
+ */
+export function getMainCoordFromSubchartCoord($$, subCoord: number): number | null {
+	const {config, scale, state} = $$;
+	const mainX = scale.zoom || scale.x;
+	const subX = scale.subX;
+
+	if (!mainX || !subX) {
+		return null;
+	}
+
+	const subLength = config.axis_rotated ? state.height2 : state.width2;
+	const mainLength = config.axis_rotated ? state.height : state.width;
+	const domainValue = subX.invert?.(subCoord);
+	let mainCoord = domainValue == null ? NaN : mainX(domainValue);
+
+	if (!Number.isFinite(mainCoord) && subLength > 0) {
+		mainCoord = Math.max(0, Math.min(1, subCoord / subLength)) * mainLength;
+	}
+
+	return Number.isFinite(mainCoord) ? Math.max(0, Math.min(mainLength, mainCoord)) : null;
+}

--- a/src/ChartInternal/internals/transform.ts
+++ b/src/ChartInternal/internals/transform.ts
@@ -5,8 +5,8 @@
 import {$ARC, $AXIS} from "../../config/classes";
 import {asHalfPixel} from "../../module/util";
 
-type TranslateParam = "main" | "context" | "legend" | "x" | "y" | "y2" | "subX" | "arc" | "radar"
-	| "polar";
+type TranslateParam = "main" | "context" | "legend" | "x" | "y" | "y2" | "subX" | "subY" | "subY2"
+	| "arc" | "radar" | "polar";
 
 export default {
 	getTranslate(target: TranslateParam, index = 0): string {
@@ -42,6 +42,12 @@ export default {
 		} else if (target === "subX") {
 			x = 0;
 			y = isRotated ? 0 : state.height2;
+		} else if (target === "subY") {
+			x = 0;
+			y = isRotated ? state.height2 : 0;
+		} else if (target === "subY2") {
+			x = isRotated ? 0 : state.width2;
+			y = isRotated ? -1 : 0;
 		} else if (target === "arc") {
 			x = state.arcWidth / 2;
 			y = state.arcHeight / 2;

--- a/src/ChartInternal/internals/type.ts
+++ b/src/ChartInternal/internals/type.ts
@@ -37,6 +37,110 @@ export default {
 		return !!(type && Object.values(TYPE).indexOf(type) > -1);
 	},
 
+	/**
+	 * Get the chart type to use for the subchart target.
+	 * subchart.types > subchart.type > data.types > data.type > line
+	 * @param {object|string} d Target data or id
+	 * @returns {string}
+	 * @private
+	 */
+	getSubchartTargetType(d): string {
+		const $$ = this;
+		const {config} = $$;
+		const id = isString(d) ? d : d?.id;
+		const subchartTypes = config.subchart_types || {};
+		const subchartType = config.subchart_type;
+		const dataTypes = config.data_types || {};
+		const targetSubchartType = id && subchartTypes[id];
+
+		if (targetSubchartType && $$.isValidChartType(targetSubchartType)) {
+			return targetSubchartType;
+		} else if (subchartType && $$.isValidChartType(subchartType)) {
+			return subchartType;
+		}
+
+		return (id && dataTypes[id]) || config.data_type || TYPE.LINE;
+	},
+
+	/**
+	 * Get the regular chart type configured for the target.
+	 * @param {object|string} d Target data or id
+	 * @returns {string}
+	 * @private
+	 */
+	getTargetType(d): string {
+		const {config} = this;
+		const id = isString(d) ? d : d?.id;
+
+		return (id && config.data_types?.[id]) || config.data_type || TYPE.LINE;
+	},
+
+	/**
+	 * Get the target's original chart type while subchart.type context is active.
+	 * @param {object|string} d Target data or id
+	 * @returns {string}
+	 * @private
+	 */
+	getSubchartSourceTargetType(d): string {
+		const {state} = this;
+		const id = isString(d) ? d : d?.id;
+		const sourceTypes = state.subchartSourceTypes;
+
+		return (id && sourceTypes?.[id]) || this.getTargetType(d);
+	},
+
+	/**
+	 * Check whether a target had the given source type before subchart.type remapping.
+	 * @param {object|string} d Target data or id
+	 * @param {string|Array} type chart type
+	 * @returns {boolean}
+	 * @private
+	 */
+	isSubchartSourceTypeOf(d, type): boolean {
+		const sourceType = this.getSubchartSourceTargetType(d);
+
+		return isArray(type) ? type.indexOf(sourceType) >= 0 : sourceType === type;
+	},
+
+	/**
+	 * Run a callback while regular type helpers resolve using subchart.type/types.
+	 * @param {function(): unknown} callback Callback to run
+	 * @returns {unknown} Callback return value
+	 * @private
+	 */
+	withSubchartTypeContext(callback: () => unknown) {
+		const $$ = this;
+		const {config, data, state} = $$;
+		const dataType = config.data_type;
+		const dataTypes = config.data_types;
+		const currentTypes = state.current.types;
+		const sourceTypes = state.subchartSourceTypes;
+		const subchartTypes = {};
+		const subchartSourceTypes = {};
+		const subchartType = config.subchart_type;
+
+		$$.mapToIds(data.targets).forEach(id => {
+			subchartSourceTypes[id] = $$.getTargetType(id);
+			subchartTypes[id] = $$.getSubchartTargetType(id);
+		});
+
+		config.data_type = subchartType && $$.isValidChartType(subchartType) ?
+			subchartType :
+			dataType;
+		config.data_types = subchartTypes;
+		state.current.types = [];
+		state.subchartSourceTypes = subchartSourceTypes;
+
+		try {
+			return callback();
+		} finally {
+			config.data_type = dataType;
+			config.data_types = dataTypes;
+			state.current.types = currentTypes;
+			state.subchartSourceTypes = sourceTypes;
+		}
+	},
+
 	setTargetType(targetIds: string[], type: string): void {
 		const $$ = this;
 		const {config, state: {withoutFadeIn}} = $$;
@@ -131,7 +235,7 @@ export default {
 	 */
 	isTypeOf(d, type): boolean {
 		const id = isString(d) ? d : d.id;
-		const dataType = this.config && (this.config.data_types?.[id] || this.config.data_type);
+		const dataType = this.config && this.getTargetType(id);
 
 		return isArray(type) ? type.indexOf(dataType) >= 0 : dataType === type;
 	},

--- a/src/ChartInternal/shape/bar.ts
+++ b/src/ChartInternal/shape/bar.ts
@@ -165,10 +165,14 @@ export default {
 		const barPath: BarConnectLine[] = [];
 		const connectLineCache = new Map<string, string | null>();
 		const getRadius = getBarRadiusResolver($$);
+		const barColor = $$.generateUpdateBarColor();
 
 		// Computes the target path string and performs bar.connectLine side-effects.
 		const getBarPath = function(this: SVGPathElement, d, i, arr): string {
-			const path = (isNumber(d.value) || $$.isBarRangeType(d)) && drawFn(d, i);
+			const isDrawable = isNumber(d.value) ||
+				$$.isBarRangeType(d) ||
+				$$.isSubchartCandlestickBarValue?.(d, isSub);
+			const path = isDrawable ? drawFn(d, i) : [""];
 
 			// Memoize per series id: config lookup + regex runs once per id, not per bar
 			let connectLineType = connectLineCache.get(d.id);
@@ -220,7 +224,7 @@ export default {
 
 		return [
 			barTransition
-				.style("fill", $$.generateUpdateBarColor())
+				.style("fill", d => $$.getSubchartCandlestickBarColor?.(d, isSub) || barColor(d))
 				.style("clip-path", d => d.clipPath)
 				.style("opacity", null)
 		];

--- a/src/ChartInternal/shape/core/candlestick.ts
+++ b/src/ChartInternal/shape/core/candlestick.ts
@@ -36,7 +36,7 @@ export default {
 		const yScale = $$.getYScaleById.bind($$);
 
 		return (d, i) => {
-			const y0 = yScale.call($$, d.id, isSub)($$.getShapeYMin(d.id));
+			const y0 = yScale.call($$, d.id, isSub)($$.getShapeYMin(d.id, isSub));
 			const offset = shapeOffset(d, i) || y0; // offset is for stacked bar chart
 			const width = isNumber(barW) ? barW : barW[d.id] || barW._$width;
 			const value = $$.getCandlestickData(d);

--- a/src/ChartInternal/shape/core/path.ts
+++ b/src/ChartInternal/shape/core/path.ts
@@ -8,6 +8,36 @@ type PathContext = CanvasRenderingContext2D | null | undefined;
 type PathResult = string | void;
 
 /**
+ * Get path y value with subchart candlestick projection.
+ * @param {object} $$ ChartInternal instance
+ * @param {object} d Data row
+ * @param {boolean} isSub Whether to use subchart scales
+ * @returns {number|Array|null|undefined} Path y value
+ * @private
+ */
+function getPathValue($$, d, isSub?: boolean) {
+	const value = $$.getSubchartCandlestickShapeValue?.(d, isSub);
+
+	return value === undefined ? $$.getBaseValue(d) : value;
+}
+
+/**
+ * Get drawable values with subchart candlestick projection.
+ * @param {object} $$ ChartInternal instance
+ * @param {Array} values Drawable values
+ * @param {boolean} isSub Whether to use subchart scales
+ * @returns {Array} Projected values
+ * @private
+ */
+function getProjectedValues($$, values, isSub?: boolean): any[] {
+	return values.map(d => {
+		const value = $$.getSubchartCandlestickShapeValue?.(d, isSub);
+
+		return value === undefined ? d : {...d, value};
+	});
+}
+
+/**
  * Get values with step handling for line-like paths.
  * @param {object} $$ ChartInternal instance
  * @param {object} d Data target (needs `.id` for per-series step type detection)
@@ -43,7 +73,9 @@ export function generateDrawLinePath(
 
 	const xValue = d => (isSub ? $$.subxx : $$.xx).call($$, d);
 	const yValue = (d, i) => (
-		$$.isGrouped(d.id) ? getPoints(d, i)[0][1] : yScale(d.id, isSub)($$.getBaseValue(d))
+		$$.isGrouped(d.id) ? getPoints(d, i)[0][1] : yScale(d.id, isSub)(
+			getPathValue($$, d, isSub)
+		)
 	);
 
 	let line = d3Line<any>();
@@ -52,7 +84,7 @@ export function generateDrawLinePath(
 	context && (line = line.context(context));
 
 	if (!lineConnectNull) {
-		line = line.defined(d => $$.getBaseValue(d) !== null);
+		line = line.defined(d => getPathValue($$, d, isSub) !== null);
 	}
 
 	const x = isSub ? scale.subX : scale.x;
@@ -69,6 +101,8 @@ export function generateDrawLinePath(
 			const regions = config.data_regions[d.id];
 
 			if (regions && !context && $$.lineWithRegions) {
+				values = getProjectedValues($$, values, isSub);
+
 				if ($$.isAreaRangeType(d)) {
 					values = values.map(dv => ({...dv, value: $$.getRangedData(dv, "mid")}));
 				}
@@ -84,7 +118,7 @@ export function generateDrawLinePath(
 		} else {
 			if (values[0]) {
 				x0 = x(values[0].x);
-				y0 = y(values[0].value);
+				y0 = y(getPathValue($$, values[0], isSub));
 			}
 
 			path = isRotated ? `M ${y0} ${x0}` : `M ${x0} ${y0}`;
@@ -118,10 +152,10 @@ export function generateDrawAreaPath(
 
 	const xValue = d => (isSub ? $$.subxx : $$.xx).call($$, d);
 	const value0 = (d, i) => ($$.isGrouped(d.id) ? getPoints(d, i)[0][1] : yScale(d.id, isSub)(
-		$$.isAreaRangeType(d) ? $$.getRangedData(d, "high") : $$.getShapeYMin(d.id)
+		$$.isAreaRangeType(d) ? $$.getRangedData(d, "high") : $$.getShapeYMin(d.id, isSub)
 	));
 	const value1 = (d, i) => ($$.isGrouped(d.id) ? getPoints(d, i)[1][1] : yScale(d.id, isSub)(
-		$$.isAreaRangeType(d) ? $$.getRangedData(d, "low") : d.value
+		$$.isAreaRangeType(d) ? $$.getRangedData(d, "low") : getPathValue($$, d, isSub)
 	));
 
 	return d => {
@@ -139,14 +173,16 @@ export function generateDrawAreaPath(
 					.x1(value1) :
 				area.x(xValue)
 					.y0(config.area_above ? 0 : (
-						config.area_below ? $$.state.height : value0
+						config.area_below ? (isSub ? $$.state.height2 : $$.state.height) : value0
 					))
 					.y1(value1);
 			context && (area = area.context(context));
 
 			if (!lineConnectNull) {
-				area = area.defined(d => $$.getBaseValue(d) !== null);
+				area = area.defined(d => getPathValue($$, d, isSub) !== null);
 			}
+
+			values = getProjectedValues($$, values, isSub);
 
 			if ($$.isStepType(d)) {
 				values = $$.convertValuesToStep(values);
@@ -155,8 +191,8 @@ export function generateDrawAreaPath(
 			path = area.curve($$.getCurve(d))(values);
 		} else {
 			if (values[0]) {
-				x0 = $$.scale.x(values[0].x);
-				y0 = $$.getYScaleById(d.id)(values[0].value);
+				x0 = (isSub ? $$.scale.subX : $$.scale.x)(values[0].x);
+				y0 = $$.getYScaleById(d.id, isSub)(getPathValue($$, values[0], isSub));
 			}
 
 			path = isRotated ? `M ${y0} ${x0}` : `M ${x0} ${y0}`;

--- a/src/ChartInternal/shape/shape.ts
+++ b/src/ChartInternal/shape/shape.ts
@@ -25,6 +25,7 @@ import {
 } from "d3-shape";
 import type {d3Selection} from "../../../types/types";
 import CLASS from "../../config/classes";
+import {TYPE} from "../../config/const";
 import {KEY} from "../../module/Cache";
 import {
 	capitalize,
@@ -97,15 +98,93 @@ function getLinePointGroupTypeFilter($$): Function {
  * Get numeric value used for stacked offset calculation.
  * @param {object} $$ ChartInternal instance
  * @param {object} d Data row
+ * @param {boolean} isSub Whether coordinates are for the subchart
  * @returns {number|Array|object|null} Offset value
  * @private
  */
-function getShapeOffsetValue($$, d) {
+function getShapeOffsetValue($$, d, isSub?: boolean) {
+	const subchartCandlestickValue = getSubchartCandlestickShapeValue($$, d, isSub);
+
+	if (isNumber(subchartCandlestickValue)) {
+		return subchartCandlestickValue;
+	}
+
 	if ($$.isCandlestickType?.(d)) {
 		return $$.getCandlestickData?.(d)?.close;
 	}
 
 	return $$.getBaseValue(d);
+}
+
+/**
+ * Get candlestick data projected for alternate subchart shapes.
+ * @param {object} $$ ChartInternal instance
+ * @param {object} d Data row
+ * @param {boolean} isSub Whether coordinates are for the subchart
+ * @returns {number|undefined} Projected value
+ * @private
+ */
+function getSubchartCandlestickShapeValue($$, d, isSub?: boolean) {
+	if (
+		!isSub ||
+		$$.isCandlestickType?.(d) ||
+		!$$.isSubchartSourceTypeOf?.(d, TYPE.CANDLESTICK)
+	) {
+		return undefined;
+	}
+
+	const value = $$.getCandlestickData?.(d);
+
+	if (!value) {
+		return undefined;
+	}
+
+	if ($$.isBarType(d)) {
+		return isNumber(value.open) && isNumber(value.close) ?
+			value._isUp ? value.close : value.open :
+			undefined;
+	}
+
+	return isNumber(value.close) ? value.close : undefined;
+}
+
+/**
+ * Check whether candlestick data can be projected as a subchart bar value.
+ * @param {object} $$ ChartInternal instance
+ * @param {object} d Data row
+ * @param {boolean} isSub Whether coordinates are for the subchart
+ * @returns {boolean}
+ * @private
+ */
+function isSubchartCandlestickBarValue($$, d, isSub?: boolean): boolean {
+	const value = getSubchartCandlestickShapeValue($$, d, isSub);
+
+	return isNumber(value) && $$.isBarType(d);
+}
+
+/**
+ * Get subchart bar color projected from candlestick up/down state.
+ * @param {object} $$ ChartInternal instance
+ * @param {object} d Data row
+ * @param {boolean} isSub Whether coordinates are for the subchart
+ * @returns {string|null} Bar color
+ * @private
+ */
+function getSubchartCandlestickBarColor($$, d, isSub?: boolean): string | null {
+	if (!isSubchartCandlestickBarValue($$, d, isSub)) {
+		return null;
+	}
+
+	const value = $$.getCandlestickData?.(d);
+
+	if (value?._isUp) {
+		return $$.color(d);
+	}
+
+	const downColor = $$.config.candlestick_color_down;
+	const color = downColor && typeof downColor === "object" ? downColor[d.id] : downColor;
+
+	return color || $$.color(d);
 }
 
 /**
@@ -453,9 +532,12 @@ export default {
 
 		return d => {
 			let {value} = d;
+			const subchartCandlestickValue = getSubchartCandlestickShapeValue($$, d, isSub);
 
 			if (isNumber(d)) {
 				value = d;
+			} else if (isNumber(subchartCandlestickValue)) {
+				value = subchartCandlestickValue;
 			} else if ($$.isAreaRangeType(d)) {
 				value = $$.getBaseValue(d, "mid");
 			} else if (isStackNormalized) {
@@ -474,13 +556,14 @@ export default {
 	/**
 	 * Get shape based y Axis min value
 	 * @param {string} id Data id
+	 * @param {boolean} isSub Whether to use subchart scale
 	 * @returns {number}
 	 * @private
 	 */
-	getShapeYMin(id: string): number {
+	getShapeYMin(id: string, isSub = false): number {
 		const $$ = this;
 		const axisId = $$.axis.getId(id);
-		const scale = $$.scale[axisId];
+		const scale = $$.getYScaleById(id, isSub);
 		const [yMin] = scale.domain();
 		const inverted = $$.config[`axis_${axisId}_inverted`];
 
@@ -490,10 +573,11 @@ export default {
 	/**
 	 * Get Shape's offset data
 	 * @param {function} typeFilter Type filter function
+	 * @param {boolean} isSub Whether coordinates are for the subchart
 	 * @returns {object}
 	 * @private
 	 */
-	getShapeOffsetData(typeFilter) {
+	getShapeOffsetData(typeFilter, isSub?: boolean) {
 		const $$ = this;
 		const targets = $$.orderTargets(
 			$$.filterTargetsToShow($$.data.targets.filter(typeFilter, $$))
@@ -503,7 +587,7 @@ export default {
 		// caching can leave stacked offsets pointing at stale row maps.
 		const dataGeneration = $$.state.dataGeneration;
 		const targetIds = targets.map(t => t.id).join("_");
-		const cacheKey = `${KEY.shapeOffset}_${targetIds}`;
+		const cacheKey = `${KEY.shapeOffset}_${isSub ? "sub" : "main"}_${targetIds}`;
 
 		// Check if result is already cached
 		const cachedData = $$.cache.get(cacheKey);
@@ -524,7 +608,7 @@ export default {
 
 			const rowValueMapByXValue = rowValues.reduce((out, d) => {
 				const key = Number(d.x);
-				const value = getShapeOffsetValue($$, d);
+				const value = getShapeOffsetValue($$, d, isSub);
 
 				out[key] = d;
 				values[key] = isStackNormalized ? $$.getRatio("index", d, true) : value;
@@ -555,7 +639,8 @@ export default {
 	getShapeOffset(typeFilter, indices, isSub?: boolean): Function {
 		const $$ = this;
 		const {shapeOffsetTargets, indexMapByTargetId} = $$.getShapeOffsetData(
-			typeFilter
+			typeFilter,
+			isSub
 		);
 		const groupsZeroAs = $$.config.data_groupsZeroAs;
 
@@ -580,7 +665,7 @@ export default {
 
 		return (d, idx) => {
 			const {id, value, x} = d;
-			const baseValue = getShapeOffsetValue($$, d);
+			const baseValue = getShapeOffsetValue($$, d, isSub);
 			const ind = $$.getIndices(indices, d);
 			const scale = $$.getYScaleById(id, isSub);
 
@@ -590,7 +675,7 @@ export default {
 			}
 
 			const dataXAsNumber = Number(x);
-			const y0 = scale(groupsZeroAs === "zero" ? 0 : $$.getShapeYMin(id));
+			const y0 = scale(groupsZeroAs === "zero" ? 0 : $$.getShapeYMin(id, isSub));
 			let offset = y0;
 
 			const sameGroupTargets = sameGroupByTargetId?.get(id) ??
@@ -614,7 +699,7 @@ export default {
 						row = rowValueMapByXValue[dataXAsNumber];
 					}
 
-					const rowValue = row && getShapeOffsetValue($$, row);
+					const rowValue = row && getShapeOffsetValue($$, row, isSub);
 
 					if (
 						isNumber(rowValue) &&
@@ -658,7 +743,7 @@ export default {
 		const yScale = $$.getYScaleById.bind($$);
 
 		return (d, i) => {
-			const y0 = yScale.call($$, d.id, isSub)($$.getShapeYMin(d.id));
+			const y0 = yScale.call($$, d.id, isSub)($$.getShapeYMin(d.id, isSub));
 			const offset = lineOffset(d, i) || y0;
 			const posX = x(d);
 			let posY = y(d);
@@ -707,7 +792,7 @@ export default {
 			let y0 = y0Cache.get(d.id);
 
 			if (y0 === undefined) {
-				y0 = yScale.call($$, d.id, isSub)($$.getShapeYMin(d.id)) as number;
+				y0 = yScale.call($$, d.id, isSub)($$.getShapeYMin(d.id, isSub)) as number;
 				y0Cache.set(d.id, y0);
 			}
 
@@ -763,7 +848,7 @@ export default {
 
 			if (!idInfo) {
 				idInfo = {
-					y0: yScale.call($$, id, isSub)($$.getShapeYMin(id)),
+					y0: yScale.call($$, id, isSub)($$.getShapeYMin(id, isSub)),
 					isInverted: config[`axis_${$$.axis.getId(id)}_inverted`]
 				};
 
@@ -840,14 +925,46 @@ export default {
 		const typeFilter = getLinePointGroupTypeFilter($$);
 		const getPoints = $$.generateGetLinePoints($$.getShapeIndices(typeFilter), isSub,
 			typeFilter);
+		const y = $$.getShapeY(isSub);
 
 		return (d, i) => {
 			const id = d.id;
 
-			return $$.isGrouped(id) && isLinePointGroupType($$, d) ?
-				getPoints(d, i)[0][1] :
-				$$.getYScaleById(id, isSub)($$.getBaseValue(d));
+			return $$.isGrouped(id) && isLinePointGroupType($$, d) ? getPoints(d, i)[0][1] : y(d);
 		};
+	},
+
+	/**
+	 * Get candlestick data projected for alternate subchart shapes.
+	 * @param {object} d Data row
+	 * @param {boolean} isSub Whether coordinates are for the subchart
+	 * @returns {number|undefined} Projected value
+	 * @private
+	 */
+	getSubchartCandlestickShapeValue(d, isSub?: boolean) {
+		return getSubchartCandlestickShapeValue(this, d, isSub);
+	},
+
+	/**
+	 * Check whether the row should be drawn as a candlestick-derived subchart bar.
+	 * @param {object} d Data row
+	 * @param {boolean} isSub Whether coordinates are for the subchart
+	 * @returns {boolean}
+	 * @private
+	 */
+	isSubchartCandlestickBarValue(d, isSub?: boolean): boolean {
+		return isSubchartCandlestickBarValue(this, d, isSub);
+	},
+
+	/**
+	 * Get subchart bar color projected from candlestick up/down state.
+	 * @param {object} d Data row
+	 * @param {boolean} isSub Whether coordinates are for the subchart
+	 * @returns {string|null} Bar color
+	 * @private
+	 */
+	getSubchartCandlestickBarColor(d, isSub?: boolean): string | null {
+		return getSubchartCandlestickBarColor(this, d, isSub);
 	},
 
 	/**

--- a/src/canvas/CanvasAxisRenderer.ts
+++ b/src/canvas/CanvasAxisRenderer.ts
@@ -10,6 +10,7 @@ import {
 	getAdditionalAxisScale,
 	getAdditionalAxisTickFormat,
 	getAdditionalAxisTickValues,
+	getSubXTickLineValues,
 	getSubXTickValues,
 	getXScale,
 	getXTickLinePosition,
@@ -34,7 +35,14 @@ type AdditionalAxisOptions = {
 	ticks: AxisTickValue[],
 	format: AxisTickFormat,
 	index: number,
-	outerTick: boolean
+	outerTick: boolean,
+	margin?: {left: number, top: number},
+	width?: number,
+	height?: number,
+	prefix?: string,
+	tickShow?: boolean,
+	tickTextShow?: boolean,
+	tickTextPosition?: {x: number, y: number}
 };
 
 const X_AXIS_TICK_TEXT_HORIZONTAL_CLIP_PADDING = 20;
@@ -59,6 +67,26 @@ function getXTickTextDirection(isRotated: boolean): number {
  */
 function getYTickTextDirection(isRotated: boolean, isY2: boolean): number {
 	return isRotated ? (isY2 ? -1 : 1) : (isY2 ? 1 : -1);
+}
+
+/**
+ * Get tick formatter for the canvas subchart y/y2 axis.
+ * @param {object} $$ ChartInternal context
+ * @param {string} id Axis id
+ * @returns {function} Tick formatter
+ * @private
+ */
+function getSubYTickFormat($$, id: YAxisId): AxisTickFormat {
+	const subAxisId = id === "y2" ? "subY2" : "subY";
+	const axisFormat = $$.axis?.[subAxisId]?.tickFormat?.();
+	const configFormat = $$.config[`subchart_axis_${id}_tick_format`] ||
+		$$.config[`axis_${id}_tick_format`];
+
+	if (axisFormat) {
+		return axisFormat;
+	}
+
+	return typeof configFormat === "function" ? configFormat.bind($$.api) : (v => v);
 }
 
 /**
@@ -788,6 +816,8 @@ export default class CanvasAxisRenderer {
 		const rangeStart = isRotated ? y1 : x1;
 		const rangeEnd = isRotated ? y2 : x2;
 		const ticks = getSubXTickValues($$);
+		const lineTicks = getSubXTickLineValues($$, ticks, axis.tickWidth);
+		const outerTick = config.subchart_axis_x_tick_outer ?? config.axis_x_tick_outer;
 		const tickDirection = isRotated ?
 			(config.axis_x_tick_inner ? 1 : -1) :
 			(config.axis_x_tick_inner ? -1 : 1);
@@ -807,8 +837,10 @@ export default class CanvasAxisRenderer {
 				y: margin2.top
 			},
 			() => {
+				ctx.globalAlpha = 1;
 				ctx.strokeStyle = axis.lineColor;
 				ctx.lineWidth = axis.lineWidth;
+				ctx.setLineDash([]);
 
 				painter.strokePath(() => {
 					if (isRotated) {
@@ -817,7 +849,7 @@ export default class CanvasAxisRenderer {
 						painter.traceLine(x1, y, x2, y);
 					}
 
-					if (config.axis_x_tick_outer) {
+					if (outerTick) {
 						if (isRotated) {
 							painter.traceLine(x, y1, x + (AXIS_TICK_SIZE * outerTickDirection), y1);
 							painter.traceLine(x, y2, x + (AXIS_TICK_SIZE * outerTickDirection), y2);
@@ -843,6 +875,27 @@ export default class CanvasAxisRenderer {
 				const lineHeight = getXTickTextLineHeight(painter, getFontSize(tickFont));
 				const tickTextWidth = getXTickTextWidth($$, ticks, isRotated, scale.subX);
 
+				if (config.subchart_axis_x_tick_show) {
+					for (const tick of lineTicks) {
+						const tickPos = scale.subX(normalizeXValue($$, tick));
+						const tx = margin2.left + tickPos;
+						const ty = margin2.top + tickPos;
+						const pos = isRotated ? ty : tx;
+
+						if (!isInAxisRange(pos, rangeStart, rangeEnd)) {
+							continue;
+						}
+
+						painter.strokePath(() => {
+							if (isRotated) {
+								painter.traceLine(x, ty, x + (AXIS_TICK_SIZE * tickDirection), ty);
+							} else {
+								painter.traceLine(tx, y, tx, y + (AXIS_TICK_SIZE * tickDirection));
+							}
+						});
+					}
+				}
+
 				for (const tick of ticks) {
 					const tickPos = scale.subX(normalizeXValue($$, tick));
 					const tx = margin2.left + tickPos;
@@ -851,16 +904,6 @@ export default class CanvasAxisRenderer {
 
 					if (!isInAxisRange(pos, rangeStart, rangeEnd)) {
 						continue;
-					}
-
-					if (config.subchart_axis_x_tick_show) {
-						painter.strokePath(() => {
-							if (isRotated) {
-								painter.traceLine(x, ty, x + (AXIS_TICK_SIZE * tickDirection), ty);
-							} else {
-								painter.traceLine(tx, y, tx, y + (AXIS_TICK_SIZE * tickDirection));
-							}
-						});
 					}
 
 					if (!config.subchart_axis_x_tick_text_show) {
@@ -905,6 +948,47 @@ export default class CanvasAxisRenderer {
 				}
 			}
 		);
+	}
+
+	/**
+	 * Draw the canvas subchart y/y2 axes.
+	 * @param {object} $$ ChartInternal instance
+	 * @private
+	 */
+	drawSubYAxes($$): void {
+		const {
+			config,
+			scale,
+			state: {margin2, width2, height2}
+		} = $$;
+
+		if (!config.subchart_show || width2 <= 0 || height2 <= 0) {
+			return;
+		}
+
+		(["y", "y2"] as YAxisId[]).forEach(id => {
+			const subScale = id === "y2" ? scale.subY2 : scale.subY;
+
+			if (!config[`subchart_axis_${id}_show`] || !subScale) {
+				return;
+			}
+
+			this.drawYAxis($$, id, {
+				scale: subScale,
+				ticks: getYTickValues($$, id, undefined, true, subScale, `subchart_axis_${id}`),
+				format: getSubYTickFormat($$, id),
+				index: 0,
+				outerTick: config[`subchart_axis_${id}_tick_outer`] ??
+					config[`axis_${id}_tick_outer`],
+				margin: margin2,
+				width: width2,
+				height: height2,
+				prefix: `subchart_axis_${id}`,
+				tickShow: config[`subchart_axis_${id}_tick_show`],
+				tickTextShow: config[`subchart_axis_${id}_tick_text_show`],
+				tickTextPosition: config[`axis_${id}_tick_text_position`]
+			});
+		});
 	}
 
 	/**
@@ -1779,23 +1863,27 @@ export default class CanvasAxisRenderer {
 	 */
 	private drawYAxis($$, id: YAxisId = "y", axisOptions?: AdditionalAxisOptions): void {
 		const {ctx, painter, theme: {style: {axis}}} = this;
-		const {config, scale, state: {margin, width, height}} = $$;
-		const prefix = `axis_${id}`;
+		const {config, scale, state} = $$;
+		const {margin, width, height} = state;
+		const plotMargin = axisOptions?.margin || margin;
+		const plotWidth = axisOptions?.width ?? width;
+		const plotHeight = axisOptions?.height ?? height;
+		const prefix = axisOptions?.prefix || `axis_${id}`;
 		const targetScale = axisOptions?.scale || scale[id];
 		const isY2 = id === "y2";
 		const isRotated = config.axis_rotated;
 		const axisOffset = axisOptions?.index ? $$.getAxisSize(id) * axisOptions.index : 0;
 		const x = painter.crisp(
-			margin.left + (isY2 ? width + (isRotated ? 0 : axisOffset) : -axisOffset),
+			plotMargin.left + (isY2 ? plotWidth + (isRotated ? 0 : axisOffset) : -axisOffset),
 			axis.lineWidth
 		);
-		const y = painter.crisp(margin.top + (
-			isRotated ? (isY2 ? -axisOffset - 1 : height + axisOffset) : 0
+		const y = painter.crisp(plotMargin.top + (
+			isRotated ? (isY2 ? -axisOffset - 1 : plotHeight + axisOffset) : 0
 		), axis.lineWidth);
-		const x1 = margin.left;
-		const x2 = margin.left + width;
-		const y1 = margin.top;
-		const y2 = margin.top + height;
+		const x1 = plotMargin.left;
+		const x2 = plotMargin.left + plotWidth;
+		const y1 = plotMargin.top;
+		const y2 = plotMargin.top + plotHeight;
 		const ticks = axisOptions?.ticks || getYTickValues($$, id);
 		const lineTicks = axisOptions?.ticks || (
 			config[`${prefix}_tick_culling`] && config[`${prefix}_tick_culling_lines`] !== false ?
@@ -1811,7 +1899,13 @@ export default class CanvasAxisRenderer {
 			(isY2 ? (config.axis_y2_tick_inner ? -1 : 1) : (config.axis_y_tick_inner ? 1 : -1));
 		const outerTickDirection = getYOuterTickDirection(config, isRotated, isY2);
 		const tickTextDirection = getYTickTextDirection(isRotated, isY2);
-		const tickTextPosition = config[`${prefix}_tick_text_position`];
+		const tickTextPosition = axisOptions?.tickTextPosition ||
+			config[`${prefix}_tick_text_position`] ||
+			config[`axis_${id}_tick_text_position`];
+		const tickShow = axisOptions?.tickShow ??
+			(axisOptions ? true : config[`${prefix}_tick_show`]);
+		const tickTextShow = axisOptions?.tickTextShow ??
+			(axisOptions ? true : config[`${prefix}_tick_text_show`]);
 
 		painter.withState(() => {
 			ctx.strokeStyle = axis.lineColor;
@@ -1849,8 +1943,8 @@ export default class CanvasAxisRenderer {
 
 			const addDrawableTick = (tick, target) => {
 				const value = normalizeYValue($$, tick, id);
-				const tx = margin.left + targetScale(value);
-				const ty = margin.top + targetScale(value);
+				const tx = plotMargin.left + targetScale(value);
+				const ty = plotMargin.top + targetScale(value);
 				const pos = isRotated ? tx : ty;
 
 				if (!isDrawable(pos)) {
@@ -1868,7 +1962,7 @@ export default class CanvasAxisRenderer {
 				addDrawableTick(tick, drawableLineTicks);
 			}
 
-			if (axisOptions || config[`${prefix}_tick_show`]) {
+			if (tickShow) {
 				painter.strokePath(() => {
 					for (const {tx, ty} of drawableLineTicks) {
 						if (isRotated) {
@@ -1880,7 +1974,7 @@ export default class CanvasAxisRenderer {
 				});
 			}
 
-			if (axisOptions || config[`${prefix}_tick_text_show`]) {
+			if (tickTextShow) {
 				for (const {tick, tx, ty} of drawableTicks) {
 					if (isRotated) {
 						painter.text(

--- a/src/canvas/CanvasRenderer.ts
+++ b/src/canvas/CanvasRenderer.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
+import {isContinuousGridFocusEnabled} from "../ChartInternal/internals/subchart.util";
 import {
 	getBarRadiusInfo,
 	getBarRadiusResolver,
@@ -1198,11 +1199,14 @@ export default class CanvasRenderer {
 	/**
 	 * Draw the canvas subchart overview and brush selection.
 	 * @param {object} $$ ChartInternal instance
-	 * @param {object} shape Cached draw shape object
+	 * @param {object} _shape Cached main shape object
 	 * @private
 	 */
-	drawSubchart($$, shape): void {
+	drawSubchart($$, _shape?): void {
 		const {config, state} = $$;
+
+		// Keep accepting the main chart shape from existing internal calls.
+		void _shape;
 
 		if (!config.subchart_show || !state.hasAxis || state.width2 <= 0 || state.height2 <= 0) {
 			return;
@@ -1211,182 +1215,191 @@ export default class CanvasRenderer {
 		const {ctx, painter, theme: {style}} = this;
 		const {margin2, width2, height2} = state;
 		const rect = {x: margin2.left, y: margin2.top, w: width2, h: height2};
-		const targets = $$.filterTargetsToShow()
-			.filter(isCanvasRenderableTarget.bind(null, $$));
 
-		painter.withState(() => {
-			ctx.strokeStyle = style.axis.lineColor;
-			ctx.lineWidth = style.axis.lineWidth;
-			painter.strokePath(() => {
-				if (config.axis_rotated) {
-					painter.traceLine(rect.x, rect.y, rect.x, rect.y + rect.h);
-				} else {
-					painter.traceLine(rect.x, rect.y + rect.h, rect.x + rect.w, rect.y + rect.h);
-				}
-			});
+		$$.withSubchartTypeContext(() => {
+			const targets = $$.filterTargetsToShow()
+				.filter(isCanvasRenderableTarget.bind(null, $$));
+			const shape = $$.getDrawShape();
 
-			painter.clipRect(rect, () => {
-				painter.withTranslation(rect.x, rect.y, () => {
-					const areaTargets = targets.filter(isCanvasAreaType.bind(null, $$));
-					const areaIndices = getCanvasShapeIndices(
-						$$,
-						shape,
-						TYPE.AREA,
-						isCanvasAreaType.bind(null, $$)
-					);
+			$$.updateSubchartYDomain?.(targets);
 
-					ctx.globalAlpha = style.shape.areaOpacity;
-					for (const target of areaTargets) {
-						if (!target.values.some(hasCanvasDrawableValue.bind(null, $$))) {
-							continue;
-						}
+			painter.withState(() => {
+				painter.clipRect(rect, () => {
+					painter.withTranslation(rect.x, rect.y, () => {
+						const areaTargets = targets.filter(isCanvasAreaType.bind(null, $$));
+						const areaIndices = getCanvasShapeIndices(
+							$$,
+							shape,
+							TYPE.AREA,
+							isCanvasAreaType.bind(null, $$)
+						);
 
-						ctx.fillStyle = $$.color(target.id);
-						drawCanvasArea($$, target, areaIndices, painter, true);
-					}
-					ctx.globalAlpha = 1;
+						for (const target of areaTargets) {
+							if (!target.values.some(hasCanvasDrawableValue.bind(null, $$))) {
+								continue;
+							}
 
-					const barTargets = targets.filter(isCanvasBarType.bind(null, $$));
-					const barIndices = getCanvasShapeIndices(
-						$$,
-						shape,
-						TYPE.BAR,
-						isCanvasBarType.bind(null, $$)
-					);
-					const getBarPoints = $$.generateGetBarPoints?.(barIndices, true);
-
-					if (getBarPoints) {
-						ctx.globalAlpha = style.shape.barOpacity;
-						for (const target of barTargets) {
+							ctx.globalAlpha = style.shape.areaOpacity *
+								getCanvasTargetFocusOpacity($$, target);
 							ctx.fillStyle = $$.color(target.id);
-							target.values.forEach((d, i) => {
-								if (!hasCanvasDrawableValue($$, d)) {
-									return;
-								}
-
-								const geometry = getCanvasBarGeometry($$, getBarPoints, d, i);
-
-								geometry && painter.fillRect(geometry.rect, {fill: ctx.fillStyle});
-							});
+							drawCanvasArea($$, target, areaIndices, painter, true);
 						}
 						ctx.globalAlpha = 1;
-					}
 
-					const candlestickTargets = targets.filter(
-						isCanvasCandlestickType.bind(null, $$)
-					);
-					const candlestickIndices = getCanvasShapeIndices(
-						$$,
-						shape,
-						TYPE.CANDLESTICK,
-						isCanvasCandlestickType.bind(null, $$)
-					);
-					const getCandlestickPoints = $$.generateGetCandlestickPoints?.(
-						candlestickIndices,
-						true
-					);
+						const barTargets = targets.filter(isCanvasBarType.bind(null, $$));
+						const barIndices = getCanvasShapeIndices(
+							$$,
+							shape,
+							TYPE.BAR,
+							isCanvasBarType.bind(null, $$)
+						);
+						const getBarPoints = $$.generateGetBarPoints?.(barIndices, true);
 
-					if (getCandlestickPoints) {
-						ctx.lineWidth = style.shape.candlestickLineWidth;
-						for (const target of candlestickTargets) {
-							target.values.forEach((d, i) => {
-								const value = $$.getCandlestickData?.(d);
-								const geometry = value && getCanvasCandlestickGeometry(
-									$$,
-									getCandlestickPoints,
-									d,
-									i
-								);
-
-								if (!geometry) {
-									return;
-								}
-
-								const color = getCandlestickColor($$, {id: target.id}, value);
-
-								ctx.strokeStyle = color;
-								ctx.fillStyle = color;
-								painter.strokePath(() => {
-									painter.traceLine(
-										geometry.wickStart[0],
-										geometry.wickStart[1],
-										geometry.wickEnd[0],
-										geometry.wickEnd[1]
-									);
-								});
-								painter.fillRect(geometry.body, {fill: ctx.fillStyle});
-							});
-						}
-					}
-
-					const lineTargets = targets.filter(isCanvasLineType.bind(null, $$));
-					const lineIndices = getCanvasShapeIndices(
-						$$,
-						shape,
-						TYPE.LINE,
-						isCanvasLineType.bind(null, $$)
-					);
-
-					ctx.globalAlpha = 1;
-					ctx.lineWidth = style.shape.lineWidth;
-					for (const target of lineTargets) {
-						if (!target.values.some(hasCanvasDrawableValue.bind(null, $$))) {
-							continue;
-						}
-
-						ctx.strokeStyle = $$.color(target.id);
-						drawCanvasLine($$, target, lineIndices, painter, true);
-					}
-
-					if (config.point_show && !$$.isPointFocusOnly?.()) {
-						const cy = $$.updateCircleY?.(true);
-						const cx = $$.subxx?.bind($$);
-
-						if (cx && cy) {
-							for (const target of targets) {
-								if (
-									!isCanvasScatterType($$, target) &&
-									!isCanvasBubbleType($$, target)
-								) {
-									continue;
-								}
-
-								const color = $$.color(target.id);
-								const pointFill = style.shape.pointFillColor || color;
-								const pointStroke = style.shape.pointStrokeColor || color;
-								const pointLineWidth = pointStroke ?
-									(style.shape.pointLineWidth ?? 1) :
-									0;
-								const pointStyle = pointStroke && pointLineWidth > 0 ?
-									{
-										fill: pointFill,
-										stroke: pointStroke,
-										lineWidth: pointLineWidth
-									} :
-									{fill: pointFill};
-
-								ctx.globalAlpha = getPointOpacity($$, target);
+						if (getBarPoints) {
+							for (const target of barTargets) {
+								ctx.globalAlpha = style.shape.barOpacity *
+									getCanvasTargetFocusOpacity($$, target);
+								ctx.fillStyle = $$.color(target.id);
 								target.values.forEach((d, i) => {
 									if (!hasCanvasDrawableValue($$, d)) {
 										return;
 									}
 
-									const x = config.axis_rotated ? cy(d, i) : cx(d);
-									const y = config.axis_rotated ? cx(d) : cy(d, i);
-									const r = Math.min(getTargetPointRadius($$, target, d), 3);
+									const geometry = getCanvasBarGeometry($$, getBarPoints, d, i);
+									const fill = $$.getSubchartCandlestickBarColor?.(d, true) ||
+										ctx.fillStyle;
 
-									if (isFiniteCanvasCoordinate(x, y)) {
-										drawPointPattern(painter, "circle", x, y, r, pointStyle);
-									}
+									geometry && painter.fillRect(geometry.rect, {fill});
 								});
 							}
 							ctx.globalAlpha = 1;
 						}
-					}
-				});
-			});
 
-			this.drawSubchartBrush($$);
+						const candlestickTargets = targets.filter(
+							isCanvasCandlestickType.bind(null, $$)
+						);
+						const candlestickIndices = getCanvasShapeIndices(
+							$$,
+							shape,
+							TYPE.CANDLESTICK,
+							isCanvasCandlestickType.bind(null, $$)
+						);
+						const getCandlestickPoints = $$.generateGetCandlestickPoints?.(
+							candlestickIndices,
+							true
+						);
+
+						if (getCandlestickPoints) {
+							ctx.lineWidth = style.shape.candlestickLineWidth;
+							for (const target of candlestickTargets) {
+								const targetOpacity = getCanvasTargetFocusOpacity($$, target);
+
+								ctx.globalAlpha = targetOpacity;
+								target.values.forEach((d, i) => {
+									const value = $$.getCandlestickData?.(d);
+									const geometry = value && getCanvasCandlestickGeometry(
+										$$,
+										getCandlestickPoints,
+										d,
+										i
+									);
+
+									if (!geometry) {
+										return;
+									}
+
+									const color = getCandlestickColor($$, {id: target.id}, value);
+
+									ctx.strokeStyle = color;
+									ctx.fillStyle = color;
+									painter.strokePath(() => {
+										painter.traceLine(
+											geometry.wickStart[0],
+											geometry.wickStart[1],
+											geometry.wickEnd[0],
+											geometry.wickEnd[1]
+										);
+									});
+									painter.fillRect(geometry.body, {fill: ctx.fillStyle});
+								});
+							}
+						}
+
+						const lineTargets = targets.filter(isCanvasLineType.bind(null, $$));
+						const lineIndices = getCanvasShapeIndices(
+							$$,
+							shape,
+							TYPE.LINE,
+							isCanvasLineType.bind(null, $$)
+						);
+
+						ctx.globalAlpha = 1;
+						for (const target of lineTargets) {
+							if (!target.values.some(hasCanvasDrawableValue.bind(null, $$))) {
+								continue;
+							}
+
+							ctx.globalAlpha = getCanvasTargetFocusOpacity($$, target);
+							ctx.lineWidth = isCanvasTargetFocused($$, target) ?
+								style.shape.lineFocusedWidth :
+								style.shape.lineWidth;
+							ctx.strokeStyle = $$.color(target.id);
+							drawCanvasLine($$, target, lineIndices, painter, true);
+						}
+						ctx.globalAlpha = 1;
+
+						if (config.point_show && !$$.isPointFocusOnly?.()) {
+							const cy = $$.updateCircleY?.(true);
+							const cx = $$.subxx?.bind($$);
+
+							if (cx && cy) {
+								for (const target of targets) {
+									if (
+										!isCanvasScatterType($$, target) &&
+										!isCanvasBubbleType($$, target)
+									) {
+										continue;
+									}
+
+									const color = $$.color(target.id);
+									const pointFill = style.shape.pointFillColor || color;
+									const pointStroke = style.shape.pointStrokeColor || color;
+									const pointLineWidth = pointStroke ?
+										(style.shape.pointLineWidth ?? 1) :
+										0;
+									const pointStyle = pointStroke && pointLineWidth > 0 ?
+										{
+											fill: pointFill,
+											stroke: pointStroke,
+											lineWidth: pointLineWidth
+										} :
+										{fill: pointFill};
+
+									ctx.globalAlpha = getPointOpacity($$, target) *
+										getCanvasTargetFocusOpacity($$, target);
+									target.values.forEach((d, i) => {
+										if (!hasCanvasDrawableValue($$, d)) {
+											return;
+										}
+
+										const x = config.axis_rotated ? cy(d, i) : cx(d);
+										const y = config.axis_rotated ? cx(d) : cy(d, i);
+										const r = Math.min(getTargetPointRadius($$, target, d), 3);
+
+										if (isFiniteCanvasCoordinate(x, y)) {
+											drawPointPattern(painter, "circle", x, y, r,
+												pointStyle);
+										}
+									});
+								}
+								ctx.globalAlpha = 1;
+							}
+						}
+					});
+				});
+
+				this.drawSubchartBrush($$);
+			});
 		});
 	}
 
@@ -1399,7 +1412,12 @@ export default class CanvasRenderer {
 		const {config, scale, state} = $$;
 		const domain = state.domain;
 
-		if (!config.subchart_show || !domain?.length || !scale.subX) {
+		if (
+			!config.subchart_show ||
+			config.subchart_brush_enabled === false ||
+			!domain?.length ||
+			!scale.subX
+		) {
 			return;
 		}
 
@@ -2392,6 +2410,57 @@ export default class CanvasRenderer {
 	}
 
 	/**
+	 * Draw synchronized focus grid on the canvas subchart.
+	 * @param {object} $$ ChartInternal instance
+	 * @param {Array} selectedData Focused data rows
+	 * @private
+	 */
+	drawSubchartFocus($$, selectedData): void {
+		const {config, scale, state} = $$;
+		const focus = selectedData?.find(d =>
+			d &&
+			hasCanvasDrawableValue($$, d)
+		);
+
+		if (
+			!focus ||
+			!config.subchart_show ||
+			config.subchart_grid_focus_continuous ||
+			config.subchart_brush_enabled !== false ||
+			config.grid_focus_show === false ||
+			!config.tooltip_show ||
+			config.axis_tooltip ||
+			!scale.subX ||
+			state.width2 <= 0 ||
+			state.height2 <= 0
+		) {
+			return;
+		}
+
+		const {margin2, width2, height2} = state;
+		const pos = scale.subX(focus.x);
+
+		if (!Number.isFinite(pos)) {
+			return;
+		}
+
+		const {painter, theme: {style}} = this;
+		const lineWidth = style.axis.lineWidth;
+		const x = painter.crisp(margin2.left + pos, lineWidth);
+		const y = painter.crisp(margin2.top + pos, lineWidth);
+
+		painter.strokePath(() => {
+			config.axis_rotated ?
+				painter.traceLine(margin2.left, y, margin2.left + width2, y) :
+				painter.traceLine(x, margin2.top, x, margin2.top + height2);
+		}, {
+			lineDash: style.focusGrid.dashArray,
+			lineWidth: style.focusGrid.lineWidth,
+			stroke: style.focusGrid.lineColor
+		});
+	}
+
+	/**
 	 * Draw focus grid and focused points on canvas.
 	 * @param {object} $$ ChartInternal instance
 	 * @param {Array} selectedData Focused data rows
@@ -2410,6 +2479,9 @@ export default class CanvasRenderer {
 			hasCanvasDrawableValue($$, d)
 		);
 
+		!isContinuousGridFocusEnabled($$) &&
+			this.drawSubchartFocus($$, selectedData);
+
 		painter.withTranslation(margin.left, margin.top, () => {
 			if (
 				$$.config.tooltip_show &&
@@ -2427,6 +2499,13 @@ export default class CanvasRenderer {
 				const crispEdgeY = value =>
 					painter.crisp(margin.top + value, axisLineWidth) - margin.top;
 				const isEdge = $$.config.grid_focus_edge && !$$.config.tooltip_grouped;
+				const continuousFocus = isContinuousGridFocusEnabled($$);
+				const focusEndX = continuousFocus ?
+					$$.state.margin2.left - margin.left + $$.state.width2 :
+					$$.state.width;
+				const focusEndY = continuousFocus ?
+					$$.state.margin2.top - margin.top + $$.state.height2 :
+					$$.state.height;
 
 				if (hasIndexCoordinate) {
 					painter.strokePath(() => {
@@ -2434,7 +2513,7 @@ export default class CanvasRenderer {
 							painter.traceLine(
 								crispEdgeX(0),
 								y,
-								isEdge && hasValueCoordinate ? x : crispEdgeX($$.state.width),
+								isEdge && hasValueCoordinate ? x : crispEdgeX(focusEndX),
 								y
 							);
 
@@ -2457,7 +2536,7 @@ export default class CanvasRenderer {
 								x,
 								isEdge && hasValueCoordinate ? y : crispEdgeY(0),
 								x,
-								crispEdgeY($$.state.height)
+								crispEdgeY(focusEndY)
 							);
 
 							if (

--- a/src/canvas/CanvasTheme.ts
+++ b/src/canvas/CanvasTheme.ts
@@ -391,6 +391,28 @@ function getDefinedKeys<T extends Record<string, any>>(values: T): Array<keyof T
 }
 
 /**
+ * Copy the defined entries of an object into a target of the same shape.
+ * @param {object} target Object to copy into
+ * @param {object} source Object to copy from
+ * @param {Set} skip Keys to leave untouched
+ * @returns {object} The target object
+ * @private
+ */
+function assignDefined<T extends Record<string, any>>(
+	target: T,
+	source: T,
+	skip?: Set<keyof T>
+): T {
+	getDefinedKeys(source).forEach(<K extends keyof T>(key: K) => {
+		if (!skip?.has(key)) {
+			target[key] = source[key];
+		}
+	});
+
+	return target;
+}
+
+/**
  * Check whether a selector is simple enough for virtual optional grid line matching.
  * @param {string} selector Normalized SVG selector
  * @returns {boolean} Whether selector can be matched
@@ -415,7 +437,8 @@ function isSimpleGridLineSelector(selector: string): boolean {
 function getGridLineSelectorTarget(
 	selector: string
 ): CanvasGridLineSelectorTarget | null {
-	const target = selector.split(" ").at(-1);
+	const tokens = selector.split(" ");
+	const target = tokens[tokens.length - 1];
 
 	return target === "line" || target === "text" ? target : null;
 }
@@ -452,10 +475,7 @@ function getGridLineSelectorStyle(
 			dashArray: readDashArrayValue(style)
 		};
 
-	return getDefinedKeys(values).reduce((acc, key) => {
-		acc[key] = values[key];
-		return acc;
-	}, {} as CanvasGridLineThemeStyle);
+	return assignDefined({} as CanvasGridLineThemeStyle, values);
 }
 
 /**
@@ -519,8 +539,8 @@ function matchesGridLineSelector(
 		axisLineClass,
 		...customClasses
 	]);
-	const selectorClasses = Array.from(selector.matchAll(/\.([A-Za-z_-][\w-]*)/g))
-		.map(match => match[1]);
+	const selectorClasses = (selector.match(/\.[A-Za-z_-][\w-]*/g) || [])
+		.map(match => match.slice(1));
 
 	return !!selectorClasses.length &&
 		selectorClasses.every(cls => availableClasses.has(cls)) &&
@@ -1350,11 +1370,7 @@ export default class CanvasTheme {
 				continue;
 			}
 
-			for (const key of getDefinedKeys(override.style)) {
-				if (!this.directGridOverrideKeys.has(key)) {
-					style[key] = override.style[key];
-				}
-			}
+			assignDefined(style, override.style, this.directGridOverrideKeys);
 		}
 
 		return getDefinedKeys(style).length ? style : undefined;

--- a/src/canvas/axisTicks.ts
+++ b/src/canvas/axisTicks.ts
@@ -13,6 +13,21 @@ export type YAxisId = Exclude<AxisType, "x">;
 type XDataTickCache = {key: string, values: AxisTickValue[], comparable: number[]};
 
 /**
+ * Get tick option value for main/subchart canvas axes.
+ * @param {object} config Chart config
+ * @param {string} id Base axis id
+ * @param {string} key Tick option key
+ * @param {string} prefix Option prefix
+ * @returns {boolean|number|string|Array|object|function|null|undefined} Tick option value
+ * @private
+ */
+function getAxisTickOption(config, id: AxisType, key: string, prefix = `axis_${id}`) {
+	const value = config[`${prefix}_tick_${key}`];
+
+	return value !== undefined ? value : config[`axis_${id}_tick_${key}`];
+}
+
+/**
  * Get explicitly configured tick values.
  * @param {Array|function} values Tick values option
  * @param {object} api Chart API
@@ -578,14 +593,17 @@ export function getXTickValues($$, cull = true): AxisTickValue[] {
 function getSubXTickCullMax($$): number | undefined {
 	const {config, state: {height2, width2}} = $$;
 	const size = config.axis_rotated ? height2 : width2;
+	const count = getAxisTickOption(config, "x", "count", "subchart_axis_x");
+	const culling = getAxisTickOption(config, "x", "culling", "subchart_axis_x");
+	const cullingMax = getAxisTickOption(config, "x", "culling_max", "subchart_axis_x");
 
-	if (config.axis_x_tick_count) {
-		return config.axis_x_tick_count;
+	if (count) {
+		return count;
 	}
 
-	if (config.axis_x_tick_culling !== false) {
+	if (culling !== false) {
 		return Math.min(
-			config.axis_x_tick_culling_max || AXIS_DEFAULT_TICK_COUNT,
+			cullingMax || AXIS_DEFAULT_TICK_COUNT,
 			Math.max(2, Math.floor(size / 70))
 		);
 	}
@@ -596,57 +614,66 @@ function getSubXTickCullMax($$): number | undefined {
 /**
  * Get x ticks for the canvas subchart axis.
  * @param {object} $$ ChartInternal context
+ * @param {boolean} culling Whether to cull tick values
  * @returns {Array} Tick values
  * @private
  */
-export function getSubXTickValues($$): AxisTickValue[] {
+export function getSubXTickValues($$, culling = true): AxisTickValue[] {
 	const {axis, config, scale} = $$;
 	const targetScale = scale.subX;
 	const targetsToShow = $$.getTargetsToShow?.() || $$.filterTargetsToShow();
+	const tickCount = getAxisTickOption(config, "x", "count", "subchart_axis_x");
 	const cullMax = getSubXTickCullMax($$);
-	const cull = (ticks: AxisTickValue[]): AxisTickValue[] => cullTicks(ticks, cullMax);
+	const cullData = (ticks: AxisTickValue[], sorted = false): AxisTickValue[] =>
+		culling ? cullDataTicks($$, ticks, sorted, "subchart_axis_x", cullMax) : ticks;
 
 	if (!targetScale || !targetsToShow?.length) {
 		return [];
 	}
 
-	const explicit = getOptionTickValues(config.axis_x_tick_values, $$.api);
+	const explicit = getOptionTickValues(
+		getAxisTickOption(config, "x", "values", "subchart_axis_x"),
+		$$.api
+	);
 
 	if (explicit) {
-		return cull(normalizeXTickValues($$, explicit));
+		return cullData(normalizeXTickValues($$, explicit));
 	}
 
 	if (config.axis_x_tick_fit && $$.mapTargetsToUniqueXs) {
 		const generated = generateTickValues(
 			$$,
 			$$.mapTargetsToUniqueXs(targetsToShow),
-			config.axis_x_tick_count,
+			tickCount,
 			axis?.isTimeSeries?.()
 		);
 
-		return cull(generated);
+		return cullData(generated, true);
 	}
 
 	if (axis?.isCategorized?.() && config.axis_x_categories?.length) {
-		return cull(config.axis_x_categories.map((_, i) => i));
+		return cullData(config.axis_x_categories.map((_, i) => i), true);
 	}
 
 	const generated = getScaleTicks(
 		targetScale,
-		config.axis_x_tick_count || AXIS_DEFAULT_TICK_COUNT
+		tickCount || AXIS_DEFAULT_TICK_COUNT
 	);
 
-	return cull(generated);
+	return cullData(generated, true);
 }
 
 /**
  * Get raw category boundary tick values for x axis tick lines.
  * @param {object} $$ ChartInternal context
+ * @param {function} targetScale X scale
+ * @param {boolean} outerTick Whether outer ticks are shown
  * @returns {Array} Category boundary values
  * @private
  */
-function getCategoryXTickLineValues($$): AxisTickValue[] {
-	const scale = getXScale($$);
+function getCategoryXTickLineValues($$, targetScale = getXScale($$),
+	outerTick = $$.config.axis_x_tick_outer): AxisTickValue[] {
+	const scale = targetScale;
 	const domain = scale.orgDomain?.() || scale.domain?.();
 
 	if (!domain?.length) {
@@ -664,7 +691,7 @@ function getCategoryXTickLineValues($$): AxisTickValue[] {
 	const max = Math.floor(Math.max(start, end));
 	const values = Array.from({length: Math.max(0, max - min + 1)}, (_, i) => min + i);
 
-	return $$.config.axis_x_tick_outer ? values.slice(1, -1) : values;
+	return outerTick ? values.slice(1, -1) : values;
 }
 
 /**
@@ -700,18 +727,19 @@ export function getXTickLinePosition($$, value: AxisTickValue,
  * @param {object} $$ ChartInternal context
  * @param {Array} ticks Sorted tick values
  * @param {number} tickLineWidth Tick line stroke width
+ * @param {function} targetScale X scale
  * @returns {boolean} Whether tick lines should follow culled text ticks
  * @private
  */
-function hasOverlappedXTickLineIntervals($$, ticks: AxisTickValue[],
-	tickLineWidth: number): boolean {
+function hasOverlappedXTickLineIntervals($$, ticks: AxisTickValue[], tickLineWidth: number,
+	targetScale = getXScale($$)): boolean {
 	if (ticks.length < 2) {
 		return false;
 	}
 
 	const halfWidth = Math.max(1, tickLineWidth) / 2;
 	const positions = ticks
-		.map(tick => getXTickLinePosition($$, tick))
+		.map(tick => getXTickLinePosition($$, tick, targetScale))
 		.filter(Number.isFinite)
 		.sort((a, b) => a - b);
 
@@ -739,14 +767,16 @@ function hasOverlappedXTickLineIntervals($$, ticks: AxisTickValue[],
  * Remove line ticks that map to the same canvas pixel.
  * @param {object} $$ ChartInternal context
  * @param {Array} ticks Tick values
+ * @param {function} targetScale X scale
  * @returns {Array} Pixel-deduped tick values
  * @private
  */
-function dedupeXTickLineValues($$, ticks: AxisTickValue[]): AxisTickValue[] {
+function dedupeXTickLineValues($$, ticks: AxisTickValue[],
+	targetScale = getXScale($$)): AxisTickValue[] {
 	const seen = new Set<number>();
 
 	return ticks.filter(tick => {
-		const pos = getXTickLinePosition($$, tick);
+		const pos = getXTickLinePosition($$, tick, targetScale);
 		const key = Math.round(pos);
 
 		if (!Number.isFinite(pos) || seen.has(key)) {
@@ -789,11 +819,50 @@ export function getXTickLineValues($$, textTicks: AxisTickValue[],
 }
 
 /**
+ * Get subchart x tick values for tick lines, following SVG culling options.
+ * @param {object} $$ ChartInternal context
+ * @param {Array} textTicks Text tick values
+ * @param {number} tickLineWidth Tick line stroke width
+ * @returns {Array} Tick line values
+ * @private
+ */
+export function getSubXTickLineValues($$, textTicks: AxisTickValue[],
+	tickLineWidth = 1): AxisTickValue[] {
+	const {axis, config, scale} = $$;
+	const targetScale = scale.subX;
+	const culling = getAxisTickOption(config, "x", "culling", "subchart_axis_x");
+	const cullingLines = getAxisTickOption(config, "x", "culling_lines", "subchart_axis_x");
+	const outerTick = getAxisTickOption(config, "x", "outer", "subchart_axis_x");
+
+	if (!targetScale) {
+		return [];
+	}
+
+	if (axis?.isCategorized?.()) {
+		const categoryLineTicks = getCategoryXTickLineValues($$, targetScale, outerTick);
+
+		return dedupeXTickLineValues($$, categoryLineTicks, targetScale);
+	}
+
+	if (culling === false || cullingLines === false) {
+		return textTicks;
+	}
+
+	const lineTicks = getSubXTickValues($$, false);
+
+	return hasOverlappedXTickLineIntervals($$, lineTicks, tickLineWidth, targetScale) ?
+		textTicks :
+		dedupeXTickLineValues($$, lineTicks, targetScale);
+}
+
+/**
  * Get y ticks for indexed/linear canvas mode.
  * @param {object} $$ ChartInternal context
  * @param {string} id Axis id
  * @param {number} count Optional tick count override
  * @param {boolean} culling Whether to apply tick culling
+ * @param {d3Scale} targetScale Scale to generate ticks from
+ * @param {string} optionPrefix Tick option prefix
  * @returns {Array} Tick values
  * @private
  */
@@ -801,13 +870,18 @@ export function getYTickValues(
 	$$,
 	id: YAxisId = "y",
 	count?: number,
-	culling = true
+	culling = true,
+	targetScale = $$.scale[id],
+	optionPrefix = `axis_${id}`
 ): AxisTickValue[] {
-	const {axis, config, scale} = $$;
+	const {axis, config} = $$;
 	const prefix = `axis_${id}`;
-	const targetScale = scale[id];
-	const explicit = getOptionTickValues(config[`${prefix}_tick_values`], $$.api);
-	const maybeCull = (ticks: AxisTickValue[]) => culling ? cullAxisTicks($$, id, ticks) : ticks;
+	const explicit = getOptionTickValues(
+		getAxisTickOption(config, id, "values", optionPrefix),
+		$$.api
+	);
+	const maybeCull = (ticks: AxisTickValue[]) =>
+		culling ? cullAxisTicks($$, id, ticks, optionPrefix) : ticks;
 
 	if (explicit) {
 		return maybeCull(normalizeYTickValues($$, explicit, id));
@@ -819,7 +893,7 @@ export function getYTickValues(
 		return maybeCull(stepTicks);
 	}
 
-	const tickCount = count ?? config[`${prefix}_tick_count`];
+	const tickCount = count ?? getAxisTickOption(config, id, "count", optionPrefix);
 
 	if (axis?.isTimeSeries?.(id) && config[`${prefix}_tick_time_value`]) {
 		return maybeCull(getScaleTicks(targetScale, config[`${prefix}_tick_time_value`]));
@@ -929,17 +1003,22 @@ function cullTicks(ticks: AxisTickValue[], count?: number): AxisTickValue[] {
  * @param {object} $$ ChartInternal context
  * @param {string} id Axis id
  * @param {Array} ticks Tick values
+ * @param {string} optionPrefix Tick option prefix
  * @returns {Array} Culled tick values
  * @private
  */
-function cullAxisTicks($$, id: AxisType, ticks: AxisTickValue[]): AxisTickValue[] {
+function cullAxisTicks($$, id: AxisType, ticks: AxisTickValue[],
+	optionPrefix = `axis_${id}`): AxisTickValue[] {
 	const {config} = $$;
-	const prefix = `axis_${id}_tick_culling`;
+	const culling = getAxisTickOption(config, id, "culling", optionPrefix);
 
-	if (!config[prefix]) {
+	if (!culling) {
 		return ticks;
 	}
 
+	const cullingMax = getAxisTickOption(config, id, "culling_max", optionPrefix) ||
+		AXIS_DEFAULT_TICK_COUNT;
+	const reverse = getAxisTickOption(config, id, "culling_reverse", optionPrefix);
 	const sortedTicks = ticks.slice().sort((a, b) => {
 		const av = +a;
 		const bv = +b;
@@ -947,10 +1026,9 @@ function cullAxisTicks($$, id: AxisType, ticks: AxisTickValue[]): AxisTickValue[
 			av - bv :
 			String(a).localeCompare(String(b));
 
-		return config[`${prefix}_reverse`] ? -order : order;
+		return reverse ? -order : order;
 	});
 	const tickSize = sortedTicks.length;
-	const cullingMax = config[`${prefix}_max`] || AXIS_DEFAULT_TICK_COUNT;
 	let intervalForCulling = 0;
 
 	for (let i = 1; i < tickSize; i++) {
@@ -976,17 +1054,23 @@ function cullAxisTicks($$, id: AxisType, ticks: AxisTickValue[]): AxisTickValue[
  * @param {object} $$ ChartInternal context
  * @param {Array} ticks Tick values
  * @param {boolean} sorted Whether ticks are already sorted in x order
+ * @param {string} optionPrefix Tick option prefix
+ * @param {number} max Optional culling max override
  * @returns {Array} Culled tick values
  * @private
  */
-function cullDataTicks($$, ticks: AxisTickValue[], sorted = false): AxisTickValue[] {
+function cullDataTicks($$, ticks: AxisTickValue[], sorted = false, optionPrefix = "axis_x",
+	max?: number): AxisTickValue[] {
 	const {config} = $$;
+	const culling = getAxisTickOption(config, "x", "culling", optionPrefix);
 
-	if (config.axis_x_tick_culling === false) {
+	if (culling === false) {
 		return ticks;
 	}
 
-	const cullingMax = config.axis_x_tick_culling_max || AXIS_DEFAULT_TICK_COUNT;
+	const cullingMax = max || getAxisTickOption(config, "x", "culling_max", optionPrefix) ||
+		AXIS_DEFAULT_TICK_COUNT;
+	const reverse = getAxisTickOption(config, "x", "culling_reverse", optionPrefix);
 	const sortedTicks = sorted ? ticks : ticks
 		.slice()
 		.sort((a, b) => {
@@ -994,10 +1078,10 @@ function cullDataTicks($$, ticks: AxisTickValue[], sorted = false): AxisTickValu
 			const bv = +b;
 
 			if (Number.isFinite(av) && Number.isFinite(bv)) {
-				return config.axis_x_tick_culling_reverse ? bv - av : av - bv;
+				return reverse ? bv - av : av - bv;
 			}
 
-			return config.axis_x_tick_culling_reverse ?
+			return reverse ?
 				String(b).localeCompare(String(a)) :
 				String(a).localeCompare(String(b));
 		});
@@ -1017,9 +1101,7 @@ function cullDataTicks($$, ticks: AxisTickValue[], sorted = false): AxisTickValu
 
 	if (sorted) {
 		return ticks.filter((_, i) =>
-			config.axis_x_tick_culling_reverse ?
-				(tickSize - 1 - i) % intervalForCulling === 0 :
-				i % intervalForCulling === 0
+			reverse ? (tickSize - 1 - i) % intervalForCulling === 0 : i % intervalForCulling === 0
 		);
 	}
 

--- a/src/config/Options/interaction/subchart.ts
+++ b/src/config/Options/interaction/subchart.ts
@@ -2,13 +2,15 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
+import type {ChartTypes} from "../../../../types/types";
+
 /**
  * x Axis config options
  */
 export default {
 	/**
 	 * Set subchart options.
-	 * - **NOTE:** Not supported for `bubble`, `scatter` and non-Axis based(pie, donut, gauge, radar) types.
+	 * - **NOTE:** Not supported for non-Axis based(pie, donut, gauge, radar) types.
 	 * @name subchart
 	 * @memberof Options
 	 * @type {object}
@@ -16,11 +18,44 @@ export default {
 	 * @property {boolean} [subchart.show=false] Show sub chart on the bottom of the chart.
 	 *  - **NOTE:** for ESM imports, needs to import 'subchart' exports and instantiate it by calling `subchart()`.
 	 *    - `show: subchart()`
+	 * @property {string} [subchart.type] Set chart type for the subchart. Defaults to data.type.
+	 * @property {object} [subchart.types] Set chart type for each data in the subchart. Defaults to data.types.
+	 * @property {boolean} [subchart.brush.enabled=true] Enable subchart brush interaction.
 	 * @property {boolean} [subchart.showHandle=false] Show sub chart's handle.
+	 * @property {boolean} [subchart.grid.focus.continuous=false] Render x focus grid line as one continuous line across main chart and subchart when subchart brush is disabled.
 	 * @property {boolean} [subchart.axis.x.show=true] Show or hide x axis.
 	 * @property {boolean} [subchart.axis.x.tick.show=true] Show or hide x axis tick line.
+	 * @property {number} [subchart.axis.x.tick.count] Set the number of x axis ticks.
+	 * @property {Array|function} [subchart.axis.x.tick.values] Set x axis tick values manually.
+	 * @property {boolean|object} [subchart.axis.x.tick.culling] Setting for culling x axis ticks.
+	 * @property {number} [subchart.axis.x.tick.culling.max] The number of x axis tick texts will be adjusted to less than this value.
+	 * @property {boolean} [subchart.axis.x.tick.culling.lines=true] Control x axis tick line visibility within culling option.
+	 * @property {boolean} [subchart.axis.x.tick.culling.reverse=false] Control x axis culling start point to be reversed.
+	 * @property {boolean} [subchart.axis.x.tick.outer] Show or hide x axis outer tick.
 	 * @property {function|string} [subchart.axis.x.tick.format] Use custom format for x axis ticks - see [axis.x.tick.format](#.axis․x․tick․format) for details.
 	 * @property {boolean} [subchart.axis.x.tick.text.show=true] Show or hide x axis tick text.
+	 * @property {boolean} [subchart.axis.y.show=false] Show or hide y axis.
+	 * @property {boolean} [subchart.axis.y.tick.show=true] Show or hide y axis tick line.
+	 * @property {number} [subchart.axis.y.tick.count] Set the number of y axis ticks.
+	 * @property {Array|function} [subchart.axis.y.tick.values] Set y axis tick values manually.
+	 * @property {boolean|object} [subchart.axis.y.tick.culling] Setting for culling y axis ticks.
+	 * @property {number} [subchart.axis.y.tick.culling.max] The number of y axis tick texts will be adjusted to less than this value.
+	 * @property {boolean} [subchart.axis.y.tick.culling.lines=true] Control y axis tick line visibility within culling option.
+	 * @property {boolean} [subchart.axis.y.tick.culling.reverse=false] Control y axis culling start point to be reversed.
+	 * @property {boolean} [subchart.axis.y.tick.outer] Show or hide y axis outer tick.
+	 * @property {function|string} [subchart.axis.y.tick.format] Use custom format for y axis ticks - see [axis.y.tick.format](#.axis․y․tick․format) for details.
+	 * @property {boolean} [subchart.axis.y.tick.text.show=true] Show or hide y axis tick text.
+	 * @property {boolean} [subchart.axis.y2.show=false] Show or hide y2 axis.
+	 * @property {boolean} [subchart.axis.y2.tick.show=true] Show or hide y2 axis tick line.
+	 * @property {number} [subchart.axis.y2.tick.count] Set the number of y2 axis ticks.
+	 * @property {Array|function} [subchart.axis.y2.tick.values] Set y2 axis tick values manually.
+	 * @property {boolean|object} [subchart.axis.y2.tick.culling] Setting for culling y2 axis ticks.
+	 * @property {number} [subchart.axis.y2.tick.culling.max] The number of y2 axis tick texts will be adjusted to less than this value.
+	 * @property {boolean} [subchart.axis.y2.tick.culling.lines=true] Control y2 axis tick line visibility within culling option.
+	 * @property {boolean} [subchart.axis.y2.tick.culling.reverse=false] Control y2 axis culling start point to be reversed.
+	 * @property {boolean} [subchart.axis.y2.tick.outer] Show or hide y2 axis outer tick.
+	 * @property {function|string} [subchart.axis.y2.tick.format] Use custom format for y2 axis ticks - see [axis.y2.tick.format](#.axis․y2․tick․format) for details.
+	 * @property {boolean} [subchart.axis.y2.tick.text.show=true] Show or hide y2 axis tick text.
 	 * @property {Array} [subchart.init.range] Set initial selection domain range.
 	 * @property {number} [subchart.size.height] Change the height of the subchart.
 	 * @property {function} [subchart.onbrush] Set callback for brush event.<br>
@@ -30,8 +65,26 @@ export default {
 	 *  subchart: {
 	 *      show: true,
 	 *      showHandle: true,
+	 *
+	 *      // render the overview with a different chart type than the main chart
+	 *      type: "bar",
+	 *
+	 *      // override the type per data series
+	 *      types: {
+	 *      	data2: "area"
+	 *      },
 	 *      size: {
 	 *          height: 20
+	 *      },
+	 *      brush: {
+	 *      	// disable brush(zoom) interaction, rendering the subchart as a static overview
+	 *      	enabled: false
+	 *      },
+	 *      grid: {
+	 *      	focus: {
+	 *      		// NOTE: works only when 'brush.enabled=false'
+	 *      		continuous: true
+	 *      	}
 	 *      },
 	 *      init: {
 	 *          // specify initial range domain selection
@@ -47,6 +100,12 @@ export default {
 	 *      	        show: false
 	 *      	      }
 	 *      	    }
+	 *      	},
+	 *      	y: {
+	 *      	  show: true,
+	 *      	    tick: {
+	 *      	      count: 3
+	 *      	    }
 	 *      	}
 	 *      },
 	 *      onbrush: function(domain) { ... }
@@ -61,12 +120,46 @@ export default {
 	 * }
 	 */
 	subchart_show: false,
+	subchart_type: <ChartTypes | undefined>undefined,
+	subchart_types: <Record<string, ChartTypes>>{},
+	subchart_brush_enabled: true,
 	subchart_showHandle: false,
 	subchart_size_height: 60,
+	subchart_grid_focus_continuous: false,
 	subchart_axis_x_show: true,
 	subchart_axis_x_tick_show: true,
+	subchart_axis_x_tick_count: <number | undefined>undefined,
+	subchart_axis_x_tick_values: <(string | Date | number)[] | (() => (string | Date | number)[])
+		| undefined>undefined,
+	subchart_axis_x_tick_culling: <boolean | object | undefined>undefined,
+	subchart_axis_x_tick_culling_max: <number | undefined>undefined,
+	subchart_axis_x_tick_culling_lines: <boolean | undefined>undefined,
+	subchart_axis_x_tick_culling_reverse: <boolean | undefined>undefined,
+	subchart_axis_x_tick_outer: <boolean | undefined>undefined,
 	subchart_axis_x_tick_format: <Function | string | undefined>undefined,
 	subchart_axis_x_tick_text_show: true,
+	subchart_axis_y_show: false,
+	subchart_axis_y_tick_show: true,
+	subchart_axis_y_tick_count: <number | undefined>undefined,
+	subchart_axis_y_tick_values: <number[] | (() => number[]) | undefined>undefined,
+	subchart_axis_y_tick_culling: <boolean | object | undefined>undefined,
+	subchart_axis_y_tick_culling_max: <number | undefined>undefined,
+	subchart_axis_y_tick_culling_lines: <boolean | undefined>undefined,
+	subchart_axis_y_tick_culling_reverse: <boolean | undefined>undefined,
+	subchart_axis_y_tick_outer: <boolean | undefined>undefined,
+	subchart_axis_y_tick_format: <Function | string | undefined>undefined,
+	subchart_axis_y_tick_text_show: true,
+	subchart_axis_y2_show: false,
+	subchart_axis_y2_tick_show: true,
+	subchart_axis_y2_tick_count: <number | undefined>undefined,
+	subchart_axis_y2_tick_values: <number[] | (() => number[]) | undefined>undefined,
+	subchart_axis_y2_tick_culling: <boolean | object | undefined>undefined,
+	subchart_axis_y2_tick_culling_max: <number | undefined>undefined,
+	subchart_axis_y2_tick_culling_lines: <boolean | undefined>undefined,
+	subchart_axis_y2_tick_culling_reverse: <boolean | undefined>undefined,
+	subchart_axis_y2_tick_outer: <boolean | undefined>undefined,
+	subchart_axis_y2_tick_format: <Function | string | undefined>undefined,
+	subchart_axis_y2_tick_text_show: true,
 	subchart_init_range: <undefined | [number, number]>undefined,
 	subchart_onbrush: () => {}
 };

--- a/src/config/Store/Element.ts
+++ b/src/config/Store/Element.ts
@@ -22,7 +22,9 @@ export default class Element {
 				x: null,
 				y: null,
 				y2: null,
-				subX: null
+				subX: null,
+				subY: null,
+				subY2: null
 			},
 			axisTooltip: {
 				x: null,

--- a/src/config/Store/State.ts
+++ b/src/config/Store/State.ts
@@ -62,6 +62,7 @@ export default class State {
 
 			// Zoom/subchart domain (different from current.domain which is for rendering)
 			domain: <number[] | undefined>undefined,
+			subchartSourceTypes: <Record<string, string> | undefined>undefined,
 
 			current: {
 				// current domain value. Assigned when is zoom is called

--- a/src/config/classes.ts
+++ b/src/config/classes.ts
@@ -126,6 +126,7 @@ export const $FOCUS = {
 	defocused: "bb-defocused",
 	legendItemFocused: "bb-legend-item-focused",
 	xgridFocus: "bb-xgrid-focus",
+	xgridFocusContinuous: "bb-xgrid-focus-continuous",
 	ygridFocus: "bb-ygrid-focus"
 };
 

--- a/src/config/resolver/canvas.ts
+++ b/src/config/resolver/canvas.ts
@@ -20,6 +20,7 @@ import {
 	isCanvasTreemapType
 } from "../../canvas/util";
 import ChartInternal from "../../ChartInternal/ChartInternal";
+import {getMainCoordFromSubchartCoord} from "../../ChartInternal/internals/subchart.util";
 import {getRenderDataPoint} from "../../ChartInternal/shape/core/geometry";
 import {$FOCUS, $LEGEND} from "../../config/classes";
 import {window} from "../../module/browser";
@@ -698,6 +699,35 @@ function isCanvasSubchartPoint($$, point: number[]): boolean {
 }
 
 /**
+ * Convert a canvas subchart point to the equivalent main plot point.
+ * @param {object} $$ ChartInternal instance
+ * @param {Array} point Canvas-local point
+ * @returns {Array|null} Main plot point or null when not applicable
+ * @private
+ */
+function getCanvasMainPointFromSubchart($$, point: number[]): number[] | null {
+	const {config, state} = $$;
+	const rect = getCanvasSubchartRect($$);
+
+	if (config.subchart_brush_enabled !== false || !rect || !isCanvasSubchartPoint($$, point)) {
+		return null;
+	}
+
+	const mainCoord = getMainCoordFromSubchartCoord(
+		$$,
+		config.axis_rotated ? point[1] - rect.y : point[0] - rect.x
+	);
+
+	if (mainCoord === null) {
+		return null;
+	}
+
+	return config.axis_rotated ?
+		[state.margin.left + (state.width / 2), state.margin.top + mainCoord] :
+		[state.margin.left + mainCoord, state.margin.top + (state.height / 2)];
+}
+
+/**
  * Get the allowed local brush coordinate extent for canvas subchart interactions.
  * @param {object} $$ ChartInternal instance
  * @returns {Array} Brush extent in subchart-local pixels
@@ -1139,8 +1169,10 @@ function syncCanvasFlowYDomains($$): void {
 		scale[key]?.domain($$.getYDomain(targetsToShow, key));
 	});
 
-	scale.subY?.domain($$.getYDomain(targetsToShow, "y"));
-	scale.subY2?.domain($$.getYDomain(targetsToShow, "y2"));
+	$$.withSubchartTypeContext(() => {
+		scale.subY?.domain($$.getYDomain(targetsToShow, "y"));
+		scale.subY2?.domain($$.getYDomain(targetsToShow, "y2"));
+	});
 }
 
 const canvasInternal = {
@@ -2384,13 +2416,19 @@ const canvasInternal = {
 	 */
 	updateCanvasSubchartBrush(event: MouseEvent | PointerEvent | TouchEvent): boolean {
 		const $$ = this;
-		const {state} = $$;
+		const {config, state} = $$;
 		const start = state.canvasSubchartBrushStart;
 		const origin = state.canvasSubchartBrushOrigin;
 		const mode = state.canvasSubchartBrushMode;
 		const coord = getCanvasSubchartBrushCoord($$, event, true);
 
-		if (!state.canvasSubchartBrushDragging || start === null || coord === null || !mode) {
+		if (
+			config.subchart_brush_enabled === false ||
+			!state.canvasSubchartBrushDragging ||
+			start === null ||
+			coord === null ||
+			!mode
+		) {
 			return false;
 		}
 
@@ -2453,6 +2491,12 @@ const canvasInternal = {
 	updateCanvasSubchartCursor(event: MouseEvent | PointerEvent | TouchEvent): boolean {
 		const $$ = this;
 		const canvas = $$.$el.canvas.node();
+
+		if ($$.config.subchart_brush_enabled === false) {
+			canvas.style.cursor = "";
+			return false;
+		}
+
 		const coord = getCanvasSubchartBrushCoord($$, event);
 
 		if (coord === null) {
@@ -2476,6 +2520,11 @@ const canvasInternal = {
 	startCanvasSubchartBrush(event: MouseEvent | PointerEvent | TouchEvent): boolean {
 		const $$ = this;
 		const {state} = $$;
+
+		if ($$.config.subchart_brush_enabled === false) {
+			return false;
+		}
+
 		const coord = getCanvasSubchartBrushCoord($$, event);
 
 		if (coord === null) {
@@ -2897,7 +2946,8 @@ const canvasInternal = {
 			return;
 		}
 
-		const point = getCanvasEventPoint($$, event);
+		const rawPoint = getCanvasEventPoint($$, event);
+		const point = rawPoint && (getCanvasMainPointFromSubchart($$, rawPoint) || rawPoint);
 		const d = point ? getCanvasHoverDatumFromPoint($$, point) : null;
 
 		if (!d) {
@@ -2906,8 +2956,8 @@ const canvasInternal = {
 				state.canvasFocusKey = null;
 				$$.clearCanvasFocus();
 			}
-			if (point && config.axis_tooltip && isCanvasAxisTooltipArea($$, point)) {
-				$$.renderCanvasAxisTooltip(point);
+			if (rawPoint && config.axis_tooltip && isCanvasAxisTooltipArea($$, rawPoint)) {
+				$$.renderCanvasAxisTooltip(rawPoint);
 				$$.hideTooltip?.();
 				return;
 			}
@@ -3063,6 +3113,7 @@ const canvasInternal = {
 				$$.canvasAxisRenderer.drawGridLines($$);
 			$$.canvasRenderer.drawSubchart($$, drawShape);
 			state.hasAxis && $$.canvasAxisRenderer.drawSubXAxis($$);
+			state.hasAxis && $$.canvasAxisRenderer.drawSubYAxes($$);
 			$$.canvasRenderer.drawEmptyLabel($$);
 			rebuildHit && $$.hitDetector.rebuild($$, drawShape);
 		} finally {
@@ -3099,6 +3150,7 @@ const canvasInternal = {
 					$$.canvasAxisRenderer.drawGridLines($$);
 				$$.canvasRenderer.drawSubchart($$, drawShape);
 				state.hasAxis && $$.canvasAxisRenderer.drawSubXAxis($$);
+				state.hasAxis && $$.canvasAxisRenderer.drawSubYAxes($$);
 				$$.canvasRenderer.drawEmptyLabel($$);
 			} finally {
 				$$.canvasEngine.endFrame();

--- a/test/api/canvas-spec.ts
+++ b/test/api/canvas-spec.ts
@@ -6,6 +6,7 @@
 /* global describe, afterEach, beforeAll, it, expect */
 import {afterEach, beforeAll, describe, expect, it, vi} from "vitest";
 import bb, {
+	area,
 	bar,
 	canvas,
 	category,
@@ -31,6 +32,7 @@ describe("API canvas", () => {
 	];
 
 	beforeAll(() => {
+		area();
 		canvas();
 		category();
 		exportApi();
@@ -551,5 +553,224 @@ describe("API canvas", () => {
 
 		const dataUrl = chart.export();
 		expect(/^data:image\/png;base64,/.test(dataUrl)).to.be.true;
+	});
+
+	it("supports subchart type option in canvas mode", () => {
+		generateWithOptions({
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40]
+				],
+				type: line()
+			},
+			subchart: {
+				show: true,
+				type: bar(),
+				types: {
+					data2: line()
+				}
+			}
+		});
+
+		const $$ = chart.internal;
+
+		expect($$.getSubchartTargetType("data1")).to.be.equal("bar");
+		expect($$.getSubchartTargetType("data2")).to.be.equal("line");
+		expect(chart.config("data.type")).to.be.equal("line");
+		expect(() => $$.canvasRenderer.drawSubchart($$, $$.getDrawShape())).to.not.throw();
+		expect(chart.config("data.type")).to.be.equal("line");
+	});
+
+	it("renders subchart area from the subchart bottom in canvas mode", () => {
+		generateWithOptions({
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40]
+				],
+				type: line()
+			},
+			subchart: {
+				show: true,
+				type: area()
+			}
+		});
+
+		const lineTos: Array<[number, number]> = [];
+		const lineTo = vi.spyOn(CanvasRenderingContext2D.prototype, "lineTo")
+			.mockImplementation(function(x, y) {
+				lineTos.push([x, y]);
+			});
+
+		chart.internal.canvasRenderer.drawSubchart(chart.internal, chart.internal.getDrawShape());
+
+		const yValues = lineTos.map(([, y]) => y).filter(Number.isFinite);
+
+		expect(Math.max(...yValues)).to.be.closeTo(chart.internal.state.height2, 0.5);
+
+		lineTo.mockRestore();
+	});
+
+	it("supports subchart y/y2 axes in canvas mode", () => {
+		generateWithOptions({
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 130, 100, 140, 160]
+				],
+				axes: {
+					data2: "y2"
+				},
+				type: line()
+			},
+			subchart: {
+				show: true,
+				axis: {
+					y: {
+						show: true,
+						tick: {
+							count: 3
+						}
+					},
+					y2: {
+						show: true,
+						tick: {
+							count: 4
+						}
+					}
+				}
+			}
+		});
+
+		const $$ = chart.internal;
+		const drawSubYAxes = vi.spyOn($$.canvasAxisRenderer, "drawSubYAxes");
+		const fillText = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText");
+
+		expect($$.scale.subY).to.not.be.undefined;
+		expect($$.scale.subY2).to.not.be.undefined;
+		expect(() => $$.renderCanvasFrame()).to.not.throw();
+		expect(drawSubYAxes).toHaveBeenCalled();
+
+		fillText.mockClear();
+		$$.canvasAxisRenderer.drawSubYAxes($$);
+
+		expect(fillText).toHaveBeenCalledTimes(7);
+	});
+
+	it("renders subchart x axis line once with the main axis style in canvas mode", () => {
+		const strokes: Array<{
+			alpha: number,
+			dash: number[],
+			lineWidth: number,
+			segments: Array<{x1: number, y1: number, x2: number, y2: number}>
+		}> = [];
+		let currentPoint: [number, number] | null = null;
+		let currentSegments: Array<{x1: number, y1: number, x2: number, y2: number}> = [];
+		const crisp = (value: number, lineWidth: number) => (
+			lineWidth % 2 ? Math.round(value) + 0.5 : Math.round(value)
+		);
+		const beginPath = vi.spyOn(CanvasRenderingContext2D.prototype, "beginPath")
+			.mockImplementation(function() {
+				currentPoint = null;
+				currentSegments = [];
+			});
+		const moveTo = vi.spyOn(CanvasRenderingContext2D.prototype, "moveTo")
+			.mockImplementation(function(x, y) {
+				currentPoint = [x, y];
+			});
+		const lineTo = vi.spyOn(CanvasRenderingContext2D.prototype, "lineTo")
+			.mockImplementation(function(x, y) {
+				if (currentPoint) {
+					currentSegments.push({
+						x1: currentPoint[0],
+						y1: currentPoint[1],
+						x2: x,
+						y2: y
+					});
+				}
+
+				currentPoint = [x, y];
+			});
+		const stroke = vi.spyOn(CanvasRenderingContext2D.prototype, "stroke")
+			.mockImplementation(function(this: CanvasRenderingContext2D) {
+				strokes.push({
+					alpha: this.globalAlpha,
+					dash: this.getLineDash(),
+					lineWidth: this.lineWidth,
+					segments: currentSegments.slice()
+				});
+			});
+
+		generateWithOptions({
+			data: {
+				columns,
+				type: bar()
+			},
+			subchart: {
+				show: true
+			}
+		});
+
+		const {margin2, width2, height2} = chart.internal.state;
+		const axisStyle = chart.internal.canvasTheme.style.axis;
+		const y = crisp(margin2.top + height2, axisStyle.lineWidth);
+		const subXAxisStrokes = strokes.filter(({segments}) =>
+			segments.some(({x1, y1, x2, y2}) =>
+				Math.abs(x1 - margin2.left) < 0.5 &&
+				Math.abs(x2 - (margin2.left + width2)) < 0.5 &&
+				Math.abs(y1 - y) < 0.5 &&
+				Math.abs(y2 - y) < 0.5
+			)
+		);
+
+		expect(subXAxisStrokes).to.have.length(1);
+		expect(subXAxisStrokes[0].lineWidth).to.be.equal(axisStyle.lineWidth);
+		expect(subXAxisStrokes[0].dash).to.have.length(0);
+		expect(subXAxisStrokes[0].alpha).to.be.equal(1);
+
+		stroke.mockRestore();
+		lineTo.mockRestore();
+		moveTo.mockRestore();
+		beginPath.mockRestore();
+	});
+
+	it("supports disabling subchart brush interaction in canvas mode", () => {
+		generateWithOptions({
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40]
+				],
+				type: line()
+			},
+			subchart: {
+				show: true,
+				brush: {
+					enabled: false
+				}
+			}
+		});
+
+		const $$ = chart.internal;
+		const focusData = [$$.data.targets[0].values[1]];
+		const drawSubchartFocus = vi.spyOn($$.canvasRenderer, "drawSubchartFocus");
+		const canvas = chart.$.canvas.node();
+		const rect = canvas.getBoundingClientRect();
+
+		expect($$.startCanvasSubchartBrush(new MouseEvent("mousedown"))).to.be.false;
+		expect($$.updateCanvasSubchartCursor(new MouseEvent("mousemove"))).to.be.false;
+		expect(() => $$.canvasRenderer.drawSubchartBrush($$)).to.not.throw();
+
+		$$.renderCanvasFocus(focusData);
+
+		expect(drawSubchartFocus).toHaveBeenCalledWith($$, focusData);
+
+		canvas.dispatchEvent(new MouseEvent("mousemove", {
+			clientX: rect.left + $$.state.margin2.left + $$.scale.subX(1),
+			clientY: rect.top + $$.state.margin2.top + ($$.state.height2 / 2)
+		}));
+
+		expect($$.state.canvasFocusKey).to.contain("data1:1");
 	});
 });

--- a/test/esm/canvas-axis-ticks-coverage-spec.ts
+++ b/test/esm/canvas-axis-ticks-coverage-spec.ts
@@ -10,6 +10,7 @@ import {
 	getAdditionalAxisScale,
 	getAdditionalAxisTickFormat,
 	getAdditionalAxisTickValues,
+	getSubXTickLineValues,
 	getSubXTickValues,
 	getXScale,
 	getXTickLinePosition,
@@ -250,15 +251,38 @@ describe("ESM canvas axis tick coverage", () => {
 			axis: {isCategorized: () => true},
 			config: {
 				axis_x_categories: ["a", "b", "c"],
-				axis_x_tick_fit: false
+				axis_x_tick_fit: false,
+				subchart_axis_x_tick_culling: false
 			}
 		}))).to.be.deep.equal([0, 1, 2]);
 		expect(getSubXTickValues(getInternal({
 			config: {
 				axis_x_tick_count: 3,
-				axis_x_tick_fit: false
+				axis_x_tick_fit: false,
+				subchart_axis_x_tick_culling: false
 			}
 		}))).to.have.length(3);
+		expect(getSubXTickValues(getInternal({
+			config: {
+				axis_x_tick_values: [0, 1],
+				subchart_axis_x_tick_culling: false,
+				subchart_axis_x_tick_values: [2, 4]
+			}
+		}))).to.be.deep.equal([2, 4]);
+	});
+
+	it("resolves subchart x tick lines from subchart culling options", () => {
+		const $$ = getInternal({
+			config: {
+				subchart_axis_x_tick_count: 3,
+				subchart_axis_x_tick_culling: true,
+				subchart_axis_x_tick_culling_lines: false
+			}
+		});
+		const ticks = getSubXTickValues($$);
+
+		expect(ticks).to.have.length(2);
+		expect(getSubXTickLineValues($$, ticks, 1)).to.be.deep.equal(ticks);
 	});
 
 	it("deduplicates x tick lines and handles category boundaries", () => {
@@ -315,6 +339,14 @@ describe("ESM canvas axis tick coverage", () => {
 			config: {axis_y_tick_count: 3},
 			scale: {y: makeScale([0, 0])}
 		}))).to.be.deep.equal([0]);
+		expect(getYTickValues(getInternal({
+			config: {
+				axis_y_tick_values: [9],
+				subchart_axis_y_tick_culling: true,
+				subchart_axis_y_tick_culling_max: 2,
+				subchart_axis_y_tick_values: [0, 1, 2, 3]
+			}
+		}), "y", undefined, true, undefined, "subchart_axis_y")).to.be.deep.equal([0, 3]);
 		expect(getYGridTickValues(getInternal({
 			axis: {y: {getGeneratedTicks: () => [9, 10]}},
 			config: {grid_y_ticks: 2}

--- a/test/esm/canvas-internal-coverage-spec.ts
+++ b/test/esm/canvas-internal-coverage-spec.ts
@@ -103,6 +103,7 @@ function makeContext(overrides = {}) {
 			drawFocusedXAxisTick: vi.fn(),
 			drawGridLines: vi.fn(),
 			drawSubXAxis: vi.fn(),
+			drawSubYAxes: vi.fn(),
 			drawTitle: vi.fn(),
 			withContext(ctx, cb) {
 				cb();

--- a/test/esm/canvas-renderer-coverage-spec.ts
+++ b/test/esm/canvas-renderer-coverage-spec.ts
@@ -125,6 +125,17 @@ function makeContext() {
 			targets[2].values[0]
 		],
 		getCandlestickData: d => ({_isUp: d.index === 1}),
+		getDrawShape() {
+			return this.state.canvasShape || {
+				indices: {
+					[TYPE.AREA]: {},
+					[TYPE.BAR]: {},
+					[TYPE.CANDLESTICK]: {},
+					[TYPE.LINE]: {}
+				},
+				pos: {}
+			};
+		},
 		getShapeIndices: () => ({}),
 		getYScaleById: () => value => value,
 		isBarType: target => target.id === "bar",
@@ -155,6 +166,7 @@ function makeContext() {
 		},
 		subxx: d => d.index * 30,
 		updateCircleY: () => (d, i) => i * 12 + 5,
+		withSubchartTypeContext: fn => fn(),
 		xx: d => d.index * 30
 	};
 }
@@ -171,6 +183,7 @@ describe("ESM canvas renderer coverage", () => {
 			pos: {}
 		};
 
+		ctx.canvasTheme = renderer.theme;
 		renderer.drawSubchart(ctx, shape);
 		renderer.drawSelections(ctx, shape);
 
@@ -717,6 +730,29 @@ describe("ESM canvas renderer coverage", () => {
 		renderer.drawTreemaps(ctx);
 
 		expect(renderer.ctx).to.not.be.null;
+	});
+
+	it("draws one continuous focus grid line across main and subchart", () => {
+		const {renderer} = makeRenderer();
+		const ctx = makeContext();
+		const focus = ctx.data.targets[2].values[1];
+		const traceLine = vi.spyOn(renderer.painter, "traceLine");
+		const drawSubchartFocus = vi.spyOn(renderer, "drawSubchartFocus");
+
+		ctx.config.axis_tooltip = false;
+		ctx.config.subchart_grid_focus_continuous = true;
+		ctx.config.grid_focus_show = true;
+		ctx.config.subchart_brush_enabled = false;
+		ctx.config.tooltip_show = true;
+
+		renderer.drawFocus(ctx, [focus]);
+
+		expect(drawSubchartFocus).not.toHaveBeenCalled();
+		expect(traceLine.mock.calls.some(([x1, y1, x2, y2]) =>
+			x1 === x2 &&
+			y1 >= 0 &&
+			y2 > ctx.state.height
+		)).to.be.true;
 	});
 
 	it("positions treemap labels using SVG-compatible centered option", () => {

--- a/test/interactions/subchart-spec.ts
+++ b/test/interactions/subchart-spec.ts
@@ -6,7 +6,17 @@
 /* global describe, beforeEach, it, expect */
 import {beforeEach, beforeAll, describe, expect, it} from "vitest";
 import util from "../assets/util";
-import {$AREA, $AXIS, $BAR, $FOCUS, $LINE, $SUBCHART} from "../../src/config/classes";
+import {
+	$AREA,
+	$AXIS,
+	$BAR,
+	$COMMON,
+	$EVENT,
+	$FOCUS,
+	$LEGEND,
+	$LINE,
+	$SUBCHART
+} from "../../src/config/classes";
 
 describe("SUBCHART", () => {
 	let chart;
@@ -59,11 +69,15 @@ describe("SUBCHART", () => {
 			}).node().parentNode;
 			const children = subchart.children;
 
-			expect(children.length).to.be.equal(3);
+			expect(children.length).to.be.equal(7);
 
 			expect(children[0].querySelectorAll(`.${$BAR.chartBars}, .${$LINE.chartLines}`).length).to.be.equal(2);
 			expect(children[1].classList.contains($SUBCHART.brush)).to.be.true;
-			expect(children[2].classList.contains($AXIS.axisX)).to.be.true;
+			expect(children[2].classList.contains($EVENT.eventRects)).to.be.true;
+			expect(children[3].classList.contains($FOCUS.xgridFocus)).to.be.true;
+			expect(children[4].classList.contains($AXIS.axisX)).to.be.true;
+			expect(children[5].classList.contains($AXIS.axisY)).to.be.true;
+			expect(children[6].classList.contains($AXIS.axisY2)).to.be.true;
 		});
 
 		it("set options subchart.size={height:80}", () => {
@@ -199,6 +213,512 @@ describe("SUBCHART", () => {
 		it("should format subX ticks with subX function", () => {
 			expected.subX = ["1", "2", "3", "4", "5", "6"];
 			checkTickValues();
+		});
+	});
+
+	describe("subchart x axis tick options", () => {
+		beforeAll(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400, 150, 250]
+					],
+					type: "line"
+				},
+				subchart: {
+					show: true,
+					axis: {
+						x: {
+							tick: {
+								count: 2,
+								outer: false
+							}
+						}
+					}
+				}
+			};
+		});
+
+		it("should render subchart x ticks with configured count and outer option", () => {
+			const {axis} = chart.internal.$el;
+
+			expect(axis.subX.selectAll(".tick").size()).to.be.equal(2);
+			expect(axis.subX.select(".domain").attr("d")).to.not.include("V6");
+		});
+
+		it("set options subchart.axis.x.tick.values and culling", () => {
+			args.subchart.axis.x.tick = {
+				values: [0, 1, 2, 3, 4, 5],
+				culling: {
+					max: 2,
+					lines: false
+				}
+			};
+		});
+
+		it("should render configured subchart x tick values with culling", () => {
+			const {axis} = chart.internal.$el;
+			const ticks = axis.subX.selectAll(".tick");
+			const visibleTicks = ticks.filter(function() {
+				return this.style.display !== "none";
+			});
+
+			expect(ticks.size()).to.be.equal(6);
+			expect(visibleTicks.size()).to.be.at.most(2);
+		});
+	});
+
+	describe("subchart y/y2 axes", () => {
+		beforeAll(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100, 400],
+						["data2", 130, 100, 140, 160]
+					],
+					axes: {
+						data2: "y2"
+					},
+					type: "line"
+				},
+				subchart: {
+					show: true,
+					axis: {
+						y: {
+							show: true,
+							tick: {
+								count: 3,
+								format: v => `Y:${v}`
+							}
+						},
+						y2: {
+							show: true,
+							tick: {
+								count: 4,
+								format: v => `Y2:${v}`
+							}
+						}
+					}
+				}
+			};
+		});
+
+		it("should render subchart y/y2 axes with configured tick format", () => {
+			const {axis} = chart.internal.$el;
+			const yTicks = axis.subY.selectAll(".tick");
+			const y2Ticks = axis.subY2.selectAll(".tick");
+
+			expect(axis.subY.style("visibility")).to.not.be.equal("hidden");
+			expect(axis.subY2.style("visibility")).to.not.be.equal("hidden");
+			expect(axis.subY.attr("transform")).to.be.equal(chart.internal.getTranslate("subY"));
+			expect(axis.subY2.attr("transform")).to.be.equal(chart.internal.getTranslate("subY2"));
+			expect(yTicks.size()).to.be.equal(3);
+			expect(y2Ticks.size()).to.be.equal(4);
+
+			axis.subY.selectAll(".tick text").each(function() {
+				expect(this.textContent).to.match(/^Y:/);
+			});
+			axis.subY2.selectAll(".tick text").each(function() {
+				expect(this.textContent).to.match(/^Y2:/);
+			});
+		});
+
+		it("set options subchart.axis.y/y2.tick.values and outer=false", () => {
+			args.subchart.axis.y.tick = {
+				values: [0, 200, 400],
+				format: v => `Y:${v}`,
+				outer: false
+			};
+			args.subchart.axis.y2.tick = {
+				values: [100, 140, 160],
+				format: v => `Y2:${v}`,
+				outer: false
+			};
+		});
+
+		it("should render configured subchart y/y2 tick values and outer option", () => {
+			const {axis} = chart.internal.$el;
+			const yValues = [];
+			const y2Values = [];
+
+			axis.subY.selectAll(".tick").each(d => yValues.push(d));
+			axis.subY2.selectAll(".tick").each(d => y2Values.push(d));
+
+			expect(yValues).to.be.deep.equal([0, 200, 400]);
+			expect(y2Values).to.be.deep.equal([100, 140, 160]);
+			expect(axis.subY.select(".domain").attr("d")).to.not.include("H-6");
+			expect(axis.subY2.select(".domain").attr("d")).to.not.include("H6");
+		});
+
+		it("set options subchart.axis.y.tick.culling", () => {
+			args.subchart.axis.y.tick = {
+				values: [0, 100, 200, 300, 400],
+				culling: {
+					max: 2,
+					lines: false
+				}
+			};
+		});
+
+		it("should cull subchart y tick lines with tick text", () => {
+			const {axis} = chart.internal.$el;
+			const ticks = axis.subY.selectAll(".tick");
+			const visibleTicks = ticks.filter(function() {
+				return this.style.display !== "none";
+			});
+
+			expect(ticks.size()).to.be.equal(5);
+			expect(visibleTicks.size()).to.be.at.most(2);
+		});
+
+		it("set options subchart.axis.y.tick.show=false", () => {
+			args.subchart.axis.y.tick.show = false;
+		});
+
+		it("shouldn't be generating subchart y tick lines", () => {
+			const {axis} = chart.internal.$el;
+
+			expect(axis.subY.selectAll(".tick line").size()).to.be.equal(0);
+			expect(axis.subY.selectAll(".tick text").size()).to.be.greaterThan(0);
+		});
+
+		it("set options subchart.axis.y.tick.text.show=false", () => {
+			args.subchart.axis.y.tick.show = true;
+			args.subchart.axis.y.tick.text = {
+				show: false
+			};
+		});
+
+		it("shouldn't be generating subchart y tick text", () => {
+			const {axis} = chart.internal.$el;
+
+			expect(axis.subY.selectAll(".tick line").size()).to.be.greaterThan(0);
+			expect(axis.subY.selectAll(".tick text").size()).to.be.equal(0);
+		});
+	});
+
+	describe("subchart type option", () => {
+		beforeAll(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100],
+						["data2", 130, 100, 140]
+					],
+					type: "line"
+				},
+				subchart: {
+					show: true,
+					type: "bar"
+				}
+			};
+		});
+
+		it("should render subchart with specified type", () => {
+			const {$el: {main, subchart}} = chart.internal;
+
+			expect(chart.config("data.type")).to.be.equal("line");
+			expect(chart.config("subchart.type")).to.be.equal("bar");
+			expect(main.selectAll(`.${$LINE.line}`).size()).to.be.equal(2);
+			expect(main.selectAll(`.${$BAR.bar}`).size()).to.be.equal(0);
+			expect(subchart.main.selectAll(`.${$BAR.bar}`).size()).to.be.equal(6);
+			expect(subchart.main.selectAll(`.${$LINE.line}`).size()).to.be.equal(0);
+		});
+
+		it("set options subchart.types={data1: 'area'}", () => {
+			args.subchart.types = {
+				data1: "area"
+			};
+		});
+
+		it("should override subchart type for each data", () => {
+			const {main} = chart.internal.$el.subchart;
+
+			expect(main.selectAll(`.${$AREA.area}`).size()).to.be.equal(1);
+			expect(main.selectAll(`.${$LINE.line}`).size()).to.be.equal(1);
+			expect(main.selectAll(`.${$BAR.bar}`).size()).to.be.equal(3);
+		});
+
+		it("should render subchart area from the subchart bottom", () => {
+			const {internal: {state, $el: {subchart: {main}}}} = chart;
+			const path = main.select(`.${$COMMON.target}-data1 .${$AREA.area}`).attr("d");
+			const values = path.match(/-?\d+(?:\.\d+)?(?:e[-+]?\d+)?/gi).map(Number);
+			const yValues = values.filter((_, i) => i % 2);
+
+			expect(Math.max(...yValues)).to.be.closeTo(state.height2, 0.5);
+		});
+	});
+
+	describe("subchart candlestick source values", () => {
+		beforeAll(() => {
+			args = {
+				data: {
+					columns: [
+						["data1",
+							{open: 10, high: 20, low: 5, close: 12, volume: 1000},
+							{open: 18, high: 19, low: 8, close: 12, volume: 2000},
+							{open: 16, high: 22, low: 14, close: 20, volume: 3000}
+						]
+					],
+					type: "candlestick"
+				},
+				candlestick: {
+					color: {
+						down: "red"
+					}
+				},
+				subchart: {
+					show: true,
+					type: "bar"
+				}
+			};
+		});
+
+		it("should render candlestick source as zero-based body value bars in subchart", () => {
+			const $$ = chart.internal;
+			const {main} = $$.$el.subchart;
+			const [up, down] = $$.data.targets[0].values;
+			const [upValue, downValue, upPoints, downPoints] = $$.withSubchartTypeContext(() => {
+				const indices = $$.getShapeIndices($$.isBarType);
+				const getPoints = $$.generateGetBarPoints(indices, true);
+
+				return [
+					$$.getSubchartCandlestickShapeValue(up, true),
+					$$.getSubchartCandlestickShapeValue(down, true),
+					getPoints(up, 0),
+					getPoints(down, 1)
+				];
+			});
+			const y = $$.getYScaleById("data1", true);
+
+			expect(main.selectAll(`.${$BAR.bar}`).size()).to.be.equal(3);
+			expect($$.scale.subY.domain()[0]).to.be.equal(0);
+			expect(upValue).to.be.equal(12);
+			expect(downValue).to.be.equal(18);
+			expect(upPoints[0][1]).to.be.closeTo(y(0), 0.5);
+			expect(upPoints[1][1]).to.be.closeTo(y(12), 0.5);
+			expect(downPoints[0][1]).to.be.closeTo(y(0), 0.5);
+			expect(downPoints[1][1]).to.be.closeTo(y(18), 0.5);
+		});
+
+		it("should apply candlestick down color to down-value subchart bars", () => {
+			const bars = chart.internal.$el.subchart.main
+				.selectAll(`.${$BAR.bar}`)
+				.nodes();
+
+			expect(window.getComputedStyle(bars[0]).fill).to.be.equal("rgb(31, 119, 180)");
+			expect(window.getComputedStyle(bars[1]).fill).to.be.equal("rgb(255, 0, 0)");
+		});
+
+		it("set options subchart.type='line'", () => {
+			args.subchart.type = "line";
+		});
+
+		it("should render candlestick source as close values for single-value subchart types", () => {
+			const $$ = chart.internal;
+			const {main} = $$.$el.subchart;
+			const d = $$.data.targets[0].values[0];
+			const path = main.select(`.${$LINE.line}`).attr("d");
+			const point = $$.withSubchartTypeContext(() => {
+				const indices = $$.getShapeIndices($$.isLineType);
+
+				return $$.generateGetLinePoints(indices, true)(d, 0)[0];
+			});
+			const [min, max] = $$.withSubchartTypeContext(() =>
+				$$.getYDomainMinMaxBoth($$.data.targets)
+			);
+
+			expect(main.selectAll(`.${$LINE.line}`).size()).to.be.equal(1);
+			expect(path).to.not.include("NaN");
+			expect(path).to.not.be.equal("M 0 0");
+			expect(point[1]).to.be.closeTo($$.getYScaleById("data1", true)(12), 0.5);
+			expect(min).to.be.equal(12);
+			expect(max).to.be.equal(20);
+		});
+
+		it("set options subchart.type='area'", () => {
+			args.subchart.type = "area";
+		});
+
+		it("should render candlestick source as close values for area subchart types", () => {
+			const $$ = chart.internal;
+			const {main} = $$.$el.subchart;
+			const path = main.select(`.${$AREA.area}`).attr("d");
+
+			expect(main.selectAll(`.${$AREA.area}`).size()).to.be.equal(1);
+			expect(path).to.not.include("NaN");
+			expect(path).to.not.be.equal("M 0 0");
+			expect(path).to.include("L");
+		});
+	});
+
+	describe("subchart brush interaction", () => {
+		beforeAll(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100],
+						["data2", 130, 100, 140]
+					],
+					type: "line"
+				},
+				subchart: {
+					show: true,
+					brush: {
+						enabled: false
+					}
+				}
+			};
+		});
+
+		it("should disable subchart brush pointer interaction", () => {
+			const brush = chart.internal.$el.subchart.main.select(`.${$SUBCHART.brush}`);
+
+			expect(brush.style("pointer-events")).to.be.equal("none");
+		});
+
+		it("should sync x focus grid to subchart when hovering main chart", () => {
+			const {internal: {state, $el: {subchart}}} = chart;
+			const mainLine = chart.$.grid.main.select(`line.${$FOCUS.xgridFocus}`)
+				.style("stroke", "rgb(1, 2, 3)")
+				.style("stroke-dasharray", "4 2")
+				.style("stroke-width", "2px");
+			const line = subchart.main.select(`g.${$FOCUS.xgridFocus} line.${$FOCUS.xgridFocus}`);
+
+			expect(line.style("visibility")).to.be.equal("hidden");
+
+			util.hoverChart(chart, "mousemove", {
+				clientX: 250,
+				clientY: 100
+			});
+
+			expect(line.style("visibility")).to.be.equal("visible");
+			expect(line.attr("x1")).to.be.equal(line.attr("x2"));
+			expect(+line.attr("y1")).to.be.equal(0);
+			expect(+line.attr("y2")).to.be.equal(state.height2);
+
+			const mainStyle = window.getComputedStyle(mainLine.node());
+
+			["stroke", "stroke-dasharray", "stroke-width"].forEach(prop => {
+				expect(line.style(prop)).to.be.equal(mainStyle.getPropertyValue(prop));
+			});
+
+			util.hoverChart(chart, "mouseout", {
+				clientX: -100,
+				clientY: -100
+			});
+
+			expect(line.style("visibility")).to.be.equal("hidden");
+		});
+
+		it("should behave like main chart hover from subchart area", () => {
+			const {internal: {$el: {subchart, tooltip}}} = chart;
+			const eventRect = subchart.eventRect.node();
+			const rect = eventRect.getBoundingClientRect();
+			const line = subchart.main.select(`g.${$FOCUS.xgridFocus} line.${$FOCUS.xgridFocus}`);
+
+			eventRect.dispatchEvent(new MouseEvent("mouseover", {
+				clientX: rect.left + (rect.width / 2),
+				clientY: rect.top + (rect.height / 2)
+			}));
+			eventRect.dispatchEvent(new MouseEvent("mousemove", {
+				clientX: rect.left + (rect.width / 2),
+				clientY: rect.top + (rect.height / 2)
+			}));
+
+			expect(tooltip.style("display")).to.be.equal("block");
+			expect(chart.$.grid.main.select(`line.${$FOCUS.xgridFocus}`).style("visibility"))
+				.to.not.be.equal("hidden");
+			expect(line.style("visibility")).to.be.equal("visible");
+
+			eventRect.dispatchEvent(new MouseEvent("mouseout", {
+				clientX: rect.left + (rect.width / 2),
+				clientY: rect.top + (rect.height / 2)
+			}));
+
+			expect(tooltip.style("display")).to.be.equal("none");
+			expect(line.style("visibility")).to.be.equal("hidden");
+		});
+
+		it("should apply legend hover opacity to subchart targets same as main chart", () => {
+			const legend = chart.$.legend.select(`.${$LEGEND.legendItem}-data1`);
+
+			util.fireEvent(legend.node(), "mouseover", {
+				clientX: 100,
+				clientY: 100
+			}, chart);
+
+			const mainTarget = chart.$.main.select(`.${$COMMON.target}-data2`);
+			const subchartTarget = chart.internal.$el.subchart.main
+				.select(`.${$COMMON.target}-data2`);
+
+			expect(mainTarget.classed($FOCUS.defocused)).to.be.true;
+			expect(subchartTarget.classed($FOCUS.defocused)).to.be.true;
+			expect(window.getComputedStyle(subchartTarget.node()).opacity)
+				.to.be.equal(window.getComputedStyle(mainTarget.node()).opacity);
+
+			util.fireEvent(legend.node(), "mouseout", {
+				clientX: 100,
+				clientY: 100
+			}, chart);
+
+			expect(subchartTarget.classed($FOCUS.defocused)).to.be.false;
+		});
+	});
+
+	describe("subchart continuous focus grid", () => {
+		beforeAll(() => {
+			args = {
+				data: {
+					columns: [
+						["data1", 30, 200, 100],
+						["data2", 130, 100, 140]
+					],
+					type: "line"
+				},
+				subchart: {
+					show: true,
+					brush: {
+						enabled: false
+					},
+					grid: {
+						focus: {
+							continuous: true
+						}
+					}
+				}
+			};
+		});
+
+		it("should render one continuous x focus grid line across main and subchart", () => {
+			const {internal: {state, $el: {grid, main, subchart}}} = chart;
+			const mainLine = grid.main.select(`line.${$FOCUS.xgridFocus}`);
+			const subchartLine = subchart.main
+				.select(`g.${$FOCUS.xgridFocus} line.${$FOCUS.xgridFocus}`);
+			const continuousLine = main.select(`line.${$FOCUS.xgridFocusContinuous}`);
+			const expectedY2 = state.margin2.top - state.margin.top + state.height2;
+
+			expect(continuousLine.empty()).to.be.false;
+			expect(continuousLine.style("visibility")).to.be.equal("hidden");
+
+			util.hoverChart(chart, "mousemove", {
+				clientX: 250,
+				clientY: 100
+			});
+
+			expect(mainLine.style("visibility")).to.be.equal("hidden");
+			expect(subchartLine.style("visibility")).to.be.equal("hidden");
+			expect(continuousLine.style("visibility")).to.not.be.equal("hidden");
+			expect(continuousLine.attr("x1")).to.be.equal(continuousLine.attr("x2"));
+			expect(+continuousLine.attr("y1")).to.be.equal(0);
+			expect(+continuousLine.attr("y2")).to.be.closeTo(expectedY2, 0.5);
+
+			util.hoverChart(chart, "mouseout", {
+				clientX: -100,
+				clientY: -100
+			});
+
+			expect(continuousLine.style("visibility")).to.be.equal("hidden");
 		});
 	});
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Axis} from "./axis.js";
+import {Axis, AxisTickValues} from "./axis.js";
 import {ChartTypes, d3Selection, DataItem, PrimitiveArray} from "./types.js";
 import {Chart} from "./chart.js";
 import {IArcData, IData, IDataPoint, IDataRow} from "../src/ChartInternal/data/IData.js";
@@ -777,6 +777,35 @@ export interface SubchartOptions {
 	 */
 	showHandle?: boolean;
 
+	/**
+	 * Set chart type for the subchart.
+	 * If this option is specified, the type will be applied to every data in the subchart.
+	 * This setting can be overwritten by subchart.types.
+	 */
+	type?: ChartTypes;
+
+	/**
+	 * Set chart type for each data in the subchart.
+	 * This setting overwrites subchart.type setting.
+	 */
+	types?: { [key: string]: ChartTypes };
+
+	brush?: {
+		/**
+		 * Enable subchart brush interaction.
+		 */
+		enabled?: boolean;
+	};
+
+	grid?: {
+		focus?: {
+			/**
+			 * Render x focus grid line as one continuous line across main chart and subchart when subchart brush is disabled.
+			 */
+			continuous?: boolean;
+		};
+	};
+
 	size?: {
 		/**
 		 * Change the height of the subchart.
@@ -791,6 +820,41 @@ export interface SubchartOptions {
 			 */
 			show?: boolean;
 			tick?: {
+				/**
+				 * The number of x axis ticks to show.
+				 */
+				count?: number;
+
+				/**
+				 * Set the x values of ticks manually.
+				 */
+				values?: AxisTickValues;
+
+				/**
+				 * Setting for culling ticks.
+				 */
+				culling?: boolean | {
+					/**
+					 * The number of tick texts will be adjusted to less than this value.
+					 */
+					max?: number;
+
+					/**
+					 * Control visibility of tick lines within culling option, along with tick text.
+					 */
+					lines?: boolean;
+
+					/**
+					 * Control culling start point to be reversed.
+					 */
+					reverse?: boolean;
+				};
+
+				/**
+				 * Show x axis outer tick.
+				 */
+				outer?: boolean;
+
 				/**
 				 * Use custom format for x axis ticks - see 'axis.x.tick.format' option for details.
 				 */
@@ -814,6 +878,120 @@ export interface SubchartOptions {
 						first?: boolean;
 						last?: boolean;
 					}
+				};
+			};
+		};
+		y?: {
+			/**
+			 * Show or hide y axis.
+			 */
+			show?: boolean;
+			tick?: {
+				/**
+				 * Set the number of y axis ticks.
+				 */
+				count?: number;
+
+				/**
+				 * Set y axis tick values manually.
+				 */
+				values?: AxisTickValues;
+
+				/**
+				 * Setting for culling ticks.
+				 */
+				culling?: boolean | {
+					/**
+					 * The number of tick texts will be adjusted to less than this value.
+					 */
+					max?: number;
+
+					/**
+					 * Control visibility of tick lines within culling option, along with tick text.
+					 */
+					lines?: boolean;
+
+					/**
+					 * Control culling start point to be reversed.
+					 */
+					reverse?: boolean;
+				};
+
+				/**
+				 * Show y axis outer tick.
+				 */
+				outer?: boolean;
+
+				/**
+				 * Use custom format for y axis ticks - see 'axis.y.tick.format' option for details.
+				 */
+				format?: (this: Chart, x: number | Date) => string | number;
+				/**
+				 * Show or hide y axis tick line.
+				 */
+				show?: boolean;
+				text?: {
+					/**
+					 * Show or hide y axis tick text.
+					 */
+					show?: boolean;
+				};
+			};
+		};
+		y2?: {
+			/**
+			 * Show or hide y2 axis.
+			 */
+			show?: boolean;
+			tick?: {
+				/**
+				 * Set the number of y2 axis ticks.
+				 */
+				count?: number;
+
+				/**
+				 * Set y2 axis tick values manually.
+				 */
+				values?: AxisTickValues;
+
+				/**
+				 * Setting for culling ticks.
+				 */
+				culling?: boolean | {
+					/**
+					 * The number of tick texts will be adjusted to less than this value.
+					 */
+					max?: number;
+
+					/**
+					 * Control visibility of tick lines within culling option, along with tick text.
+					 */
+					lines?: boolean;
+
+					/**
+					 * Control culling start point to be reversed.
+					 */
+					reverse?: boolean;
+				};
+
+				/**
+				 * Show y2 axis outer tick.
+				 */
+				outer?: boolean;
+
+				/**
+				 * Use custom format for y2 axis ticks - see 'axis.y2.tick.format' option for details.
+				 */
+				format?: (this: Chart, x: number | Date) => string | number;
+				/**
+				 * Show or hide y2 axis tick line.
+				 */
+				show?: boolean;
+				text?: {
+					/**
+					 * Show or hide y2 axis tick text.
+					 */
+					show?: boolean;
 				};
 			};
 		};


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4175


## Details
<!-- Detailed description of the change/feature -->
- Add subchart.type and subchart.types for independent overview series rendering.
- Support subchart x/y/y2 axis ticks, formats, culling, outer ticks, and text visibility. 
- Add brush.enabled=false hover behavior and continuous focus grid across main/subchart. 
- Project candlestick values for subchart bars, line, and area using stock chart semantics. 
- Align SVG/canvas subchart axis, grid, and interaction behavior with demos/tests.

<img width="646" height="430" alt="image" src="https://github.com/user-attachments/assets/b0ed1874-614d-4f96-b463-a31444c3232a" />
