### PR TITLE
feat(subchart): add focus grid toggle

### DIFF
--- a/src/ChartInternal/interactions/subchart.ts
+++ b/src/ChartInternal/interactions/subchart.ts
@@ -626,6 +626,7 @@ export default {
 			!config.subchart_show ||
 			$$.isSubchartBrushEnabled() ||
 			config.grid_focus_show === false ||
+			config.subchart_grid_focus === false ||
 			!config.tooltip_show ||
 			config.axis_tooltip
 		) {

--- a/src/ChartInternal/internals/grid.ts
+++ b/src/ChartInternal/internals/grid.ts
@@ -354,11 +354,12 @@ export default {
 					.attr("class", $FOCUS.ygridFocus);
 			}
 
-			config.subchart_grid_focus_continuous && $el.main.insert("g", className)
-				.attr("class", $FOCUS.xgridFocusContinuous)
-				.append("line")
-				.attr("class", `${$FOCUS.xgridFocus} ${$FOCUS.xgridFocusContinuous}`)
-				.style("visibility", "hidden");
+			config.subchart_grid_focus_continuous && config.subchart_grid_focus !== false &&
+				$el.main.insert("g", className)
+					.attr("class", $FOCUS.xgridFocusContinuous)
+					.append("line")
+					.attr("class", `${$FOCUS.xgridFocus} ${$FOCUS.xgridFocusContinuous}`)
+					.style("visibility", "hidden");
 		}
 	},
 

