### PR TITLE
fix(boost): harden worker fallback paths

### DIFF
--- a/src/Plugin/textoverlap/index.ts
+++ b/src/Plugin/textoverlap/index.ts
@@ -2,11 +2,24 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {Delaunay as d3Delaunay} from "d3-delaunay";
 import type {d3Selection} from "../../../types/types";
 import {polygonArea, polygonCentroid} from "../../module/polygon";
 import Plugin from "../Plugin";
 import Options from "./Options";
+
+let d3Delaunay: Promise<typeof import("d3-delaunay").Delaunay> | null = null;
+
+/**
+ * Load d3-delaunay only when the plugin actually needs Voronoi layout.
+ * @returns {Promise} Delaunay constructor
+ * @private
+ */
+function getDelaunay() {
+	return d3Delaunay ?? (
+		d3Delaunay = import("d3-delaunay")
+			.then(({Delaunay}) => Delaunay)
+	);
+}
 
 /**
  * TextOverlap plugin<br>
@@ -50,6 +63,8 @@ import Options from "./Options";
  * })
  */
 export default class TextOverlap extends Plugin {
+	private redrawId = 0;
+
 	constructor(options?: Options) {
 		super(options);
 		this.config = new Options();
@@ -64,8 +79,11 @@ export default class TextOverlap extends Plugin {
 	$redraw(): void {
 		const {$$: {$el}, config: {selector}} = this;
 		const text = selector ? $el.main.selectAll(selector) : $el.text;
+		const redrawId = ++this.redrawId;
 
-		!text.empty() && this.preventLabelOverlap(text);
+		if (!text.empty()) {
+			void this.preventLabelOverlap(text, redrawId);
+		}
 	}
 
 	/**
@@ -74,14 +92,15 @@ export default class TextOverlap extends Plugin {
 	 * @returns {object} Voronoi layout points and corresponding Data points
 	 * @private
 	 */
-	generateVoronoi(points: [number, number][]) {
+	async generateVoronoi(points: [number, number][]) {
 		const {$$} = this;
 		const {scale} = $$;
 		const [min, max] = ["x", "y"].map(v => scale[v].domain());
+		const Delaunay = await getDelaunay();
 
 		[min[1], max[0]] = [max[0], min[1]];
 
-		return d3Delaunay
+		return Delaunay
 			.from(points)
 			.voronoi([
 				...min as [number, number],
@@ -92,13 +111,18 @@ export default class TextOverlap extends Plugin {
 	/**
 	 * Set text label's position to preventg overlap.
 	 * @param {d3Selection} text target text selection
+	 * @param {number} redrawId Redraw request identifier
 	 * @private
 	 */
-	preventLabelOverlap(text: d3Selection): void {
+	async preventLabelOverlap(text: d3Selection, redrawId = this.redrawId): Promise<void> {
 		const {extent, area} = this.config;
 		const points = text.data().map(v => [v.index, v.value]) as [number, number][];
-		const voronoi = this.generateVoronoi(points);
+		const voronoi = await this.generateVoronoi(points).catch(() => null);
 		let i = 0;
+
+		if (!voronoi || redrawId !== this.redrawId) {
+			return;
+		}
 
 		text.each(function() {
 			const cell = voronoi.cellPolygon(i);

--- a/src/config/Options/common/boost.ts
+++ b/src/config/Options/common/boost.ts
@@ -19,7 +19,8 @@ export default {
 	 * @property {boolean} [boost.useWorker=false] Use Web Worker as possible for processing.
 	 * - **NOTE:**
 	 *   - For now, only applies for data conversion at the initial time.
-	 *   - As of Web Worker's async nature, handling chart instance synchrously is not recommended.
+	 *   - As of Web Worker's async nature, handling chart instance synchronously is not recommended.
+	 *   - When Worker isn't available, fails or times out, data conversion falls back to main thread.
 	 *   - When given data is empty, useWorker will be ignored.
 	 * @example
 	 *  boost: {

--- a/src/module/worker.ts
+++ b/src/module/worker.ts
@@ -6,9 +6,64 @@ import {window} from "./browser";
 
 // Store worker cache in memory
 const cache: {[key: string]: {src: string, worker: Worker | null}} = {};
+const disabledKeys = new Set<string>();
+const DEFAULT_WORKER_TIMEOUT = 5000;
 
 // Correlation id for worker request/response matching
 let messageId = 0;
+
+/**
+ * Get Web Worker related browser APIs when all required primitives are available.
+ * @returns {object|null} Worker API handles
+ * @private
+ */
+function getWorkerAPI():
+	| {Blob: typeof Blob, Worker: typeof Worker, URL: typeof URL}
+	| null {
+	const {Blob, Worker, URL} = window;
+
+	return Worker && Blob && URL?.createObjectURL && URL?.revokeObjectURL ?
+		{Blob, Worker, URL} :
+		null;
+}
+
+/**
+ * Generate a stable cache key from the worker source.
+ * @param {string} str Worker source string
+ * @returns {string} Cache key
+ * @private
+ */
+function hashString(str: string): string {
+	let hash = 2166136261;
+
+	for (let i = 0, len = str.length; i < len; i++) {
+		hash ^= str.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+
+	return `worker-${str.length}-${(hash >>> 0).toString(36)}`;
+}
+
+/**
+ * Release cached worker resources and optionally disable this worker for the session.
+ * @param {string} key Cache key
+ * @param {boolean} disable Whether to disable future worker attempts
+ * @private
+ */
+function releaseWorker(key: string, disable = false): void {
+	const cached = cache[key];
+	const api = getWorkerAPI();
+
+	if (disable) {
+		disabledKeys.add(key);
+	}
+
+	if (cached) {
+		cached.worker?.terminate();
+		cached.src && api?.URL.revokeObjectURL(cached.src);
+		delete cache[key];
+	}
+}
 
 /**
  * Get or create cached worker resources (Object URL, Worker)
@@ -20,27 +75,39 @@ let messageId = 0;
 function getOrCreateWorkerResources(fn: Function, depsFn?: Function[]):
 	| {key: string, src: string}
 	| null {
+	const api = getWorkerAPI();
 	const fnString = fn.toString();
 	// Include depsFn in cache key to handle different dependencies
 	const depsString = depsFn?.map(String).join(";") ?? "";
-	const key = (fnString + depsString).replace(/(function|[\s\W\n])/g, "").substring(0, 30);
+	const key = hashString(`${fnString}\n${depsString}`);
+
+	if (!api || disabledKeys.has(key)) {
+		return null;
+	}
 
 	if (!(key in cache)) {
 		try {
 			// Create Blob and Object URL for Web Worker
-			const blob = new window.Blob([
+			const blob = new api.Blob([
 				`${depsString}
 
 				self.onmessage=function({data}) {
-					const result = (${fnString}).apply(null, data.args);
-					self.postMessage({id: data.id, result});
+					try {
+						const result = (${fnString}).apply(null, data.args);
+						self.postMessage({id: data.id, result});
+					} catch (error) {
+						self.postMessage({
+							id: data.id,
+							error: error && (error.message || error.name) || String(error)
+						});
+					}
 				};`
 			], {
 				type: "text/javascript"
 			});
 
 			cache[key] = {
-				src: window.URL.createObjectURL(blob),
+				src: api.URL.createObjectURL(blob),
 				worker: null
 			};
 		} catch {
@@ -60,25 +127,19 @@ function getOrCreateWorkerResources(fn: Function, depsFn?: Function[]):
  */
 export function getWorker(key: string, src: string): Worker | null {
 	const cached = cache[key];
+	const api = getWorkerAPI();
 
 	// Return null if cache entry doesn't exist
-	if (!cached) {
+	if (!cached || !api || disabledKeys.has(key)) {
 		return null;
 	}
 
 	if (!cached.worker) {
 		try {
-			cached.worker = new window.Worker(src);
+			cached.worker = new api.Worker(src);
 		} catch {
+			releaseWorker(key, true);
 			return null;
-		}
-
-		// handle error
-		if (cached.worker) {
-			cached.worker.onerror = function(e: ErrorEvent) {
-				// eslint-disable-next-line no-console
-				console.error ? console.error(e) : console.log(e);
-			};
 		}
 	}
 
@@ -91,6 +152,7 @@ export function getWorker(key: string, src: string): Worker | null {
  * @param {function} fn Function to be executed in worker
  * @param {function} callback Callback function to receive result from worker
  * @param {Array} depsFn Dependency functions to run given function(fn).
+ * @param {number} timeout Worker response timeout in milliseconds.
  * @returns {function}
  * @example
  * 	const worker = runWorker(function(arg) {
@@ -112,33 +174,71 @@ export function runWorker(
 	useWorker = true,
 	fn: Function,
 	callback: Function,
-	depsFn?: Function[]
+	depsFn?: Function[],
+	timeout = DEFAULT_WORKER_TIMEOUT
 ): Function {
-	let runFn = function(...args: unknown[]) {
+	const runSync = function(...args: unknown[]) {
 		const res = fn(...args);
 
 		callback(res);
 	};
+	let runFn = runSync;
 
-	if (window.Worker && useWorker) {
+	if (useWorker) {
 		const workerResources = getOrCreateWorkerResources(fn, depsFn);
-		const worker = workerResources && getWorker(workerResources.key, workerResources.src);
+		const worker = workerResources ? getWorker(workerResources.key, workerResources.src) : null;
 
-		if (worker) {
+		if (worker && workerResources) {
+			const {key} = workerResources;
+
 			runFn = function(...args: unknown[]) {
 				// workers are cached and shared: match the response by id so concurrent
 				// callers don't steal each other's result
 				const id = ++messageId;
+				let settled = false;
+
+				const fallback = () => {
+					if (!settled) {
+						settled = true;
+						cleanup();
+						releaseWorker(key, true);
+						runFn = runSync;
+						runSync(...args);
+					}
+				};
 
 				const handler = function(e: MessageEvent) {
 					if (e.data?.id === id) {
-						worker.removeEventListener("message", handler);
+						if (e.data.error) {
+							fallback();
+							return;
+						}
+
+						settled = true;
+						cleanup();
 						callback(e.data.result);
 					}
 				};
 
+				const errorHandler = function() {
+					fallback();
+				};
+
+				const timer = setTimeout(fallback, timeout);
+				const cleanup = () => {
+					clearTimeout(timer);
+					worker.removeEventListener("message", handler);
+					worker.removeEventListener("error", errorHandler);
+				};
+
 				worker.addEventListener("message", handler);
-				worker.postMessage({id, args});
+				worker.addEventListener("error", errorHandler);
+
+				try {
+					worker.postMessage({id, args});
+				} catch {
+					fallback();
+				}
 			};
 		}
 	}
@@ -151,6 +251,8 @@ export function runWorker(
  * @private
  */
 export function cleanupWorkers(): void {
+	const api = getWorkerAPI();
+
 	for (const key in cache) {
 		const cached = cache[key];
 
@@ -159,9 +261,11 @@ export function cleanupWorkers(): void {
 		}
 
 		if (cached.src) {
-			window.URL.revokeObjectURL(cached.src);
+			api?.URL.revokeObjectURL(cached.src);
 		}
 
 		delete cache[key];
 	}
+
+	disabledKeys.clear();
 }

--- a/test/internals/text-util-spec.ts
+++ b/test/internals/text-util-spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+import {describe, expect, it, vi} from "vitest";
+
+import {batchGetBBox} from "../../src/ChartInternal/internals/text.util";
+
+describe("TEXT utility", () => {
+	describe("batchGetBBox", () => {
+		it("measures every element once and keeps the bbox mapped by element", () => {
+			const elements = [0, 1, 2].map(() =>
+				document.createElementNS("http://www.w3.org/2000/svg", "text")
+			) as SVGTextElement[];
+			const boxes = [
+				{x: 0, y: 0, width: 12, height: 10},
+				{x: 1, y: 2, width: 24, height: 11},
+				{x: 3, y: 4, width: 36, height: 12}
+			] as DOMRect[];
+
+			elements.forEach((element, i) => {
+				element.getBBox = vi.fn(() => boxes[i]);
+			});
+
+			const result = batchGetBBox(elements);
+
+			elements.forEach((element, i) => {
+				expect(result.get(element)).to.be.equal(boxes[i]);
+				expect(element.getBBox).toHaveBeenCalledTimes(1);
+			});
+		});
+	});
+});

--- a/test/module/module-coverage-spec.ts
+++ b/test/module/module-coverage-spec.ts
@@ -240,6 +240,120 @@ describe("MODULE coverage helpers", () => {
 			}
 		});
 
+		it("falls back to sync execution when worker postMessage fails", () => {
+			const OriginalWorker = window.Worker;
+			const originalCreateObjectURL = window.URL.createObjectURL;
+			const originalRevokeObjectURL = window.URL.revokeObjectURL;
+			const values: number[] = [];
+			const revoked: string[] = [];
+			const terminated: string[] = [];
+
+			try {
+				window.Worker = class {
+					src;
+
+					constructor(src) {
+						this.src = src;
+					}
+
+					addEventListener() {}
+					removeEventListener() {}
+					postMessage() {
+						throw new Error("postMessage blocked");
+					}
+					terminate() {
+						terminated.push(this.src);
+					}
+				};
+				window.URL.createObjectURL = () => "blob:post-message";
+				window.URL.revokeObjectURL = url => revoked.push(url);
+
+				runWorker(true, value => value * 4, value => values.push(value))(3);
+
+				expect(values).to.be.deep.equal([12]);
+				expect(terminated).to.be.deep.equal(["blob:post-message"]);
+				expect(revoked).to.be.deep.equal(["blob:post-message"]);
+			} finally {
+				window.Worker = OriginalWorker;
+				window.URL.createObjectURL = originalCreateObjectURL;
+				window.URL.revokeObjectURL = originalRevokeObjectURL;
+			}
+		});
+
+		it("falls back to sync execution when worker emits an error", () => new Promise(done => {
+			const OriginalWorker = window.Worker;
+			const originalCreateObjectURL = window.URL.createObjectURL;
+			const originalRevokeObjectURL = window.URL.revokeObjectURL;
+
+			class MockWorker {
+				src;
+				listeners = {error: [], message: []};
+
+				constructor(src) {
+					this.src = src;
+				}
+
+				addEventListener(type, fn) {
+					this.listeners[type].push(fn);
+				}
+
+				removeEventListener(type, fn) {
+					this.listeners[type] = this.listeners[type].filter(f => f !== fn);
+				}
+
+				postMessage() {
+					setTimeout(() => {
+						this.listeners.error.slice().forEach(fn => fn(new Error("worker failed")));
+					});
+				}
+
+				terminate() {}
+			}
+
+			window.Worker = MockWorker;
+			window.URL.createObjectURL = () => "blob:error";
+			window.URL.revokeObjectURL = () => {};
+
+			runWorker(true, value => value + 2, value => {
+				try {
+					expect(value).to.be.equal(7);
+				} finally {
+					window.Worker = OriginalWorker;
+					window.URL.createObjectURL = originalCreateObjectURL;
+					window.URL.revokeObjectURL = originalRevokeObjectURL;
+				}
+				done(1);
+			})(5);
+		}));
+
+		it("falls back to sync execution when worker response times out", () => new Promise(done => {
+			const OriginalWorker = window.Worker;
+			const originalCreateObjectURL = window.URL.createObjectURL;
+			const originalRevokeObjectURL = window.URL.revokeObjectURL;
+
+			class MockWorker {
+				addEventListener() {}
+				removeEventListener() {}
+				postMessage() {}
+				terminate() {}
+			}
+
+			window.Worker = MockWorker;
+			window.URL.createObjectURL = () => "blob:timeout";
+			window.URL.revokeObjectURL = () => {};
+
+			runWorker(true, value => value - 1, value => {
+				try {
+					expect(value).to.be.equal(4);
+				} finally {
+					window.Worker = OriginalWorker;
+					window.URL.createObjectURL = originalCreateObjectURL;
+					window.URL.revokeObjectURL = originalRevokeObjectURL;
+				}
+				done(1);
+			}, undefined, 10)(5);
+		}));
+
 	});
 
 	describe("geometry and brush helpers", () => {

--- a/test/plugin/textoverlap/textoverlap-spec.ts
+++ b/test/plugin/textoverlap/textoverlap-spec.ts
@@ -38,7 +38,9 @@ describe("PLUGIN: TEXTOVERLAP", () => {
 		chart = util.generate(args);
 	});
 
-    it("should move data labels into correct position", () => {
+    it("should move data labels into correct position", async () => {
+		await chart.plugins[0].preventLabelOverlap(chart.$.text.texts);
+
         const {texts} = chart.$.text;
 
         chart.data().forEach((v, i) => {
@@ -69,7 +71,9 @@ describe("PLUGIN: TEXTOVERLAP", () => {
         ];
     });
 
-    it("should move data labels into correct position with specified extent and area", () => {
+    it("should move data labels into correct position with specified extent and area", async () => {
+		await chart.plugins[0].preventLabelOverlap(chart.$.text.texts);
+
         const expected = [
             {data1: "", data2: "none", data3: ""},
             {data1: "", data2: "", data3: ""},

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -113,7 +113,8 @@ export interface ChartOptions {
 		 * Use Web Worker as possible for processing.
 		 * - **NOTE:**
 		 *   - For now, only applies for data conversion at the initial time.
-		 *   - As of Web Worker's async nature, handling chart instance synchrously is not recommended.
+		 *   - As of Web Worker's async nature, handling chart instance synchronously is not recommended.
+		 *   - When Worker isn't available, fails or times out, data conversion falls back to main thread.
 		 */
 		useWorker?: boolean;
 	};


### PR DESCRIPTION
## Summary
- Lazy-load d3-delaunay inside the textoverlap plugin path and guard stale async redraws.
- Harden Web Worker data conversion with environment guards, stable cache keys, timeout fallback, postMessage/error fallback, and resource cleanup.
- Document boost.useWorker fallback behavior and add regression coverage for worker failures and batched text measurement.

## Tests
- pnpm exec vitest test/module/module-coverage-spec.ts test/internals/text-util-spec.ts test/plugin/textoverlap/textoverlap-spec.ts
- pnpm run lint
- pnpm exec dprint check src/Plugin/textoverlap/index.ts src/config/Options/common/boost.ts src/module/worker.ts test/module/module-coverage-spec.ts test/plugin/textoverlap/textoverlap-spec.ts test/internals/text-util-spec.ts types/options.d.ts
- pnpm test
- pnpm run build

Note: pnpm run build reports the existing webpack asset-size warning for billboardjs-plugin-stanford.pkgd.min.js.