--- a/src/ChartInternal/internals/subchart.util.ts
+++ b/src/ChartInternal/internals/subchart.util.ts
@@ -16,6 +16,7 @@ export function isContinuousGridFocusEnabled($$): boolean {
 
 	return !!(
 		config.subchart_grid_focus_continuous &&
+		config.subchart_grid_focus !== false &&
 		config.subchart_show &&
 		config.subchart_brush_enabled === false &&
 		state.width2 > 0 &&

--- a/src/canvas/CanvasRenderer.ts
+++ b/src/canvas/CanvasRenderer.ts
@@ -2428,6 +2428,7 @@ export default class CanvasRenderer {
 			config.subchart_grid_focus_continuous ||
 			config.subchart_brush_enabled !== false ||
 			config.grid_focus_show === false ||
+			config.subchart_grid_focus === false ||
 			!config.tooltip_show ||
 			config.axis_tooltip ||
 			!scale.subX ||
@@ -2479,7 +2480,8 @@ export default class CanvasRenderer {
 			hasCanvasDrawableValue($$, d)
 		);
 
-		!isContinuousGridFocusEnabled($$) &&
+		$$.config.subchart_grid_focus !== false &&
+			!isContinuousGridFocusEnabled($$) &&
 			this.drawSubchartFocus($$, selectedData);
 
 		painter.withTranslation(margin.left, margin.top, () => {

--- a/src/config/Options/interaction/subchart.ts
+++ b/src/config/Options/interaction/subchart.ts
@@ -22,6 +22,7 @@ export default {
 	 * @property {object} [subchart.types] Set chart type for each data in the subchart. Defaults to data.types.
 	 * @property {boolean} [subchart.brush.enabled=true] Enable subchart brush interaction.
 	 * @property {boolean} [subchart.showHandle=false] Show sub chart's handle.
+	 * @property {boolean|object} [subchart.grid.focus=true] Show x focus grid line in subchart when subchart brush is disabled.
 	 * @property {boolean} [subchart.grid.focus.continuous=false] Render x focus grid line as one continuous line across main chart and subchart when subchart brush is disabled.
 	 * @property {boolean} [subchart.axis.x.show=true] Show or hide x axis.
 	 * @property {boolean} [subchart.axis.x.tick.show=true] Show or hide x axis tick line.
@@ -81,6 +82,8 @@ export default {
 	 *      	enabled: false
 	 *      },
 	 *      grid: {
+	 *      	// set false to hide focus grid line in subchart
+	 *      	// focus: false,
 	 *      	focus: {
 	 *      		// NOTE: works only when 'brush.enabled=false'
 	 *      		continuous: true
@@ -125,6 +128,7 @@ export default {
 	subchart_brush_enabled: true,
 	subchart_showHandle: false,
 	subchart_size_height: 60,
+	subchart_grid_focus: <boolean | object>true,
 	subchart_grid_focus_continuous: false,
 	subchart_axis_x_show: true,
 	subchart_axis_x_tick_show: true,

--- a/test/esm/canvas-renderer-coverage-spec.ts
+++ b/test/esm/canvas-renderer-coverage-spec.ts
@@ -755,6 +755,35 @@ describe("ESM canvas renderer coverage", () => {
 		)).to.be.true;
 	});
 
+	it("does not draw subchart focus grid line when grid focus subchart is disabled", () => {
+		const {renderer} = makeRenderer();
+		const ctx = makeContext();
+		const focus = ctx.data.targets[2].values[1];
+		const traceLine = vi.spyOn(renderer.painter, "traceLine");
+		const drawSubchartFocus = vi.spyOn(renderer, "drawSubchartFocus");
+
+		ctx.config.axis_tooltip = false;
+		ctx.config.grid_focus_show = true;
+		ctx.config.subchart_grid_focus = false;
+		ctx.config.subchart_brush_enabled = false;
+		ctx.config.subchart_grid_focus_continuous = true;
+		ctx.config.tooltip_show = true;
+
+		renderer.drawFocus(ctx, [focus]);
+
+		expect(drawSubchartFocus).not.toHaveBeenCalled();
+		expect(traceLine.mock.calls.some(([x1, y1, x2, y2]) =>
+			x1 === x2 &&
+			y1 >= 0 &&
+			Math.abs(y2 - ctx.state.height) <= 0.5
+		)).to.be.true;
+		expect(traceLine.mock.calls.some(([x1, y1, x2, y2]) =>
+			x1 === x2 &&
+			y1 >= 0 &&
+			y2 > ctx.state.height + 1
+		)).to.be.false;
+	});
+
 	it("positions treemap labels using SVG-compatible centered option", () => {
 		const {renderer} = makeRenderer();
 		const ctx = makeContext();

--- a/test/interactions/subchart-spec.ts
+++ b/test/interactions/subchart-spec.ts
@@ -720,6 +720,38 @@ describe("SUBCHART", () => {
 
 			expect(continuousLine.style("visibility")).to.be.equal("hidden");
 		});
+
+		it("set options subchart.grid.focus=false", () => {
+			args.subchart.grid = {
+				focus: {
+					continuous: true
+				}
+			};
+			args.subchart.grid.focus = false;
+		});
+
+		it("should map subchart.grid.focus=false to config", () => {
+			expect(chart.internal.config.subchart_grid_focus).to.be.false;
+			expect(chart.internal.config.subchart_grid_focus_continuous).to.be.false;
+		});
+
+		it("should not render x focus grid line in subchart when disabled", () => {
+			const {internal: {$el: {main, subchart}}} = chart;
+			const subchartLine = subchart.main
+				.select(`g.${$FOCUS.xgridFocus} line.${$FOCUS.xgridFocus}`);
+			const continuousLine = main.select(`line.${$FOCUS.xgridFocusContinuous}`);
+
+			expect(continuousLine.empty()).to.be.true;
+
+			util.hoverChart(chart, "mousemove", {
+				clientX: 250,
+				clientY: 100
+			});
+
+			expect(chart.$.grid.main.select(`line.${$FOCUS.xgridFocus}`).style("visibility"))
+				.to.not.be.equal("hidden");
+			expect(subchartLine.style("visibility")).to.be.equal("hidden");
+		});
 	});
 
 	describe("subchart selection", () => {

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -798,7 +798,7 @@ export interface SubchartOptions {
 	};
 
 	grid?: {
-		focus?: {
+		focus?: boolean | {
 			/**
 			 * Render x focus grid line as one continuous line across main chart and subchart when subchart brush is disabled.
 			 */


### PR DESCRIPTION
## Summary
- add subchart.grid.focus to disable subchart x focus grid lines
- keep subchart.grid.focus.continuous as the existing continuous focus option
- preserve main chart focus grid behavior when subchart focus is disabled
- apply the option to SVG subchart focus rendering and canvas focus rendering

## Tests
- pnpm exec vitest test/interactions/subchart-spec.ts test/esm/canvas-renderer-coverage-spec.ts
- pnpm run lint
- pnpm test

Ref #4176