### PR TITLE
feat(boost): pre-bundle the worker source and add workerUrl

### DIFF
--- a/CHANGELOG-v4.md
+++ b/CHANGELOG-v4.md
@@ -9,6 +9,9 @@ change.
 For the persistent guide on **how to import modules**, see [MODULE_IMPORTS.md](./MODULE_IMPORTS.md)
 — that document is the canonical reference and is linked from runtime error messages.
 
+Changes released after 4.0 are collected under
+[Post-4.0 improvements](#post-40-improvements) below.
+
 ## BREAKING CHANGES
 
 ### ESM: optional APIs require explicit import
@@ -423,6 +426,131 @@ Current SVG parity backlog and implementation plan:
 
 Each completed parity item should remove the corresponding `warnUnsupportedCanvasOptions()` warning,
 update the canvas ESM exports when API surface changes, and add SVG-vs-canvas regression coverage.
+## Post-4.0 improvements
+
+Landing in the next 4.x minor. Refinements on top of v4: the module-import
+contract, the option surface and the rendered output are unchanged, apart from
+the two notes below.
+
+### TextOverlap no longer needs `d3-delaunay`
+
+The plugin used exactly one call, `voronoi().cellPolygon(i)`. `src/module/voronoi.ts`
+computes bounded Voronoi cells by half-plane clipping instead, so the plugin has
+no third-party dependency left and its label positioning is synchronous again —
+the dynamic `import()` and the two lazy chunks (39.7 KB + 113.2 KB raw) it used
+to emit are gone.
+
+`d3-delaunay` was never a declared dependency (the plugin documented it as
+"install separately"), so nothing changes for consumers who did not install it.
+If you installed it only for this plugin, you can drop it.
+
+### Behavior changes to check
+
+Two externally visible differences. Everything else is byte-identical output —
+verified by diffing the rendered DOM of published 4.0.3 against this build across
+every chart type, all 18 spline curves, all 6 treemap tiles, timeseries
+formatting, `log` scales, data parsing and both affected plugins, with no config
+key or API method removed.
+
+#### `axis.{x,y,y2}.axes` sub-axes are now rendered by `AxisRenderer`
+
+The additional axes were the last thing still drawn by `d3-axis`. They now go through the same
+renderer as the main axes, which changes three things about the markup. The chart body, the main
+axes and every other chart type are byte-identical; this is the only rendered difference in the
+release.
+
+**1. Ticks moved 0.5px — into alignment.** `d3-axis` offsets its output by half a pixel for crisp
+edges on non-retina displays; `AxisRenderer` never did, so the sub-axes used to sit half a pixel off
+from the main axis they sat under:
+
+| x-axis tick[0] | 4.0.3 | next |
+|---|---|---|
+| main (`.bb-axis-x`) | `translate(5.088…)` | `translate(5.088…)` |
+| sub (`.bb-axis-x-1`) | `translate(5.588…)` | `translate(5.088…)` |
+
+The main axis is unchanged; the sub-axis now matches it. If you compensated for that half pixel in
+your own overlay, drop the compensation.
+
+**2. `<path class="domain">` is now the last child.** `AxisRenderer` appends the domain path first
+but *inserts* each tick before it, so it ends up last. Only position-based selectors break:
+
+```diff
+- .bb-axis-x-1 .tick:last-child
++ .bb-axis-x-1 .tick:last-of-type
+```
+
+`:first-child` on ticks is affected the same way. Class-based selectors (`.tick`, `.domain`) need no
+change.
+
+**3. Four presentation attributes are gone** from the sub-axis group: `fill="none"`,
+`font-size="10"`, `font-family="sans-serif"` and `text-anchor="middle"`, which `d3-axis` set and
+`AxisRenderer` does not. **This does not change how it looks**: `billboard.css` styles `.bb-axis`
+text, and CSS wins over presentation attributes, so the computed style is `10px / sans-serif /
+rgb(0,0,0)` in both versions. It matters only if you queried those attributes directly, or render
+without the stylesheet.
+
+#### Bundle sizes shift
+
+What a consumer downloads, measured against published 4.0.3 (`gzip -9`):
+
+| | 4.0.3 | next | |
+|---|---:|---:|---:|
+| ESM app bundle<sup>*</sup> | 122,283 | 124,279 | +1,996 |
+| `billboard.pkgd.min.js` | 264,577 | 270,150 | +5,573 |
+| `billboard.min.js` | 149,512 | 156,566 | +7,054 |
+
+<sup>*</sup> esbuild bundle of `import bb, {bar, line, area, pie, zoom} from "billboard.js"`
+with each version's own dependency tree installed.
+
+The growth is the new feature work — configurable subchart rendering, canvas grid
+selectors, the React subpath and the pre-bundled worker. The d3 dependency graph
+is unchanged from 4.0.3.
+
+Runtime is at parity: every benchmark scenario lands within ±4% of 4.0.3 once
+re-measured at 40 samples. A 7–13% canvas line/area regression introduced by
+`feat(subchart)` was found and fixed in the process; see
+[PERFORMANCE.md](./PERFORMANCE.md).
+
+### New options
+
+#### `billboard.js/react` subpath
+
+A React component wrapper, shipped as its own entry so importing it never pulls the root bundle into
+a non-React bundle. The billboard namespace comes in through the `bb` prop.
+
+```tsx
+import bb, {line} from "billboard.js";
+import BillboardJS from "billboard.js/react";
+
+<BillboardJS bb={bb} options={{data: {columns: [["data1", 30, 120, 80]], type: line()}}} />;
+```
+
+`dist/billboard.react.js` is the UMD counterpart, exposing the `BillboardReact` global. It treats
+`react` as an external and does not bundle billboard.js, so both must already be on the page — and
+since it reads the `React` global, that path needs a UMD build of React, which React 18 and below
+ship and React 19 does not. See [README](./README.md#react) for the full markup.
+
+#### `boost.workerUrl`
+
+Points the data-conversion Worker at a static script instead of an inline `blob:` worker, for strict
+CSP environments. `billboard.worker.js` ships in `dist/` for this purpose.
+
+```js
+boost: {
+    useWorker: true,
+    workerUrl: "/path/to/billboard.worker.js"
+}
+```
+
+A custom script must implement the same protocol: receive `{id, op, args}`, post back `{id, result}`
+or `{id, error}`. No `eval()` is involved — the worker is addressed by op name, so no application
+function is ever stringified. Any failure (load error, unknown op, timeout, result mismatch) falls
+back to the main thread.
+
+#### `boost.useWorker: "auto"`
+
+Offloads conversion only when the data exceeds ~5,000 cells, below which structured cloning costs
+more than the offload saves.
 
 ## Previous major versions
 

--- a/CHANGELOG-v4.md
+++ b/CHANGELOG-v4.md
@@ -67,7 +67,7 @@ a function`.
 > roughly **~19 KB minified / ~6.3 KB gzipped** vs v3 for the same chart (≈ 6.5–7 % of a minimal bar
 > chart bundle).
 
-Measured with `esbuild --bundle --minify --tree-shaking=true` on a minimal bar chart entry. Each row
+Measured by bundling a minimal bar chart entry with minification and tree-shaking enabled. Each row
 adds only the named module to the baseline.
 
 | Configuration | Minified | Gzipped |
@@ -495,12 +495,13 @@ What a consumer downloads, measured against published 4.0.3 (`gzip -9`):
 
 | | 4.0.3 | next | |
 |---|---:|---:|---:|
-| ESM app bundle<sup>*</sup> | 122,283 | 124,279 | +1,996 |
-| `billboard.pkgd.min.js` | 264,577 | 270,150 | +5,573 |
-| `billboard.min.js` | 149,512 | 156,566 | +7,054 |
+| ESM app bundle<sup>*</sup> | 120,049 | 121,827 | +1,778 |
+| `billboard.pkgd.min.js` | 264,577 | 270,413 | +5,836 |
+| `billboard.min.js` | 149,512 | 156,826 | +7,314 |
 
-<sup>*</sup> esbuild bundle of `import bb, {bar, line, area, pie, zoom} from "billboard.js"`
-with each version's own dependency tree installed.
+<sup>*</sup> rolldown bundle of an entry importing and using
+`bb, {bar, line, area, pie, zoom}` from `billboard.js`, with each version's own
+dependency tree installed. See [PERFORMANCE.md](./PERFORMANCE.md) for the method.
 
 The growth is the new feature work — configurable subchart rendering, canvas grid
 selectors, the React subpath and the pre-bundled worker. The d3 dependency graph

--- a/MODULE_IMPORTS.md
+++ b/MODULE_IMPORTS.md
@@ -333,6 +333,29 @@ time, so `chart.xgrids()`, `chart.export()`, etc. work out of the box:
 </script>
 ```
 
+The same holds for the React component: `dist/billboard.react.js` is a UMD build exposing the
+`BillboardReact` global, and the packaged entry it is paired with has every module registered, so
+no resolver call is needed.
+
+```html
+<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/billboard.js/dist/billboard.pkgd.min.js"></script>
+<script src="$YOUR_PATH/billboard.react.js"></script>
+<script>
+  ReactDOM.createRoot(document.getElementById("root")).render(
+    React.createElement(BillboardReact.Chart, {
+      bb,
+      options: { data: { type: "bar", columns: [["data1", 30, 200, 100]] } }
+    })
+  );
+</script>
+```
+
+The `modules` prop is only meaningful for the ESM entries — under UMD there is nothing left to
+register. React itself is an external here, so a UMD build of React must be on the page: React 18
+and below ship one, React 19 does not.
+
 ## See also
 
 - Release-specific changes: [CHANGELOG-v4.md](./CHANGELOG-v4.md),

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -166,8 +166,26 @@ interleaved before acting on it.
 - Worker data conversion must always fall back to the main thread on creation
   failure, postMessage failure, worker error, unknown op, timeout, or parity
   mismatch.
-- The first successful result per op is compared with the main-thread result. A
-  mismatch disables the worker for the session.
+- **The parity self-test runs on a sampled payload, not the real one.** The first
+  time a worker is asked for an op, `startVerify()` posts a truncated copy of the
+  arguments (3 leading entries, 3 leading cells each) and compares the reply with
+  the main thread's result for that same sample. A mismatch disables the worker for
+  the session and the real payload falls back.
+  - The sample is posted *before* the real request. The worker answers in order, so
+    the check overlaps the real conversion instead of adding a round trip after it,
+    and a cold worker shows two replies rather than one.
+  - The question the check answers is "does this worker implement this op the way
+    the main thread does", which a sample settles as well as the full dataset. Do
+    not restore the full re-parse: it costs one whole main-thread conversion, which
+    is the exact work the offload exists to avoid, and `boost.useWorker` only covers
+    the initial conversion — so a single-chart page paid it every time and came out
+    behind `useWorker: false`.
+  - Truncation is shape-generic on purpose: `args[0]` is the data array for all three
+    ops, so slicing it (and its entries, when they are arrays) stays valid for
+    `columns`, `rows` and `json` alike without per-op fixtures.
+  - Guarded by "self-tests on a sampled payload, not the full one" in
+    `test/module/module-coverage-spec.ts`, which asserts the main-thread converter
+    sees 3x3 cells while the worker gets the whole payload.
 - `boost.workerUrl` can point to a static worker script for strict CSP
   environments that disallow Blob worker URLs. `dist/billboard.worker.js` is
   emitted for exactly this purpose (703 bytes gzip). The protocol is

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,262 @@
+# Performance Notes
+
+This document records implementation notes for dependency reduction and DOM
+batching work that can affect rendering behavior.
+
+## D3 Dependency Reduction
+
+> **Do not re-attempt the in-tree d3 ports.** An earlier revision of this branch
+> replaced `d3-scale`, `d3-axis`, `d3-shape`, `d3-path`, `d3-time`,
+> `d3-time-format` and `d3-hierarchy` with modules under `src/module/`. Those
+> modules were *adapted from* d3's ISC-licensed source, which makes them
+> derivative works: shipping them obliges us to carry d3's copyright and
+> permission notice, and the code cannot sit under billboard.js' own copyright.
+> That was judged unacceptable, so the ports were reverted and the packages
+> restored.
+>
+> A rewrite does not fix this. Paraphrasing source you have read is still
+> copying; only a clean-room implementation - written by someone who has never
+> seen d3's source, from an independently written specification - produces a
+> non-derivative work. The output also has to stay byte-identical to d3 for
+> backward compatibility, which in practice forces d3's exact algorithms
+> (`ticks()` rounding, the tick interval table, the 18 curve constructions).
+> Weigh that cost before revisiting.
+
+What survives is the one replacement that was **not** derived from d3:
+
+- `d3-delaunay` is gone. The TextOverlap plugin needed exactly one call,
+  `voronoi().cellPolygon(i)`. `src/module/voronoi.ts` computes bounded cells by
+  half-plane clipping - the clip rectangle is clipped against the perpendicular
+  bisector to every other site (Sutherland-Hodgman, published 1974), which *is*
+  the cell by definition. That is a different algorithm from d3-delaunay's
+  Delaunay triangulation, written from the geometric definition rather than
+  adapted from its source. O(n^2) rather than O(n log n), which is the right
+  trade at label counts.
+- The plugin dropped its dynamic `import()` with it, so `preventLabelOverlap()`
+  is synchronous again and the two lazy chunks it used to emit are gone.
+- `d3-delaunay` is kept as a **devDependency** to drive
+  `test/module/voronoi-parity-spec.ts`, which asserts the cells match.
+
+## Release-over-release benchmark (4.0.3 -> HEAD)
+
+**Method.** Published `billboard.js@4.0.3` from npm versus HEAD. Rebuilding the
+4.0.3 tag with the current devDependencies reproduces the published
+`billboard.pkgd.min.js` **byte-for-byte** (sha256 `492c3aa6...`), so every delta
+is a source change, not a build change. Runtime figures come from
+`benchmark/perf.spec.ts` against `dist/billboard.pkgd.min.js` in headless
+Chromium - 2 warmup + 5 iterations, run twice, reported as the median of the
+pooled 10. Bundle figures are `gzip -9`.
+
+### Delivered bytes
+
+| gzip | 4.0.3 | HEAD | delta |
+|---|---:|---:|---:|
+| ESM app bundle<sup>*</sup> | 122,283 | 124,279 | +1,996 |
+| `billboard.pkgd.min.js` | 264,577 | 270,150 | +5,573 |
+| `billboard.min.js` | 149,512 | 156,566 | +7,054 |
+| d3-family packages installed | 20 | 20 | 0 |
+
+<sup>*</sup> esbuild `--bundle --minify --format=esm --target=es2015` over
+`import bb, {bar, line, area, pie, zoom} from "billboard.js"`, with each
+version's own dependency tree installed from npm.
+
+The growth is the post-4.0.3 feature work - configurable subchart rendering,
+canvas grid selectors, the React subpath and the pre-bundled worker. The
+dependency graph is unchanged: `d3-delaunay` was never a declared dependency, so
+removing it does not move the install count.
+
+### Runtime
+
+At parity. Every scenario lands within +/-4% except five rows that crossed +/-5%
+in the standard harness; all of them collapsed when re-measured at 40 samples
+with builds interleaved round-robin:
+
+| Scenario | metric | standard harness | 40 samples |
+|---|---|---:|---:|
+| SVG 5x5000 area | generate | +13.5% | -3.7% |
+| SVG 5x10000 area | load | +7.5% | -10.9% |
+| Canvas 5x5000 line | load | +8.6% | -0.5% |
+| SVG 5x1000 stacked bar | load | +6.1% | +1.6% |
+| SVG 5x5000 line | load | +5.0% | -1.4% |
+
+No reproducible regression against 4.0.3 remains.
+
+### The canvas regression, bisected
+
+`feat(subchart)` introduced a 7-13% canvas line/area regression that shipped
+unnoticed. Building all nine commits between 4.0.3 and this branch and running a
+focused round-robin (3 warmup + 8 iterations x 3 rounds, interleaved so machine
+drift hits every build equally) put the entire jump on one commit:
+
+| commit | Canvas 5x1000 area generate | Canvas 5x5000 line generate |
+|---|---:|---:|
+| `0b7255c96` | 11.05 | 29.60 |
+| `37ec4b7c8` feat(subchart) | 12.65 **(+14.5%)** | 31.50 **(+6.4%)** |
+| `2762d0240` ... `401c13b2d` | flat | flat |
+
+**Root cause**: `getTargetValueMinMax()` in `internals/domain.ts` called
+`$$.getSubchartCandlestickShapeValue?.(row, true)` from inside the per-data-point
+loop, with `isSub` hardcoded to `true`. That helper's first act is to return
+early when `!isSub` - hardcoding `true` defeated it, so every main-chart domain
+pass walked the subchart type chain (`isCandlestickType` ->
+`isSubchartSourceTypeOf` -> `getSubchartSourceTargetType` -> `getTargetType`)
+once per data point. The projection is keyed by target id, so it is now resolved
+once per target and skipped per row.
+
+**Second cost**: `getShapeYMin()` ran per data point from the area `y0` accessor
+in `shape/core/path.ts`, resolving a scale through `getYScaleById()` and slicing
+its domain (`scale.domain()` returns a copy) each time. It depends only on the
+target id, so it is memoized per series - the pattern `generateGetAreaPoints()`
+already used through its `y0Cache`, which `generateGetLinePoints()` was missing
+and now has too. That call predates the subchart commit, so fixing it took canvas
+area below 4.0.3.
+
+Two false leads, both instructive:
+
+- A CPU profile of the pre-regression parent against HEAD appeared to blame the
+  shape generators, because an in-tree port's function names had replaced
+  `d3-shape`'s in the profile. **The names had simply moved.** A profile diff
+  across two different implementations cannot attribute anything on its own -
+  only a controlled A/B (swap one import, change nothing else) can.
+- `hasCanvasDrawableValue()`, which the commit adds to several canvas loops,
+  looked like the area-specific cost. It is not: `drawAreas()` is byte-identical
+  between `0b7255c96` and `37ec4b7c8`.
+
+### Noise floor of `benchmark/perf.spec.ts`
+
+The default 2 warmup + 5 iterations resolves roughly ±5–8% on the bar scenarios.
+Two rows crossed the ✗ threshold in the full harness and both evaporated when
+re-run at 40 samples with builds interleaved round-robin:
+
+| Scenario | metric | full harness | 40 samples |
+|---|---|---:|---:|
+| 5x1000 stacked bar | generate | +8.7% | +1.5% |
+| Canvas 5x5000 bar | load | +8.8% | +1.3% |
+
+Treat a single-run ✗ as a hypothesis, not a finding. Re-measure with builds
+interleaved before acting on it.
+
+## DOM Read/Write Batching
+
+- Axis tick size calculation uses a hidden dummy axis, cached fingerprints, and
+  batched bounding-rect reads before removing the dummy node.
+- Text overlap marking reads text lengths first and applies overlap classes in a
+  separate write phase.
+- Keep future layout-sensitive changes in the same read-then-write shape:
+  collect all `getBBox()`, `getBoundingClientRect()`, `offsetWidth`, and
+  `getComputedTextLength()` reads before changing attributes, styles, or classes.
+
+## Worker Safety
+
+- **The worker source is pre-bundled at build time, never derived from
+  `Function.prototype.toString()`.** `src/module/worker.entry.ts` is bundled by
+  `config/worker-src.js` (esbuild, IIFE) and injected as a string constant by all
+  three pipelines: webpack `DefinePlugin`, the `bb-worker-src` rolldown plugin, and
+  vitest `define`. Work is addressed by **op name** (`json`, `rows`, `columns`), so
+  no application function is ever stringified or evaluated.
+- Why this matters: stringifying a live function carries whatever the host
+  toolchain injected into its body - coverage counters, babel helpers,
+  bundler-hoisted module scope - into a context where those bindings don't exist.
+  `test/module/worker-real-spec.ts` reproduced exactly that, failing with
+  `cov_xxx is not defined` under istanbul instrumentation until the source was
+  pre-bundled. That is the same failure class reported for React/webpack setups.
+- The rolldown injection is **textual**. Never name the injected constant outside
+  its single reference in `getWorkerSrc()` - even a mention in a comment inlines
+  the entire worker source a second time.
+- Worker data conversion must always fall back to the main thread on creation
+  failure, postMessage failure, worker error, unknown op, timeout, or parity
+  mismatch.
+- The first successful result per op is compared with the main-thread result. A
+  mismatch disables the worker for the session.
+- `boost.workerUrl` can point to a static worker script for strict CSP
+  environments that disallow Blob worker URLs. `dist/billboard.worker.js` is
+  emitted for exactly this purpose (703 bytes gzip). The protocol is
+  `{id, op, args}` in, `{id, result}` or `{id, error}` out - **no `eval()` on the
+  worker side**, which the previous `{id, fn, deps, args}` protocol required and
+  which strict CSP would have blocked anyway.
+- `boost.useWorker` accepts `"auto"`, which offloads only past
+  `WORKER_CELL_THRESHOLD` (5,000 cells in `convert.ts`). Below that, structured
+  cloning the payload costs more than the parsing it saves.
+- **The default is still `false`.** Everything the plan required before flipping it
+  is now in place and covered by `test/internals/boost-worker-env-spec.ts` (real
+  worker, static worker script, blocked Worker constructor, blocked blob URL,
+  missing Worker/Blob, plus both `"auto"` branches - all rendering identical
+  results). The one remaining consideration is semantic, not safety: offloading
+  makes the initial data conversion asynchronous, so code that reads chart data
+  synchronously right after `bb.generate()` would change behavior for large
+  datasets. Flipping the default to `"auto"` is a one-line change in
+  `src/config/Options/common/boost.ts` once that trade-off is accepted.
+
+## Worker Environment Matrix
+
+Verified in a real Chromium page through the Vite/esbuild pipeline
+(`test/internals/boost-worker-env-spec.ts`). Each row must end with the same
+rendered chart:
+
+| Environment | Path taken |
+|---|---|
+| Worker available | pre-bundled blob worker |
+| `blob:` refused (CSP `script-src`) | main thread |
+| Worker construction refused (CSP `worker-src 'none'`) | main thread |
+| `boost.workerUrl` set | static `dist/billboard.worker.js` |
+| No `Worker`/`Blob` (SSR-shaped runtime) | main thread |
+| `"auto"` under threshold | main thread, no worker created |
+| `"auto"` over threshold | worker |
+
+Not covered here: real CRA / Next.js / Vite application builds. Those need
+installed fixture apps; the failure mode they would expose (host toolchain
+rewriting function bodies) is what the pre-bundled worker source structurally
+eliminates.
+
+## Verification
+
+Use targeted tests for the affected paths before running the full suite:
+
+```bash
+# the one in-tree replacement left, and its reference implementation
+pnpm exec vitest test/module/voronoi-parity-spec.ts
+# worker
+pnpm exec vitest test/module/worker-real-spec.ts test/internals/boost-worker-env-spec.ts
+pnpm exec vitest test/module/module-coverage-spec.ts -t worker
+pnpm run lint
+pnpm test
+pnpm run build
+```
+
+Keep `d3-delaunay` in `devDependencies`: `voronoi-parity-spec.ts` imports it as
+the reference implementation. Removing it silently guts the safety net.
+
+### Release-over-release compatibility check
+
+A unit-level parity suite compares a module against the package it replaced. It
+cannot catch a difference that only appears once the module is wired into a
+chart, so before shipping any replacement, diff the rendered output of the last
+published build against the build under test:
+
+1. `npm pack billboard.js@<last release>` and unpack, or build the release tag —
+   the two are byte-identical for `billboard.pkgd.min.js`, so either works.
+2. Load each bundle in a headless page with `dist/billboard.css` applied,
+   `bb.generate()` the same option object, and compare the bind element's
+   `innerHTML` after normalizing instance ids (`bb-\d{10,}`), `url(#…)`
+   references and float noise past 3 decimals.
+3. Cover at minimum: every chart type, all 18 `spline.interpolation.type` curves,
+   all 6 `treemap.tile` algorithms, timeseries formatting, `log` scale,
+   `data.json`/`rows`/`xFormat` parsing, and the `stanford` / `textoverlap`
+   plugin bundles.
+4. Where the DOM legitimately differs, fall back to a screenshot diff — a DOM
+   difference is not automatically a visual one.
+
+Also diff the public surface, which is cheap and catches accidental removals:
+`bb.generate()` a chart on each build and compare `Object.keys(chart.internal.config)`,
+the chart API method list and `Object.keys(bb)`.
+
+The last such run (4.0.3 → HEAD) came out identical on 38/39 core scenarios,
+both plugins and all 6 treemap tiles, with no config key or API method removed.
+The one differing scenario is `subchart`, where `feat(subchart)` adds a
+`bb-event-rects-subchart` group — additive, `fill-opacity: 0` and
+`pointer-events: none`, and pixel-identical in the screenshot diff. Separately,
+the `axis.*.axes` sub-axes differ; written up in
+[CHANGELOG-v4.md](./CHANGELOG-v4.md#behavior-changes-to-check); the DOM diff
+there looked alarming (four presentation attributes gone) and the screenshot
+diff reduced it to a 0.5px tick shift that *removed* a pre-existing misalignment
+with the main axis.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -51,14 +51,19 @@ pooled 10. Bundle figures are `gzip -9`.
 
 | gzip | 4.0.3 | HEAD | delta |
 |---|---:|---:|---:|
-| ESM app bundle<sup>*</sup> | 122,283 | 124,279 | +1,996 |
-| `billboard.pkgd.min.js` | 264,577 | 270,150 | +5,573 |
-| `billboard.min.js` | 149,512 | 156,566 | +7,054 |
-| d3-family packages installed | 20 | 20 | 0 |
+| ESM app bundle<sup>*</sup> | 120,049 | 121,827 | +1,778 |
+| `billboard.pkgd.min.js` | 264,577 | 270,413 | +5,836 |
+| `billboard.min.js` | 149,512 | 156,826 | +7,314 |
+| d3-family packages installed | 19 | 19 | 0 |
 
-<sup>*</sup> esbuild `--bundle --minify --format=esm --target=es2015` over
-`import bb, {bar, line, area, pie, zoom} from "billboard.js"`, with each
-version's own dependency tree installed from npm.
+<sup>*</sup> rolldown `{format: "esm", minify: true}` over an entry that imports **and
+uses** `bb, {bar, line, area, pie, zoom}` - a bare import would be tree-shaken away.
+Each version is installed in its own project so it brings its own dependency tree,
+4.0.3 from npm and HEAD from `npm pack` of the working tree. Everything resolves into
+one chunk, with no bare imports left unbundled.
+
+Use `gzip -9 -n`, not `gzip -9 <file>`: the latter stores the filename and mtime in the
+header, so the figure moves with the filename.
 
 The growth is the post-4.0.3 feature work - configurable subchart rendering,
 canvas grid selectors, the React subpath and the pre-bundled worker. The
@@ -150,10 +155,16 @@ interleaved before acting on it.
 
 - **The worker source is pre-bundled at build time, never derived from
   `Function.prototype.toString()`.** `src/module/worker.entry.ts` is bundled by
-  `config/worker-src.js` (esbuild, IIFE) and injected as a string constant by all
-  three pipelines: webpack `DefinePlugin`, the `bb-worker-src` rolldown plugin, and
-  vitest `define`. Work is addressed by **op name** (`json`, `rows`, `columns`), so
+  `config/worker-src.js` (rolldown, minified IIFE) and injected as a string constant
+  by all three pipelines: webpack `DefinePlugin`, the `bb-worker-src` rolldown plugin,
+  and vitest `define`. Work is addressed by **op name** (`json`, `rows`, `columns`), so
   no application function is ever stringified or evaluated.
+  - Bundled with rolldown, which the ESM build already uses. **Do not reach for another
+    bundler here**: it would become a declared devDependency for this single call, and
+    every bundler already in the tree is reached indirectly, through a loader or plugin.
+  - `getWorkerSource()` is therefore **async** - rolldown has no `buildSync`. It
+    memoizes the promise, so the worker is bundled at most once per process, and
+    `vitest.config.ts` exports an async config to await it.
 - Why this matters: stringifying a live function carries whatever the host
   toolchain injected into its body - coverage counters, babel helpers,
   bundler-hoisted module scope - into a context where those bindings don't exist.
@@ -207,7 +218,7 @@ interleaved before acting on it.
 
 ## Worker Environment Matrix
 
-Verified in a real Chromium page through the Vite/esbuild pipeline
+Verified in a real Chromium page through the Vite pipeline
 (`test/internals/boost-worker-env-spec.ts`). Each row must end with the same
 rendered chart:
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ $ pnpm add billboard.js
 
 ### React
 
-The React component is available from the `billboard.js/react` subpath.
+The React component is available from the `billboard.js/react` subpath. The billboard namespace is
+passed in through the `bb` prop, so importing the React subpath never pulls the root bundle into a
+non-React bundle.
 
 ```tsx
 import bb, {line} from "billboard.js";
@@ -183,6 +185,46 @@ import BillboardJS from "billboard.js/react";
   }}
 />;
 ```
+
+Without a bundler, load `dist/billboard.react.js`. It is a UMD build exposing the `BillboardReact`
+global, which holds the component as both `.Chart` and `.default`:
+
+```html
+<!-- React first: this path reads the 'React' global, so it needs a UMD build of
+     React. React 18 and below ship one; React 19 does not. -->
+<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+
+<link rel="stylesheet" href="$YOUR_PATH/billboard.css">
+<script src="$YOUR_PATH/billboard.pkgd.js"></script>
+<script src="$YOUR_PATH/billboard.react.js"></script>
+
+<div id="root"></div>
+<script>
+  const {Chart} = BillboardReact;
+
+  ReactDOM.createRoot(document.getElementById("root")).render(
+    React.createElement(Chart, {
+      bb,
+      options: {
+        data: {
+          columns: [["data1", 30, 120, 80]],
+          type: "line"
+        }
+      }
+    })
+  );
+</script>
+```
+
+> [!NOTE]
+> - `billboard.react.js` treats `react` as an external, so React must already be on the page. It
+>   does **not** bundle billboard.js either — load `billboard.js`/`billboard.pkgd.js` first and hand
+>   the `bb` global to the component.
+> - On **React 19+** there is no UMD build of React to load. Use a bundler, or import both packages
+>   as ESM in the browser through an import map.
+> - The packaged build registers every chart type, so string types (`type: "line"`) work as-is. With
+>   the ESM entry, pass the module instead (`type: line()`) or through the `type` prop.
 
 For local visual testing of the React component, run:
 
@@ -238,7 +280,17 @@ Load billboard.js after D3.js.
 <!-- 2) or Load billboard.js packaged with D3.js -->
     <link rel="stylesheet" href="$YOUR_PATH/billboard.css">
     <script src="$YOUR_PATH/billboard.pkgd.js"></script>
+
+<!-- 3) optionally, the React component on top of either of the above.
+     Needs the 'React' global, so load a UMD build of React first
+     (React 18 and below ship one; React 19 does not). -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="$YOUR_PATH/billboard.react.js"></script>
 ```
+
+Loading `billboard.js` exposes the `bb` global, and `billboard.react.js` exposes `BillboardReact`.
+See [React](#react) for a full example.
 
 or by importing ESM.
 > [!TIP]

--- a/config/globals.d.ts
+++ b/config/globals.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Build-time constants injected by the build pipelines.
+ *
+ * Lives under config/ rather than types/ because types/ ships in `files`: a bare
+ * global declared there would leak `__WORKER_SRC__` into every consumer program
+ * that picked the file up.
+ *
+ * Declared here rather than inside the consuming module on purpose: esbuild only
+ * substitutes `define` values for identifiers that are not bound in scope, and a
+ * module-level `declare const` binds the name and silently disables the
+ * replacement.
+ */
+
+/**
+ * Pre-bundled Web Worker source, injected from `src/module/worker.entry.ts`
+ * by config/worker-src.js. See PERFORMANCE.md "Worker Safety".
+ */
+declare const __WORKER_SRC__: string;

--- a/config/globals.d.ts
+++ b/config/globals.d.ts
@@ -5,8 +5,8 @@
  * global declared there would leak `__WORKER_SRC__` into every consumer program
  * that picked the file up.
  *
- * Declared here rather than inside the consuming module on purpose: esbuild only
- * substitutes `define` values for identifiers that are not bound in scope, and a
+ * Declared here rather than inside the consuming module on purpose: a `define`-based
+ * substitution only replaces identifiers that are not bound in scope, and a
  * module-level `declare const` binds the name and silently disables the
  * replacement.
  */

--- a/config/rolldown/esm.js
+++ b/config/rolldown/esm.js
@@ -12,10 +12,10 @@ const distPath = "dist-esm";
 // contains `${...}` sequences that regex-based replacement mangles or skips.
 const workerSrcPlugin = {
 	name: "bb-worker-src",
-	transform(code) {
+	async transform(code) {
 		if (code.includes("__WORKER_SRC__")) {
 			return {
-				code: code.split("__WORKER_SRC__").join(JSON.stringify(getWorkerSource())),
+				code: code.split("__WORKER_SRC__").join(JSON.stringify(await getWorkerSource())),
 				map: null
 			};
 		}

--- a/config/rolldown/esm.js
+++ b/config/rolldown/esm.js
@@ -1,10 +1,26 @@
 import {readdirSync, rmSync} from "fs";
 import {replacePlugin} from "rolldown/plugins";
 import {getBanner, readJson, resolvePath} from "../util.js";
+import {getWorkerSource} from "../worker-src.js";
 
 const pkg = readJson("package.json");
 const prefix = readJson("./const.json").pluginPrefix;
 const distPath = "dist-esm";
+
+// Inject the separately bundled worker source (see config/worker-src.js).
+// Done with split/join rather than replacePlugin: the minified worker source
+// contains `${...}` sequences that regex-based replacement mangles or skips.
+const workerSrcPlugin = {
+	name: "bb-worker-src",
+	transform(code) {
+		if (code.includes("__WORKER_SRC__")) {
+			return {
+				code: code.split("__WORKER_SRC__").join(JSON.stringify(getWorkerSource())),
+				map: null
+			};
+		}
+	}
+};
 
 const {plugin, production} = getBanner();
 const version = process.env.VERSION || pkg.version;
@@ -45,7 +61,8 @@ const plugins = [
 	replacePlugin({
 		"__VERSION__": version,
 		preventAssignment: true
-	})
+	}),
+	workerSrcPlugin
 ];
 
 const external = id => /^d3-/.test(id) || /^react(?:\/|$)/.test(id);

--- a/config/worker-src.js
+++ b/config/worker-src.js
@@ -1,0 +1,32 @@
+/**
+ * Bundle src/module/worker.entry.ts into a self-contained worker source string.
+ *
+ * The result is injected as the `__WORKER_SRC__` constant by every build
+ * pipeline (webpack, rolldown, vitest), so the worker never depends on
+ * `Function.prototype.toString` of transformed application code.
+ */
+import {buildSync} from "esbuild";
+import {dirname, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+
+let cached = null;
+
+export function getWorkerSource() {
+	if (cached === null) {
+		const {outputFiles} = buildSync({
+			entryPoints: [
+				resolve(dirname(fileURLToPath(import.meta.url)), "../src/module/worker.entry.ts")
+			],
+			bundle: true,
+			minify: true,
+			format: "iife",
+			target: "es2015",
+			legalComments: "none",
+			write: false
+		});
+
+		cached = outputFiles[0].text;
+	}
+
+	return cached;
+}

--- a/config/worker-src.js
+++ b/config/worker-src.js
@@ -4,29 +4,36 @@
  * The result is injected as the `__WORKER_SRC__` constant by every build
  * pipeline (webpack, rolldown, vitest), so the worker never depends on
  * `Function.prototype.toString` of transformed application code.
+ *
+ * Bundled with rolldown, which the ESM build already uses. Don't reach for another
+ * bundler here: it would become a declared devDependency for this single call, while
+ * every bundler already in the tree is reached indirectly, through a loader or plugin.
  */
-import {buildSync} from "esbuild";
 import {dirname, resolve} from "node:path";
 import {fileURLToPath} from "node:url";
+import {build} from "rolldown";
 
 let cached = null;
 
+/**
+ * Get the bundled worker source, building it at most once per process.
+ * @returns {Promise<string>} Minified IIFE worker source
+ */
 export function getWorkerSource() {
-	if (cached === null) {
-		const {outputFiles} = buildSync({
-			entryPoints: [
-				resolve(dirname(fileURLToPath(import.meta.url)), "../src/module/worker.entry.ts")
-			],
-			bundle: true,
-			minify: true,
+	// the promise is the cache: concurrent callers share one build
+	cached ??= build({
+		input: resolve(dirname(fileURLToPath(import.meta.url)), "../src/module/worker.entry.ts"),
+		write: false,
+		output: {
 			format: "iife",
-			target: "es2015",
-			legalComments: "none",
-			write: false
-		});
-
-		cached = outputFiles[0].text;
-	}
+			minify: true,
+			// worker.entry.ts exports `ops`/`handleMessage` for the specs to import.
+			// An IIFE has to put them somewhere, and naming that binding is what
+			// silences rolldown's MISSING_NAME_OPTION_FOR_IIFE_EXPORT warning. The
+			// worker never reads it - it self-registers through `self.onmessage`.
+			name: "bbWorker"
+		}
+	}).then(({output}) => output[0].code);
 
 	return cached;
 }

--- a/demo/chart.js
+++ b/demo/chart.js
@@ -523,6 +523,20 @@ var billboardDemo = {
 				) + ", // for ESM specify as: " + module +"()";
 			});
 
+		// boost.useWorker only says *whether* to offload, not where the worker source
+		// comes from - spell the CSP/ESM variants out next to it
+		code.data = code.data.replace(
+			/^([\t ]*)(useWorker: (?:true|"auto"))(,?)$/m,
+			function(match, indent, decl, comma) {
+				return indent + decl + comma +
+					" // inline blob: worker, nothing extra to serve\r\n" +
+					indent + '// "auto" instead of true: offload only past ~5,000 cells\r\n' +
+					indent + "// strict CSP blocks blob: workers - serve the shipped script and add:\r\n" +
+					indent + '//   workerUrl: "$YOUR_PATH/dist/billboard.worker.js"\r\n' +
+					indent + '// for ESM specify as: import workerUrl from "billboard.js/dist/billboard.worker.js?url"';
+			}
+		);
+
 		this.$code.innerHTML = '// for ESM environment, need to import modules as:\r\n' +
 '// import bb, {'+ code.esm.join(", ") +'} from "'+
 			(code.esm.indexOf("canvas") > -1 ? "billboard.js/canvas" : "billboard.js") +'";\r\n';

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -8204,10 +8204,28 @@ setTimeout(function() {
 			}
 		},
 		useWorker: {
-			description: "Given data will be formatted in Worker thread at the initial time.",
+			description: "Given data will be formatted in Worker thread at the initial time.<br>*Under a strict CSP which blocks <code>blob:</code> workers, serve <code>dist/billboard.worker.js</code> and point <code>boost.workerUrl</code> at it.",
 			options: {
 				boost: {
+					// the worker source is inlined in the bundle and run through a
+					// blob: URL, so there's no extra file to serve
 					useWorker: true
+
+					// "auto" offloads only past ~5,000 cells, below which structured
+					// cloning costs more than the offload saves:
+					//   useWorker: "auto"
+
+					// a strict CSP blocks blob: workers. Serve the script shipped in the
+					// package and point at it instead - 'useWorker' must stay on, since
+					// 'workerUrl' only picks where the source comes from:
+					//   useWorker: true,
+					//   workerUrl: "$YOUR_PATH/dist/billboard.worker.js"
+
+					// ESM - the file is reachable as a package subpath:
+					//   import workerUrl from "billboard.js/dist/billboard.worker.js?url";
+					// Vite inlines assets under 4KB as a data: URI, which a strict CSP
+					// rejects just like blob:. Either opt this file out of inlining via
+					// build.assetsInlineLimit, or copy it into public/ and use that path.
 				},
 				data: {
 					columns: [

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
 		"d3-time": "^3.1.0",
 		"docdash": "^2.0.2",
 		"dprint": "^0.54.0",
+		"esbuild": "^0.28.1",
 		"esbuild-loader": "^4.5.0",
 		"eslint": "^10.5.0",
 		"eslint-plugin-import": "^2.32.0",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
 		"d3-time": "^3.1.0",
 		"docdash": "^2.0.2",
 		"dprint": "^0.54.0",
-		"esbuild": "^0.28.1",
 		"esbuild-loader": "^4.5.0",
 		"eslint": "^10.5.0",
 		"eslint-plugin-import": "^2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,9 +172,6 @@ importers:
       dprint:
         specifier: ^0.54.0
         version: 0.54.0
-      esbuild:
-        specifier: ^0.28.1
-        version: 0.28.1
       esbuild-loader:
         specifier: ^4.5.0
         version: 4.5.0(webpack@5.108.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       dprint:
         specifier: ^0.54.0
         version: 0.54.0
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       esbuild-loader:
         specifier: ^4.5.0
         version: 4.5.0(webpack@5.108.0)

--- a/src/ChartInternal/Axis/Axis.ts
+++ b/src/ChartInternal/Axis/Axis.ts
@@ -3,15 +3,9 @@
  * billboard.js project is licensed under the MIT license
  */
 
-import {
-	axisBottom as d3AxisBottom,
-	axisLeft as d3AxisLeft,
-	axisRight as d3AxisRight,
-	axisTop as d3AxisTop
-} from "d3-axis";
 import type {AxisType} from "../../../types/types";
 import {$AXIS, $COMMON} from "../../config/classes";
-import {AXIS_TICK_LINE_OVERLAP_PADDING, AXIS_TICK_SIZE} from "../../config/const";
+import {AXIS_TICK_LINE_OVERLAP_PADDING} from "../../config/const";
 import {KEY} from "../../module/Cache";
 import {
 	capitalize,
@@ -611,17 +605,17 @@ class Axis {
 	generateAxes(id: string) {
 		const $$ = this.owner;
 		const {config} = $$;
-		const axes: any[] = [];
+		const axes: AxisRenderer[] = [];
 		const axesConfig = config[`axis_${id}_axes`];
 		const isRotated = config.axis_rotated;
-		let d3Axis;
+		let orient;
 
 		if (id === "x") {
-			d3Axis = isRotated ? d3AxisLeft : d3AxisBottom;
+			orient = isRotated ? "left" : "bottom";
 		} else if (id === "y") {
-			d3Axis = isRotated ? d3AxisBottom : d3AxisLeft;
+			orient = isRotated ? "bottom" : "left";
 		} else if (id === "y2") {
-			d3Axis = isRotated ? d3AxisTop : d3AxisRight;
+			orient = isRotated ? "top" : "right";
 		}
 
 		if (axesConfig.length) {
@@ -631,15 +625,27 @@ class Axis {
 
 				v.domain && scale.domain(v.domain);
 
-				axes.push(
-					d3Axis(scale)
-						.ticks(tick.count)
-						.tickFormat(
-							isFunction(tick.format) ? tick.format.bind($$.api) : ((x: any) => x)
-						)
-						.tickValues(tick.values)
-						.tickSizeOuter(tick.outer === false ? 0 : AXIS_TICK_SIZE)
-				);
+				// reuses the same renderer as the main axes, which is what removed the
+				// d3-axis dependency: `tick.outer` maps onto `outerTick`, and the rest
+				// of the surface (ticks/tickValues/tickFormat) is identical
+				const axis = new AxisRenderer({
+					outerTick: tick.outer !== false,
+					noTransition: false,
+					config,
+					id,
+					isSubAxes: true,
+					owner: $$
+				})
+					.scale(scale)
+					.orient(orient)
+					.tickFormat(
+						isFunction(tick.format) ? tick.format.bind($$.api) : ((x: any) => x)
+					);
+
+				isValue(tick.count) && axis.ticks(tick.count);
+				tick.values && axis.tickValues(tick.values);
+
+				axes.push(axis);
 			});
 		}
 
@@ -671,15 +677,17 @@ class Axis {
 				const className = `${this.getAxisClassName(id)}-${i + 1}`;
 				let g = main.select(`.${className.replace(/\s/, ".")}`);
 
+				// AxisRenderer renders through create(), unlike d3-axis' callable form
 				if (g.empty()) {
 					g = main.append("g")
 						.attr("class", className)
-						.style("visibility", config[`axis_${id}_show`] ? null : "hidden")
-						.call(v);
+						.style("visibility", config[`axis_${id}_show`] ? null : "hidden");
+
+					v.create(g);
 				} else {
 					axesConfig[i].domain && scale.domain(axesConfig[i].domain);
 
-					$T(g).call(v.scale(scale));
+					v.scale(scale).create($T(g));
 				}
 
 				g.attr("transform", $$.getTranslate(id, i + 1));

--- a/src/ChartInternal/Axis/AxisRenderer.ts
+++ b/src/ChartInternal/Axis/AxisRenderer.ts
@@ -150,14 +150,19 @@ export default class AxisRenderer {
 		// // get the axis' tick position configuration
 		const id = params.id;
 		const type = getBaseAxisId(id);
-		const tickTextPos = type && /^(x|y|y2)$/.test(type) ?
+		// `axis.*.axes` entries carry their own tick options only (outer/format/count/
+		// values). The main axis' visibility and text position never reached them while
+		// they were rendered by d3-axis, which reads no billboard config, so they keep
+		// the defaults here.
+		const {isSubAxes} = params;
+		const tickTextPos = !isSubAxes && type && /^(x|y|y2)$/.test(type) ?
 			params.config[`axis_${type}_tick_text_position`] :
 			{x: 0, y: 0};
 
 		// tick visiblity
 		const prefix = getAxisOptionPrefix(id);
 		const axisShow = params.config[`${prefix}_show`];
-		const tickShow = {
+		const tickShow = isSubAxes ? {tick: true, text: true} : {
 			tick: axisShow ? params.config[`${prefix}_tick_show`] : false,
 			text: axisShow ? params.config[`${prefix}_tick_text_show`] : false
 		};

--- a/src/ChartInternal/data/convert.ts
+++ b/src/ChartInternal/data/convert.ts
@@ -17,6 +17,39 @@ import type {IData} from "../data/IData";
 import {columns, json, rows, url} from "./convert.helper";
 
 /**
+ * Cell count from which `boost.useWorker: "auto"` offloads conversion.
+ *
+ * Below this, structured cloning the payload to the worker and back costs more
+ * than the parsing it saves.
+ * @private
+ */
+const WORKER_CELL_THRESHOLD = 5000;
+
+/**
+ * Estimate the number of data cells to be converted.
+ * @param {Array} data Raw json(array form)/rows/columns data
+ * @returns {number} Approximate cell count
+ * @private
+ */
+function _getCellCount(data): number {
+	const first = data[0];
+
+	// rows/columns: array of arrays
+	if (isArray(first)) {
+		let count = 0;
+
+		for (let i = 0, len = data.length; i < len; i++) {
+			count += data[i]?.length ?? 0;
+		}
+
+		return count;
+	}
+
+	// json: array of objects
+	return data.length * Object.keys(first ?? {}).length;
+}
+
+/**
  * Get data key for JSON
  * @param {string|object} keysParam Key params
  * @param {object} config Config object
@@ -101,7 +134,22 @@ export default {
 	 */
 	convertData(args, callback: Function): void {
 		const {config} = this;
-		const useWorker = d => d?.length && !isEmpty(d[0]) ? config.boost_useWorker : false;
+		const useWorker = d => {
+			if (!d?.length || isEmpty(d[0])) {
+				return false;
+			}
+
+			// "auto": offloading small payloads costs more in structured cloning than
+			// it saves, so only hand over datasets past the threshold
+			return config.boost_useWorker === "auto" ?
+				_getCellCount(d) >= WORKER_CELL_THRESHOLD :
+				!!config.boost_useWorker;
+		};
+		const workerOptions = config.boost_workerUrl ?
+			{
+				workerUrl: config.boost_workerUrl
+			} :
+			undefined;
 		let data = args;
 
 		if (args.bindto) {
@@ -121,14 +169,16 @@ export default {
 			url(data.url, data.mimeType, data.headers, _getDataKeyForJson(data.keys, config),
 				callback);
 		} else if (data.json) {
-			runWorker(useWorker(data.json), json, callback, [columns, rows])(
+			runWorker(useWorker(data.json), "json", json, callback, workerOptions)(
 				data.json,
 				_getDataKeyForJson(data.keys, config)
 			);
 		} else if (data.rows) {
-			runWorker(useWorker(data.rows), rows, callback)(data.rows);
+			runWorker(useWorker(data.rows), "rows", rows, callback, workerOptions)(data.rows);
 		} else if (data.columns) {
-			runWorker(useWorker(data.columns), columns, callback)(data.columns);
+			runWorker(useWorker(data.columns), "columns", columns, callback, workerOptions)(
+				data.columns
+			);
 		} else if (args.bindto) {
 			throw Error("url or json or rows or columns is required.");
 		}

--- a/src/ChartInternal/internals/color.ts
+++ b/src/ChartInternal/internals/color.ts
@@ -2,7 +2,6 @@
  * Copyright (c) 2017 ~ present NAVER Corp.
  * billboard.js project is licensed under the MIT license
  */
-import {scaleOrdinal as d3ScaleOrdinal} from "d3-scale";
 import {select as d3Select} from "d3-selection";
 import {d3Selection} from "../../../types";
 import {$ARC, $COLOR, $SHAPE} from "../../config/classes";
@@ -93,9 +92,10 @@ export default {
 		const hasGradient = config.area_linearGradient || config.bar_linearGradient ||
 			config.point_radialGradient;
 
+		// was `d3ScaleOrdinal(colors).range()`, which only ever copied the array
 		let pattern = notEmpty(config.color_pattern) ?
 			config.color_pattern :
-			d3ScaleOrdinal(_getColorFromCss($el.chart) || schemeCategory10).range();
+			[...(_getColorFromCss($el.chart) || schemeCategory10)];
 
 		const originalColorPattern = pattern;
 

--- a/src/ChartInternal/internals/domain.ts
+++ b/src/ChartInternal/internals/domain.ts
@@ -115,8 +115,11 @@ function getTargetValueMinMax($$, targets: IData[]): DomainMinMax {
 
 	for (let i = 0; i < targets.length; i++) {
 		const target = targets[i];
-		const isCandlestick = $$.isCandlestickType?.(target) ||
-			$$.isSubchartSourceTypeOf?.(target, TYPE.CANDLESTICK);
+		const isCandlestick = $$.isCandlestickType?.(target);
+		// resolved per target, not per value: the projection is keyed by target id, so
+		// asking per row made every main-chart domain pass walk the subchart type chain
+		const isSubchartCandlestick = !isCandlestick &&
+			!!$$.isSubchartSourceTypeOf?.(target, TYPE.CANDLESTICK);
 		const {values} = target;
 
 		for (let j = 0; j < values.length; j++) {
@@ -127,11 +130,13 @@ function getTargetValueMinMax($$, targets: IData[]): DomainMinMax {
 				continue;
 			}
 
-			const subchartCandlestickValue = $$.getSubchartCandlestickShapeValue?.(row, true);
+			const subchartCandlestickValue = isSubchartCandlestick ?
+				$$.getSubchartCandlestickShapeValue?.(row, true) :
+				undefined;
 
 			if (isNumber(subchartCandlestickValue)) {
 				value = subchartCandlestickValue;
-			} else if (value !== null && isCandlestick) {
+			} else if (value !== null && (isCandlestick || isSubchartCandlestick)) {
 				value = Array.isArray(value) ?
 					value.slice(0, 4) :
 					[value.open, value.high, value.low, value.close];

--- a/src/ChartInternal/internals/text.ts
+++ b/src/ChartInternal/internals/text.ts
@@ -600,20 +600,33 @@ export default {
 		// Calculates the length of the hypotenuse
 		const calcHypo = (x, y) => Math.sqrt(x * x + y * y);
 
-		textNode.node() && filteredTextNodes.each(function() {
+		if (!textNode.node()) {
+			return;
+		}
+
+		const fontSize = parseInt(textNode.style("font-size"), 10);
+		const overlapStates: {node: Element, overlaps: boolean}[] = [];
+
+		filteredTextNodes.each(function() {
 			const coordinate = getTranslation(this);
-			const filteredTextNode = d3Select(this);
 			const nodeForWidth =
 				calcHypo(translate.e, translate.f) > calcHypo(coordinate.e, coordinate.f) ?
 					textNode :
-					filteredTextNode;
+					d3Select(this);
 
 			const overlapsX = Math.ceil(Math.abs(translate.e - coordinate.e)) <
 				Math.ceil(nodeForWidth.node().getComputedTextLength());
 			const overlapsY = Math.ceil(Math.abs(translate.f - coordinate.f)) <
-				parseInt(textNode.style("font-size"), 10);
+				fontSize;
 
-			filteredTextNode.classed($TEXT.TextOverlapping, overlapsX && overlapsY);
+			overlapStates.push({
+				node: this,
+				overlaps: overlapsX && overlapsY
+			});
+		});
+
+		overlapStates.forEach(({node, overlaps}) => {
+			d3Select(node).classed($TEXT.TextOverlapping, overlaps);
 		});
 	},
 

--- a/src/ChartInternal/shape/core/path.ts
+++ b/src/ChartInternal/shape/core/path.ts
@@ -8,17 +8,25 @@ type PathContext = CanvasRenderingContext2D | null | undefined;
 type PathResult = string | void;
 
 /**
- * Get path y value with subchart candlestick projection.
+ * Build the path y value accessor, with subchart candlestick projection.
  * @param {object} $$ ChartInternal instance
- * @param {object} d Data row
  * @param {boolean} isSub Whether to use subchart scales
- * @returns {number|Array|null|undefined} Path y value
+ * @returns {function} Accessor returning the path y value
  * @private
  */
-function getPathValue($$, d, isSub?: boolean) {
-	const value = $$.getSubchartCandlestickShapeValue?.(d, isSub);
+function getPathValueFn($$, isSub?: boolean): (d) => any {
+	// resolved once per generator rather than per data point: the candlestick
+	// projection only exists for the subchart, so the main chart keeps the plain
+	// `getBaseValue` accessor it used before subchart types were configurable
+	if (!isSub) {
+		return d => $$.getBaseValue(d);
+	}
 
-	return value === undefined ? $$.getBaseValue(d) : value;
+	return d => {
+		const value = $$.getSubchartCandlestickShapeValue?.(d, true);
+
+		return value === undefined ? $$.getBaseValue(d) : value;
+	};
 }
 
 /**
@@ -30,6 +38,12 @@ function getPathValue($$, d, isSub?: boolean) {
  * @private
  */
 function getProjectedValues($$, values, isSub?: boolean): any[] {
+	// the main chart has nothing to project, and this sits in the area redraw path:
+	// mapping there would clone the whole value array on every render
+	if (!isSub) {
+		return values;
+	}
+
 	return values.map(d => {
 		const value = $$.getSubchartCandlestickShapeValue?.(d, isSub);
 
@@ -70,11 +84,12 @@ export function generateDrawLinePath(
 
 	const getPoints = $$.generateGetLinePoints(lineIndices, isSub);
 	const yScale = $$.getYScaleById.bind($$);
+	const pathValue = getPathValueFn($$, isSub);
 
 	const xValue = d => (isSub ? $$.subxx : $$.xx).call($$, d);
 	const yValue = (d, i) => (
 		$$.isGrouped(d.id) ? getPoints(d, i)[0][1] : yScale(d.id, isSub)(
-			getPathValue($$, d, isSub)
+			pathValue(d)
 		)
 	);
 
@@ -84,7 +99,7 @@ export function generateDrawLinePath(
 	context && (line = line.context(context));
 
 	if (!lineConnectNull) {
-		line = line.defined(d => getPathValue($$, d, isSub) !== null);
+		line = line.defined(d => pathValue(d) !== null);
 	}
 
 	const x = isSub ? scale.subX : scale.x;
@@ -118,7 +133,7 @@ export function generateDrawLinePath(
 		} else {
 			if (values[0]) {
 				x0 = x(values[0].x);
-				y0 = y(getPathValue($$, values[0], isSub));
+				y0 = y(pathValue(values[0]));
 			}
 
 			path = isRotated ? `M ${y0} ${x0}` : `M ${x0} ${y0}`;
@@ -149,13 +164,29 @@ export function generateDrawAreaPath(
 
 	const getPoints = $$.generateGetAreaPoints(areaIndices, isSub);
 	const yScale = $$.getYScaleById.bind($$);
+	const pathValue = getPathValueFn($$, isSub);
+
+	// `getShapeYMin()` resolves a scale and slices its domain, but only depends on
+	// the target id — memoized here so the area baseline costs one lookup per
+	// series rather than one per data point
+	const shapeYMin = new Map<string, number>();
+	const getShapeYMin = (id: string): number => {
+		let min = shapeYMin.get(id);
+
+		if (min === undefined) {
+			min = $$.getShapeYMin(id, isSub) as number;
+			shapeYMin.set(id, min);
+		}
+
+		return min;
+	};
 
 	const xValue = d => (isSub ? $$.subxx : $$.xx).call($$, d);
 	const value0 = (d, i) => ($$.isGrouped(d.id) ? getPoints(d, i)[0][1] : yScale(d.id, isSub)(
-		$$.isAreaRangeType(d) ? $$.getRangedData(d, "high") : $$.getShapeYMin(d.id, isSub)
+		$$.isAreaRangeType(d) ? $$.getRangedData(d, "high") : getShapeYMin(d.id)
 	));
 	const value1 = (d, i) => ($$.isGrouped(d.id) ? getPoints(d, i)[1][1] : yScale(d.id, isSub)(
-		$$.isAreaRangeType(d) ? $$.getRangedData(d, "low") : getPathValue($$, d, isSub)
+		$$.isAreaRangeType(d) ? $$.getRangedData(d, "low") : pathValue(d)
 	));
 
 	return d => {
@@ -179,7 +210,7 @@ export function generateDrawAreaPath(
 			context && (area = area.context(context));
 
 			if (!lineConnectNull) {
-				area = area.defined(d => getPathValue($$, d, isSub) !== null);
+				area = area.defined(d => pathValue(d) !== null);
 			}
 
 			values = getProjectedValues($$, values, isSub);
@@ -192,7 +223,7 @@ export function generateDrawAreaPath(
 		} else {
 			if (values[0]) {
 				x0 = (isSub ? $$.scale.subX : $$.scale.x)(values[0].x);
-				y0 = $$.getYScaleById(d.id, isSub)(getPathValue($$, values[0], isSub));
+				y0 = $$.getYScaleById(d.id, isSub)(pathValue(values[0]));
 			}
 
 			path = isRotated ? `M ${y0} ${x0}` : `M ${x0} ${y0}`;

--- a/src/ChartInternal/shape/funnel.ts
+++ b/src/ChartInternal/shape/funnel.ts
@@ -3,8 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 import {select as d3Select} from "d3-selection";
-import {line as d3Line} from "d3-shape";
-import {curveLinear as d3CurveLinear} from "d3-shape";
+import {curveLinear as d3CurveLinear, line as d3Line} from "d3-shape";
 import {$COMMON, $FUNNEL} from "../../config/classes";
 import {isObject} from "../../module/util";
 import type {IData, IDataRow, IFunnelData} from "../data/IData";

--- a/src/ChartInternal/shape/shape.ts
+++ b/src/ChartInternal/shape/shape.ts
@@ -103,7 +103,10 @@ function getLinePointGroupTypeFilter($$): Function {
  * @private
  */
 function getShapeOffsetValue($$, d, isSub?: boolean) {
-	const subchartCandlestickValue = getSubchartCandlestickShapeValue($$, d, isSub);
+	// per data point: only the subchart can carry a projected value
+	const subchartCandlestickValue = isSub ?
+		getSubchartCandlestickShapeValue($$, d, isSub) :
+		undefined;
 
 	if (isNumber(subchartCandlestickValue)) {
 		return subchartCandlestickValue;
@@ -532,7 +535,9 @@ export default {
 
 		return d => {
 			let {value} = d;
-			const subchartCandlestickValue = getSubchartCandlestickShapeValue($$, d, isSub);
+			const subchartCandlestickValue = isSub ?
+				getSubchartCandlestickShapeValue($$, d, isSub) :
+				undefined;
 
 			if (isNumber(d)) {
 				value = d;
@@ -742,8 +747,18 @@ export default {
 		const lineOffset = $$.getShapeOffset(typeFilter || $$.isLineType, lineIndices, isSub);
 		const yScale = $$.getYScaleById.bind($$);
 
+		// per-series cache: y0 depends only on the id and is stable within one draw pass,
+		// as in generateGetAreaPoints()
+		const y0Cache = new Map<string, number>();
+
 		return (d, i) => {
-			const y0 = yScale.call($$, d.id, isSub)($$.getShapeYMin(d.id, isSub));
+			let y0 = y0Cache.get(d.id);
+
+			if (y0 === undefined) {
+				y0 = yScale.call($$, d.id, isSub)($$.getShapeYMin(d.id, isSub)) as number;
+				y0Cache.set(d.id, y0);
+			}
+
 			const offset = lineOffset(d, i) || y0;
 			const posX = x(d);
 			let posY = y(d);

--- a/src/Plugin/stanford/index.ts
+++ b/src/Plugin/stanford/index.ts
@@ -48,15 +48,11 @@ function hsl(h: number, s: number, l: number, opacity: number = 1): HSLColor {
  * - **Required modules:**
  *   - [d3-selection](https://github.com/d3/d3-selection)
  *   - [d3-interpolate](https://github.com/d3/d3-interpolate)
- *   - [d3-scale](https://github.com/d3/d3-scale)
  *   - [d3-brush](https://github.com/d3/d3-brush)
- *   - [d3-axis](https://github.com/d3/d3-axis)
  * @class plugin-stanford
  * @requires d3-selection
  * @requires d3-interpolate
- * @requires d3-scale
  * @requires d3-brush
- * @requires d3-axis
  * @param {object} options Stanford plugin options
  * @augments Plugin
  * @returns {Stanford}

--- a/src/Plugin/textoverlap/index.ts
+++ b/src/Plugin/textoverlap/index.ts
@@ -4,34 +4,17 @@
  */
 import type {d3Selection} from "../../../types/types";
 import {polygonArea, polygonCentroid} from "../../module/polygon";
+import {voronoiCells} from "../../module/voronoi";
 import Plugin from "../Plugin";
 import Options from "./Options";
-
-let d3Delaunay: Promise<typeof import("d3-delaunay").Delaunay> | null = null;
-
-/**
- * Load d3-delaunay only when the plugin actually needs Voronoi layout.
- * @returns {Promise} Delaunay constructor
- * @private
- */
-function getDelaunay() {
-	return d3Delaunay ?? (
-		d3Delaunay = import("d3-delaunay")
-			.then(({Delaunay}) => Delaunay)
-	);
-}
 
 /**
  * TextOverlap plugin<br>
  * Prevents label overlap using [Voronoi layout](https://en.wikipedia.org/wiki/Voronoi_diagram).
  * - **NOTE:**
  *   - Plugins aren't built-in. Need to be loaded or imported to be used.
- *   - Non required modules from billboard.js core, need to be installed separately.
  *   - Appropriate and works for axis based chart.
- * - **Required modules:**
- *   - [d3-delaunay](https://github.com/d3/d3-delaunay)
  * @class plugin-textoverlap
- * @requires d3-delaunay
  * @param {object} options TextOverlap plugin options
  * @augments Plugin
  * @returns {TextOverlap}
@@ -63,8 +46,6 @@ function getDelaunay() {
  * })
  */
 export default class TextOverlap extends Plugin {
-	private redrawId = 0;
-
 	constructor(options?: Options) {
 		super(options);
 		this.config = new Options();
@@ -79,53 +60,42 @@ export default class TextOverlap extends Plugin {
 	$redraw(): void {
 		const {$$: {$el}, config: {selector}} = this;
 		const text = selector ? $el.main.selectAll(selector) : $el.text;
-		const redrawId = ++this.redrawId;
 
 		if (!text.empty()) {
-			void this.preventLabelOverlap(text, redrawId);
+			this.preventLabelOverlap(text);
 		}
 	}
 
 	/**
 	 * Generates the voronoi layout for data labels
 	 * @param {Array} points Indices values
-	 * @returns {object} Voronoi layout points and corresponding Data points
+	 * @returns {Array} Voronoi cell polygons, in point order
 	 * @private
 	 */
-	async generateVoronoi(points: [number, number][]) {
+	generateVoronoi(points: [number, number][]) {
 		const {$$} = this;
 		const {scale} = $$;
 		const [min, max] = ["x", "y"].map(v => scale[v].domain());
-		const Delaunay = await getDelaunay();
 
 		[min[1], max[0]] = [max[0], min[1]];
 
-		return Delaunay
-			.from(points)
-			.voronoi([
-				...min as [number, number],
-				...max as [number, number]
-			]); // bounds = [xmin, ymin, xmax, ymax], default value: [0, 0, 960, 500]
+		// bounds = [xmin, ymin, xmax, ymax]
+		return voronoiCells(points, [...min, ...max]);
 	}
 
 	/**
 	 * Set text label's position to preventg overlap.
 	 * @param {d3Selection} text target text selection
-	 * @param {number} redrawId Redraw request identifier
 	 * @private
 	 */
-	async preventLabelOverlap(text: d3Selection, redrawId = this.redrawId): Promise<void> {
+	preventLabelOverlap(text: d3Selection): void {
 		const {extent, area} = this.config;
 		const points = text.data().map(v => [v.index, v.value]) as [number, number][];
-		const voronoi = await this.generateVoronoi(points).catch(() => null);
+		const cells = this.generateVoronoi(points);
 		let i = 0;
 
-		if (!voronoi || redrawId !== this.redrawId) {
-			return;
-		}
-
 		text.each(function() {
-			const cell = voronoi.cellPolygon(i);
+			const cell = cells[i];
 
 			if (cell && this) {
 				const [x, y] = points[i];

--- a/src/config/Options/common/boost.ts
+++ b/src/config/Options/common/boost.ts
@@ -16,18 +16,77 @@ export default {
 	 * - **NOTE:**
 	 *   - Will append &lt;style> to the head tag and will add shpes' CSS rules dynamically.
 	 *   - For now, covers colors related properties (fill, stroke, etc.) only.
-	 * @property {boolean} [boost.useWorker=false] Use Web Worker as possible for processing.
+	 * @property {boolean|string} [boost.useWorker=false] Use Web Worker as possible for processing.
+	 * - **Available values:**
+	 *   - `false`: never offload.
+	 *   - `true`: always offload when a Worker can be created.
+	 *   - `"auto"`: offload only when the given data exceeds ~5,000 cells, since smaller
+	 *     payloads lose more to structured cloning than they gain.
 	 * - **NOTE:**
 	 *   - For now, only applies for data conversion at the initial time.
 	 *   - As of Web Worker's async nature, handling chart instance synchronously is not recommended.
 	 *   - When Worker isn't available, fails or times out, data conversion falls back to main thread.
 	 *   - When given data is empty, useWorker will be ignored.
+	 * @property {string} [boost.workerUrl=undefined] Use a custom static worker script URL instead of an inline Blob worker.
+	 * - **NOTE:**
+	 *   - **Requires `boost.useWorker` to be enabled** — this option only selects where the
+	 *     worker source comes from, it does not turn offloading on by itself.
+	 *   - Useful for strict CSP environments that disallow `blob:` workers. Without it under
+	 *     such a policy, worker creation throws and each conversion waits out the 5s timeout
+	 *     before falling back, so the chart still renders but the initial draw is delayed.
+	 *   - Point it at `dist/billboard.worker.js`, shipped in the package, or any script
+	 *     implementing the same protocol: receive `{id, op, args}` and post back
+	 *     `{id, result}` or `{id, error}`. No `eval()` is involved.
+	 *   - With a bundler, make sure the file is emitted as a **real asset**, not inlined:
+	 *     it is ~1.5KB, and inlining turns it into a `data:` URI, which a strict CSP
+	 *     blocks exactly like `blob:`. Copying it into the static/public directory is the
+	 *     option that works everywhere.
+	 *   - Any failure (load error, unknown op, timeout, result mismatch) falls back to the main thread.
 	 * @example
+	 * // offload data conversion on a Worker, using the inline Blob worker
 	 *  boost: {
 	 *      useCssRule: true,
-	 *      useWorker: false
+	 *      useWorker: true
 	 *  }
+	 * @example
+	 * // offload only past ~5,000 cells
+	 *  boost: {
+	 *      useWorker: "auto"
+	 *  }
+	 * @example
+	 * // strict CSP: serve the shipped script and point at it.
+	 * // 'useWorker' still has to be on - 'workerUrl' alone offloads nothing.
+	 *  boost: {
+	 *      useWorker: true,
+	 *      workerUrl: "$YOUR_PATH/dist/billboard.worker.js"
+	 *  }
+	 * @example
+	 * // ESM: the file is reachable as a package subpath.
+	 * // Vite - '?url' resolves it, but assets under 4KB are inlined as a 'data:' URI,
+	 * // which a strict CSP rejects. Opt that one file out of inlining:
+	 * //
+	 * //   // vite.config.js
+	 * //   export default {
+	 * //     build: {
+	 * //       assetsInlineLimit: path => /billboard\.worker\.js$/.test(path) ? false : undefined
+	 * //     }
+	 * //   };
+	 * import bb, {bar} from "billboard.js";
+	 * import workerUrl from "billboard.js/dist/billboard.worker.js?url";
+	 *
+	 * bb.generate({
+	 *     boost: {useWorker: true, workerUrl},
+	 *     data: {columns: [["data1", 30, 200, 100]], type: bar()}
+	 * });
+	 * @example
+	 * // ESM, bundler-agnostic: copy the file into the served static directory
+	 * //   cp node_modules/billboard.js/dist/billboard.worker.js public/
+	 * bb.generate({
+	 *     boost: {useWorker: true, workerUrl: "/billboard.worker.js"},
+	 *     data: {columns: [["data1", 30, 200, 100]]}
+	 * });
 	 */
 	boost_useCssRule: false,
-	boost_useWorker: false
+	boost_useWorker: false,
+	boost_workerUrl: undefined
 };

--- a/src/config/Options/shape/treemap.ts
+++ b/src/config/Options/shape/treemap.ts
@@ -18,7 +18,7 @@ export default {
 	 * 	- dice ([d3.treemapDice](https://github.com/d3/d3-hierarchy/blob/main/README.md#treemapDice))
 	 * 	- slice ([d3.treemapSlice](https://github.com/d3/d3-hierarchy/blob/main/README.md#treemapSlice))
 	 * 	- sliceDice ([d3.treemapSliceDice](https://github.com/d3/d3-hierarchy/blob/main/README.md#treemapSliceDice))
-	 * 	- squrify ([d3.treemapSquarify](https://github.com/d3/d3-hierarchy/blob/main/README.md#treemapSquarify))
+	 * 	- squarify ([d3.treemapSquarify](https://github.com/d3/d3-hierarchy/blob/main/README.md#treemapSquarify))
 	 * 	- resquarify ([d3.treemapResquarify](https://github.com/d3/d3-hierarchy/blob/main/README.md#treemapResquarify))
 	 * @property {function} [treemap.label.format] Set formatter for the label text.<br>
 	 * - **Arguments:**
@@ -31,7 +31,7 @@ export default {
 	 * @see [Demo: treemap](https://naver.github.io/billboard.js/demo/#Chart.TreemapChart)
 	 * @example
 	 *  treemap: {
-	 *      // "binary", "dice", "slice", "sliceDice", "squrify", "resquarify"
+	 *      // "binary", "dice", "slice", "sliceDice", "squarify", "resquarify"
 	 *      tile: "dice",
 	 *
 	 *      label: {

--- a/src/module/voronoi.ts
+++ b/src/module/voronoi.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ *
+ * Bounded Voronoi cells, computed directly by half-plane clipping instead of
+ * going through a Delaunay triangulation.
+ *
+ * A cell is the set of points closer to its site than to any other site, which
+ * is exactly the intersection of the half-planes bounded by the perpendicular
+ * bisectors between that site and every other one. Starting from the clip
+ * rectangle and clipping it against each bisector (Sutherland-Hodgman) yields
+ * the same polygons d3-delaunay's `voronoi().cellPolygon()` returns, without
+ * the triangulation payload.
+ *
+ * The trade-off is O(n²) rather than O(n log n). That is the right trade for
+ * the label-placement use case, which runs on tens to hundreds of points.
+ *
+ * Parity with d3-delaunay is asserted by test/module/voronoi-parity-spec.ts.
+ */
+type Point = [number, number];
+
+// distance below which two sites are treated as coincident
+const EPSILON = 1e-9;
+
+/**
+ * Clip a convex polygon by the half-plane of points at least as close to `a` as
+ * to `b`, i.e. the side of the perpendicular bisector of `ab` that contains `a`.
+ * @param {Array} polygon Convex polygon as an open ring of [x, y]
+ * @param {Array} a Site kept by the half-plane
+ * @param {Array} b Opposing site
+ * @returns {Array} Clipped polygon, empty when fully outside
+ * @private
+ */
+function clipByBisector(polygon: Point[], a: Point, b: Point): Point[] {
+	const dx = b[0] - a[0];
+	const dy = b[1] - a[1];
+
+	// bisector as dx*x + dy*y = c, keeping the side where the expression is below c
+	const c = (dx * (a[0] + b[0]) + dy * (a[1] + b[1])) / 2;
+	const output: Point[] = [];
+	const n = polygon.length;
+
+	let prev = polygon[n - 1];
+	let prevDist = dx * prev[0] + dy * prev[1] - c;
+
+	for (let i = 0; i < n; i++) {
+		const curr = polygon[i];
+		const currDist = dx * curr[0] + dy * curr[1] - c;
+
+		// the edge straddles the bisector: emit the crossing point
+		if ((prevDist > 0) !== (currDist > 0)) {
+			const t = prevDist / (prevDist - currDist);
+
+			output.push([
+				prev[0] + t * (curr[0] - prev[0]),
+				prev[1] + t * (curr[1] - prev[1])
+			]);
+		}
+
+		if (currDist <= 0) {
+			output.push(curr);
+		}
+
+		prev = curr;
+		prevDist = currDist;
+	}
+
+	return output;
+}
+
+/**
+ * Compute bounded Voronoi cells for the given sites.
+ *
+ * Cells are returned in site order, closed (first vertex repeated last) as
+ * d3-delaunay does. A site yields `null` when it has no cell: it lies outside
+ * the bounds, or it coincides with an earlier site.
+ * @param {Array} points Sites as [x, y]
+ * @param {Array} bounds Clip extent as [xmin, ymin, xmax, ymax]
+ * @returns {Array} Cell polygons in site order
+ * @private
+ */
+export function voronoiCells(points: Point[], bounds: number[]): (Point[] | null)[] {
+	const [x0, y0, x1, y1] = [
+		Math.min(bounds[0], bounds[2]),
+		Math.min(bounds[1], bounds[3]),
+		Math.max(bounds[0], bounds[2]),
+		Math.max(bounds[1], bounds[3])
+	];
+	const rect: Point[] = [[x0, y0], [x1, y0], [x1, y1], [x0, y1]];
+	const n = points.length;
+
+	return points.map((site, i) => {
+		let cell = rect;
+
+		for (let j = 0; j < n && cell.length > 2; j++) {
+			if (j === i) {
+				continue;
+			}
+
+			const other = points[j];
+
+			if (
+				Math.abs(other[0] - site[0]) < EPSILON &&
+				Math.abs(other[1] - site[1]) < EPSILON
+			) {
+				// coincident sites: the first one keeps the cell, as in d3-delaunay
+				if (j < i) {
+					return null;
+				}
+
+				continue;
+			}
+
+			cell = clipByBisector(cell, site, other);
+		}
+
+		return cell.length > 2 ? [...cell, cell[0]] as Point[] : null;
+	});
+}

--- a/src/module/worker.entry.ts
+++ b/src/module/worker.entry.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+import {columns, json, rows} from "../ChartInternal/data/convert.helper";
+
+/**
+ * Worker entry point.
+ *
+ * This module is bundled separately at build time and injected into
+ * `src/module/worker.ts` as the `__WORKER_SRC__` string constant. It is never
+ * part of the main bundle graph.
+ *
+ * Offloaded work is addressed by op name, so no function source is ever
+ * stringified or evaluated. That keeps the worker immune to whatever transform
+ * the host toolchain applies to billboard.js sources - coverage instrumentation,
+ * babel helpers or bundler-hoisted module scope references cannot leak in.
+ */
+export const ops = {
+	columns,
+	json,
+	rows
+};
+
+type TWorkerRequest = {args: unknown[], id: number, op: keyof typeof ops};
+
+const ctx = self as unknown as {
+	onmessage: ((e: {data: TWorkerRequest}) => void) | null,
+	postMessage: (message: unknown) => void
+};
+
+/**
+ * Run the requested op and post the result back, keyed by the request id.
+ * @param {object} e Message event carrying the op name and arguments
+ * @param {object} e.data Request payload: `{args, id, op}`
+ * @private
+ */
+export function handleMessage({data}: {data: TWorkerRequest}): void {
+	const {args, id, op} = data;
+
+	try {
+		const fn = ops[op];
+
+		if (!fn) {
+			throw new Error(`Unknown worker op: ${op}`);
+		}
+
+		ctx.postMessage({id, result: (fn as Function)(...args)});
+	} catch (error) {
+		ctx.postMessage({
+			id,
+			error: error && ((error as Error).message || (error as Error).name) || String(error)
+		});
+	}
+}
+
+// A dedicated worker has no `window`. The guard keeps this module importable from
+// specs (see test/module/worker-real-spec.ts) without hijacking window.onmessage.
+if (typeof window === "undefined") {
+	ctx.onmessage = handleMessage;
+}

--- a/src/module/worker.ts
+++ b/src/module/worker.ts
@@ -4,13 +4,44 @@
  */
 import {window} from "./browser";
 
+/**
+ * The worker source constant (declared in config/globals.d.ts) is pre-bundled from
+ * `src/module/worker.entry.ts` and injected at build time by config/worker-src.js.
+ * Never name that constant outside the single reference in getWorkerSrc(): the
+ * rolldown injection is textual, so a mention in a comment would inline the whole
+ * source string a second time.
+ *
+ * Offloaded work is addressed by op name and the worker code is built
+ * independently of the application bundle, so no application function is ever
+ * stringified. Host toolchains that rewrite function bodies - coverage
+ * instrumentation, babel helpers, bundler-hoisted module scope - cannot break
+ * the worker anymore.
+ */
 // Store worker cache in memory
-const cache: {[key: string]: {src: string, worker: Worker | null}} = {};
+const cache: {[key: string]: {revoke: boolean, src: string, worker: Worker | null}} = {};
 const disabledKeys = new Set<string>();
+const verifiedKeys = new Set<string>();
 const DEFAULT_WORKER_TIMEOUT = 5000;
 
 // Correlation id for worker request/response matching
 let messageId = 0;
+
+type TWorkerOptions = {timeout?: number, workerUrl?: string};
+
+/**
+ * Get the build-injected worker source.
+ * @returns {string} Worker source, or empty string when it wasn't injected
+ * @private
+ */
+function getWorkerSrc(): string {
+	try {
+		// referenced exactly once: each occurrence inlines the whole source string
+		return __WORKER_SRC__;
+	} catch {
+		// not injected (e.g. consuming src/*.ts directly) - stay on the main thread
+		return "";
+	}
+}
 
 /**
  * Get Web Worker related browser APIs when all required primitives are available.
@@ -28,20 +59,25 @@ function getWorkerAPI():
 }
 
 /**
- * Generate a stable cache key from the worker source.
- * @param {string} str Worker source string
- * @returns {string} Cache key
+ * Get Worker constructor when available.
+ * @returns {function|null} Worker constructor
  * @private
  */
-function hashString(str: string): string {
-	let hash = 2166136261;
+function getWorkerConstructor(): typeof Worker | null {
+	return window.Worker || null;
+}
 
-	for (let i = 0, len = str.length; i < len; i++) {
-		hash ^= str.charCodeAt(i);
-		hash = Math.imul(hash, 16777619);
-	}
-
-	return `worker-${str.length}-${(hash >>> 0).toString(36)}`;
+/**
+ * Normalize worker options while preserving the legacy numeric timeout argument.
+ * @param {number|object} options Worker timeout or options
+ * @returns {object} Normalized worker options
+ * @private
+ */
+function normalizeWorkerOptions(options?: number | TWorkerOptions): Required<TWorkerOptions> {
+	return typeof options === "number" ? {timeout: options, workerUrl: ""} : {
+		timeout: options?.timeout ?? DEFAULT_WORKER_TIMEOUT,
+		workerUrl: options?.workerUrl ?? ""
+	};
 }
 
 /**
@@ -52,7 +88,6 @@ function hashString(str: string): string {
  */
 function releaseWorker(key: string, disable = false): void {
 	const cached = cache[key];
-	const api = getWorkerAPI();
 
 	if (disable) {
 		disabledKeys.add(key);
@@ -60,56 +95,80 @@ function releaseWorker(key: string, disable = false): void {
 
 	if (cached) {
 		cached.worker?.terminate();
-		cached.src && api?.URL.revokeObjectURL(cached.src);
+		cached.revoke && getWorkerAPI()?.URL.revokeObjectURL(cached.src);
 		delete cache[key];
+	}
+
+	// entries are stored per op as `${key}:${op}`, so a bare key never matches:
+	// drop every op verified against the worker being released
+	for (const verified of verifiedKeys) {
+		if (verified.startsWith(`${key}:`)) {
+			verifiedKeys.delete(verified);
+		}
+	}
+}
+
+/**
+ * Compare worker and main-thread results for the parity self-test.
+ * @param {unknown} actual Worker result
+ * @param {unknown} expected Main-thread result
+ * @returns {boolean} Whether results match
+ * @private
+ */
+function isSameResult(actual, expected): boolean {
+	if (actual === expected) {
+		return true;
+	}
+
+	try {
+		return JSON.stringify(actual) === JSON.stringify(expected);
+	} catch {
+		// Structured-cloned worker results should normally be serializable. If a custom
+		// worker returns an exotic value, don't disable the worker on an unverifiable result.
+		return true;
 	}
 }
 
 /**
  * Get or create cached worker resources (Object URL, Worker)
- * @param {function} fn Function to be executed in worker
- * @param {Array} depsFn Dependency functions to run given function(fn).
+ * @param {string} op Worker op name
+ * @param {string} workerUrl Custom worker script URL.
  * @returns {{key: string, src: string}} Cache key and Object URL
  * @private
  */
-function getOrCreateWorkerResources(fn: Function, depsFn?: Function[]):
+function getOrCreateWorkerResources(op: string, workerUrl = ""):
 	| {key: string, src: string}
 	| null {
-	const api = getWorkerAPI();
-	const fnString = fn.toString();
-	// Include depsFn in cache key to handle different dependencies
-	const depsString = depsFn?.map(String).join(";") ?? "";
-	const key = hashString(`${fnString}\n${depsString}`);
+	const hasWorker = !!getWorkerConstructor();
+	const api = workerUrl ? null : getWorkerAPI();
+	const src = workerUrl ? "" : getWorkerSrc();
+	// one worker per source: ops share a single cached worker per script
+	const key = workerUrl || "blob";
 
-	if (!api || disabledKeys.has(key)) {
+	if (!hasWorker || (!workerUrl && (!api || !src)) || disabledKeys.has(key)) {
 		return null;
 	}
 
 	if (!(key in cache)) {
 		try {
-			// Create Blob and Object URL for Web Worker
-			const blob = new api.Blob([
-				`${depsString}
+			if (workerUrl) {
+				cache[key] = {
+					revoke: false,
+					src: workerUrl,
+					worker: null
+				};
+			} else if (api) {
+				// Create Blob and Object URL for Web Worker
+				const blob = new api.Blob([src], {
+					type: "text/javascript"
+				});
 
-				self.onmessage=function({data}) {
-					try {
-						const result = (${fnString}).apply(null, data.args);
-						self.postMessage({id: data.id, result});
-					} catch (error) {
-						self.postMessage({
-							id: data.id,
-							error: error && (error.message || error.name) || String(error)
-						});
-					}
-				};`
-			], {
-				type: "text/javascript"
-			});
-
-			cache[key] = {
-				src: api.URL.createObjectURL(blob),
-				worker: null
-			};
+				cache[key] = {
+					revoke: true,
+					src: api.URL.createObjectURL(blob),
+					worker: null
+				};
+			}
 		} catch {
 			return null;
 		}
@@ -127,16 +186,16 @@ function getOrCreateWorkerResources(fn: Function, depsFn?: Function[]):
  */
 export function getWorker(key: string, src: string): Worker | null {
 	const cached = cache[key];
-	const api = getWorkerAPI();
+	const Worker = getWorkerConstructor();
 
 	// Return null if cache entry doesn't exist
-	if (!cached || !api || disabledKeys.has(key)) {
+	if (!cached || !Worker || disabledKeys.has(key)) {
 		return null;
 	}
 
 	if (!cached.worker) {
 		try {
-			cached.worker = new api.Worker(src);
+			cached.worker = new Worker(src);
 		} catch {
 			releaseWorker(key, true);
 			return null;
@@ -149,34 +208,28 @@ export function getWorker(key: string, src: string): Worker | null {
 /**
  * Create and run on Web Worker
  * @param {boolean} useWorker Use Web Worker
- * @param {function} fn Function to be executed in worker
+ * @param {string} op Op name registered in src/module/worker.entry.ts
+ * @param {function} fn Equivalent main-thread function, used for fallback and parity check
  * @param {function} callback Callback function to receive result from worker
- * @param {Array} depsFn Dependency functions to run given function(fn).
- * @param {number} timeout Worker response timeout in milliseconds.
+ * @param {number|object} options Worker response timeout or options.
  * @returns {function}
  * @example
- * 	const worker = runWorker(function(arg) {
- * 		  // do some tasks...
- * 		  console.log("param:", A(arg));
- *
- * 		  return 1234;
- * 	   }, function(data) {
+ * 	const worker = runWorker(true, "rows", rows, function(data) {
  * 		  // callback after worker is done
  * 	 	  console.log("result:", data);
- * 	   },
- * 	   [function A(){}]
- * 	);
+ * 	   });
  *
  * 	worker(11111);
  * @private
  */
 export function runWorker(
 	useWorker = true,
+	op: string,
 	fn: Function,
 	callback: Function,
-	depsFn?: Function[],
-	timeout = DEFAULT_WORKER_TIMEOUT
+	options?: number | TWorkerOptions
 ): Function {
+	const {timeout, workerUrl} = normalizeWorkerOptions(options);
 	const runSync = function(...args: unknown[]) {
 		const res = fn(...args);
 
@@ -185,7 +238,7 @@ export function runWorker(
 	let runFn = runSync;
 
 	if (useWorker) {
-		const workerResources = getOrCreateWorkerResources(fn, depsFn);
+		const workerResources = getOrCreateWorkerResources(op, workerUrl);
 		const worker = workerResources ? getWorker(workerResources.key, workerResources.src) : null;
 
 		if (worker && workerResources) {
@@ -216,6 +269,20 @@ export function runWorker(
 
 						settled = true;
 						cleanup();
+
+						if (!verifiedKeys.has(`${key}:${op}`)) {
+							const expected = fn(...args);
+
+							if (!isSameResult(e.data.result, expected)) {
+								releaseWorker(key, true);
+								runFn = runSync;
+								callback(expected);
+								return;
+							}
+
+							verifiedKeys.add(`${key}:${op}`);
+						}
+
 						callback(e.data.result);
 					}
 				};
@@ -235,7 +302,7 @@ export function runWorker(
 				worker.addEventListener("error", errorHandler);
 
 				try {
-					worker.postMessage({id, args});
+					worker.postMessage({args, id, op});
 				} catch {
 					fallback();
 				}
@@ -261,11 +328,12 @@ export function cleanupWorkers(): void {
 		}
 
 		if (cached.src) {
-			api?.URL.revokeObjectURL(cached.src);
+			cached.revoke && api?.URL.revokeObjectURL(cached.src);
 		}
 
 		delete cache[key];
 	}
 
 	disabledKeys.clear();
+	verifiedKeys.clear();
 }

--- a/src/module/worker.ts
+++ b/src/module/worker.ts
@@ -20,8 +20,21 @@ import {window} from "./browser";
 // Store worker cache in memory
 const cache: {[key: string]: {revoke: boolean, src: string, worker: Worker | null}} = {};
 const disabledKeys = new Set<string>();
-const verifiedKeys = new Set<string>();
+
+/**
+ * Parity self-test state, keyed as `${key}:${op}`: the in-flight check while it runs,
+ * `true` once the worker agreed with the main thread.
+ * @private
+ */
+const verifiedOps = new Map<string, true | Promise<boolean>>();
+
 const DEFAULT_WORKER_TIMEOUT = 5000;
+
+/**
+ * Number of leading entries kept when sampling arguments for the parity self-test.
+ * @private
+ */
+const VERIFY_SAMPLE_SIZE = 3;
 
 // Correlation id for worker request/response matching
 let messageId = 0;
@@ -101,9 +114,9 @@ function releaseWorker(key: string, disable = false): void {
 
 	// entries are stored per op as `${key}:${op}`, so a bare key never matches:
 	// drop every op verified against the worker being released
-	for (const verified of verifiedKeys) {
+	for (const verified of verifiedOps.keys()) {
 		if (verified.startsWith(`${key}:`)) {
-			verifiedKeys.delete(verified);
+			verifiedOps.delete(verified);
 		}
 	}
 }
@@ -127,6 +140,134 @@ function isSameResult(actual, expected): boolean {
 		// worker returns an exotic value, don't disable the worker on an unverifiable result.
 		return true;
 	}
+}
+
+/**
+ * Truncate conversion arguments to a small payload of the same shape.
+ *
+ * `args[0]` is the data array for every op: an array of series for `columns`, of rows
+ * for `rows`, of records for `json`. Keeping a few leading entries - and, where those
+ * entries are themselves arrays, a few leading cells of each - stays a valid payload
+ * for all three while costing a fixed amount regardless of the real data size.
+ * Anything that isn't an array is passed through untouched.
+ * @param {Array} args Conversion arguments
+ * @returns {Array} Sampled arguments
+ * @private
+ */
+function getVerifySample(args: unknown[]): unknown[] {
+	const [data, ...rest] = args;
+
+	if (!Array.isArray(data)) {
+		return args;
+	}
+
+	return [
+		data.slice(0, VERIFY_SAMPLE_SIZE).map(entry =>
+			// +1: a column/row entry leads with its name, which the values follow
+			Array.isArray(entry) ? entry.slice(0, VERIFY_SAMPLE_SIZE + 1) : entry
+		),
+		...rest
+	];
+}
+
+/**
+ * Post a single request to the worker and resolve with its result.
+ * @param {Worker} worker Worker instance
+ * @param {string} op Worker op name
+ * @param {Array} args Arguments to hand over
+ * @param {number} timeout Response timeout in milliseconds
+ * @returns {Promise} Worker result
+ * @private
+ */
+function request(worker: Worker, op: string, args: unknown[], timeout: number): Promise<unknown> {
+	// workers are cached and shared: match the response by id so concurrent callers
+	// don't steal each other's result
+	const id = ++messageId;
+	let settled = false;
+	let cleanup: () => void;
+
+	const promise = new Promise((resolve, reject) => {
+		const settle = (fn: Function, value: unknown) => {
+			if (!settled) {
+				settled = true;
+				cleanup();
+				fn(value);
+			}
+		};
+		const handler = function(e: MessageEvent) {
+			if (e.data?.id === id) {
+				e.data.error ?
+					settle(reject, new Error(e.data.error)) :
+					settle(resolve, e.data.result);
+			}
+		};
+		const errorHandler = function() {
+			settle(reject, new Error("worker error"));
+		};
+		const timer = setTimeout(() => settle(reject, new Error("worker timeout")), timeout);
+
+		cleanup = () => {
+			clearTimeout(timer);
+			worker.removeEventListener("message", handler);
+			worker.removeEventListener("error", errorHandler);
+		};
+
+		worker.addEventListener("message", handler);
+		worker.addEventListener("error", errorHandler);
+	});
+
+	// Thrown synchronously, not turned into a rejection: a worker that cannot even
+	// accept a message must fall back on the main thread synchronously, so that
+	// `bb.generate()` stays as synchronous as it is with `useWorker: false`.
+	try {
+		worker.postMessage({args, id, op});
+	} catch (error) {
+		settled = true;
+		cleanup!();
+		throw error;
+	}
+
+	return promise;
+}
+
+/**
+ * Start the parity self-test for an op, on a sampled payload rather than the real one.
+ *
+ * The check answers "does this worker implement this op the way the main thread does",
+ * which the sample settles just as well as the full dataset - and at a cost that does
+ * not grow with it. Re-parsing the real payload here would hand back the very
+ * main-thread work the offload was meant to avoid.
+ * @param {Worker} worker Worker instance
+ * @param {string} verifyKey Cache key as `${key}:${op}`
+ * @param {string} op Worker op name
+ * @param {function} fn Equivalent main-thread function
+ * @param {Array} args Conversion arguments to sample from
+ * @param {number} timeout Response timeout in milliseconds
+ * @returns {Promise} Whether the worker matched the main thread
+ * @private
+ */
+function startVerify(
+	worker: Worker,
+	verifyKey: string,
+	op: string,
+	fn: Function,
+	args: unknown[],
+	timeout: number
+): Promise<boolean> {
+	const sample = getVerifySample(args);
+	const check = request(worker, op, sample, timeout)
+		// a worker that errors or times out on the sample is handled by the real
+		// request's own fallback: report it as unverified and let that path run
+		.then(result => isSameResult(result, fn(...sample)), () => false)
+		.then(matched => {
+			matched ? verifiedOps.set(verifyKey, true) : verifiedOps.delete(verifyKey);
+
+			return matched;
+		});
+
+	verifiedOps.set(verifyKey, check);
+
+	return check;
 }
 
 /**
@@ -209,7 +350,8 @@ export function getWorker(key: string, src: string): Worker | null {
  * Create and run on Web Worker
  * @param {boolean} useWorker Use Web Worker
  * @param {string} op Op name registered in src/module/worker.entry.ts
- * @param {function} fn Equivalent main-thread function, used for fallback and parity check
+ * @param {function} fn Equivalent main-thread function, used for fallback and for the
+ * sampled parity self-test
  * @param {function} callback Callback function to receive result from worker
  * @param {number|object} options Worker response timeout or options.
  * @returns {function}
@@ -245,65 +387,34 @@ export function runWorker(
 			const {key} = workerResources;
 
 			runFn = function(...args: unknown[]) {
-				// workers are cached and shared: match the response by id so concurrent
-				// callers don't steal each other's result
-				const id = ++messageId;
-				let settled = false;
-
+				// any failure - worker error, {error} reply, timeout, postMessage throw,
+				// parity mismatch - gives up on this worker for the session and redoes the
+				// work on the main thread
 				const fallback = () => {
-					if (!settled) {
-						settled = true;
-						cleanup();
-						releaseWorker(key, true);
-						runFn = runSync;
-						runSync(...args);
-					}
+					releaseWorker(key, true);
+					runFn = runSync;
+					runSync(...args);
 				};
-
-				const handler = function(e: MessageEvent) {
-					if (e.data?.id === id) {
-						if (e.data.error) {
-							fallback();
-							return;
-						}
-
-						settled = true;
-						cleanup();
-
-						if (!verifiedKeys.has(`${key}:${op}`)) {
-							const expected = fn(...args);
-
-							if (!isSameResult(e.data.result, expected)) {
-								releaseWorker(key, true);
-								runFn = runSync;
-								callback(expected);
-								return;
-							}
-
-							verifiedKeys.add(`${key}:${op}`);
-						}
-
-						callback(e.data.result);
-					}
-				};
-
-				const errorHandler = function() {
-					fallback();
-				};
-
-				const timer = setTimeout(fallback, timeout);
-				const cleanup = () => {
-					clearTimeout(timer);
-					worker.removeEventListener("message", handler);
-					worker.removeEventListener("error", errorHandler);
-				};
-
-				worker.addEventListener("message", handler);
-				worker.addEventListener("error", errorHandler);
 
 				try {
-					worker.postMessage({args, id, op});
+					const verifyKey = `${key}:${op}`;
+					// Started before the real request is posted: the worker processes
+					// messages in order, so the sampled result comes back first and the
+					// check overlaps the real conversion instead of following it.
+					const verified = verifiedOps.get(verifyKey) ??
+						startVerify(worker, verifyKey, op, fn, args, timeout);
+
+					request(worker, op, args, timeout).then(result => {
+						// already verified: hand the result over without touching the
+						// main-thread converter at all
+						if (verified === true) {
+							callback(result);
+						} else {
+							verified.then(matched => (matched ? callback(result) : fallback()));
+						}
+					}, fallback);
 				} catch {
+					// postMessage refused the payload outright - stay synchronous
 					fallback();
 				}
 			};
@@ -335,5 +446,5 @@ export function cleanupWorkers(): void {
 	}
 
 	disabledKeys.clear();
-	verifiedKeys.clear();
+	verifiedOps.clear();
 }

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -119,6 +119,34 @@ function getOptions(options: ChartOptions, type?: IProp["type"]): ChartOptions {
  *     }
  *   }}
  * />;
+ * @example
+ * // UMD: 'dist/billboard.react.js' exposes the 'BillboardReact' global, holding
+ * // the same component as both '.Chart' and '.default'. React is expected on the
+ * // page as the 'React' global, so this path needs a UMD build of React - React
+ * // 18 and below ship one, React 19 does not.
+ * <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+ * <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+ *
+ * <link rel="stylesheet" href="$YOUR_PATH/billboard.css">
+ * <script src="$YOUR_PATH/billboard.pkgd.js"></script>
+ * <script src="$YOUR_PATH/billboard.react.js"></script>
+ *
+ * <div id="root"></div>
+ * <script>
+ *   const {Chart} = BillboardReact;
+ *
+ *   ReactDOM.createRoot(document.getElementById("root")).render(
+ *     React.createElement(Chart, {
+ *       bb,
+ *       options: {
+ *         data: {
+ *           columns: [["data1", 30, 120, 80]],
+ *           type: "line"
+ *         }
+ *       }
+ *     })
+ *   );
+ * </script>
  */
 const Chart = forwardRef<IChart, IProp>((props, ref) => {
 	const container = useRef<HTMLDivElement>(null);

--- a/test/api/export-spec.ts
+++ b/test/api/export-spec.ts
@@ -3,7 +3,7 @@
  * billboard.js project is licensed under the MIT license
  */
 /* eslint-disable */
-import {beforeEach, beforeAll, describe, expect, it} from "vitest";
+import {beforeEach, beforeAll, describe, expect, it, vi} from "vitest";
 // @ts-ignore
 import fontUrl from "../assets/font/alfa-slab-one.woff2?url";
 import util from "../assets/util";
@@ -253,17 +253,41 @@ describe("API export", () => {
 			});
 		}));
 
-		it("check when 'preserveFontStyle=true'", () => new Promise(done => {
+		it("check when 'preserveFontStyle=true'", async () => {
 			// use a bundled font asset: fetching from fonts.gstatic.com made this test
 			// fail on CI whenever the network was slow (fallback font → pattern mismatch)
 			const font = new FontFace("Alfa Slab One", `url(${fontUrl})`, {
 				style: "normal",
 				weight: "400"
 			});
+			const renderedTexts: Array<{text: string, font: string}> = [];
+			const originalFillText = CanvasRenderingContext2D.prototype.fillText;
+			const fillText = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText")
+				.mockImplementation(function(
+					this: CanvasRenderingContext2D,
+					text: string,
+					x: number,
+					y: number,
+					maxWidth?: number
+				) {
+					renderedTexts.push({
+						text: String(text),
+						font: this.font
+					});
+
+					if (arguments.length > 3) {
+						return originalFillText.call(this, text, x, y, maxWidth);
+					}
+
+					return originalFillText.call(this, text, x, y);
+				});
 
 			document.fonts.add(font);
 
-			font.load().then(() => {
+			try {
+				await font.load();
+				await document.fonts.ready;
+
 				chart.$.chart
 					.style("margin-left", "100px")
 					.style("padding-top", "50px");
@@ -271,20 +295,28 @@ describe("API export", () => {
 				chart.$.svg
 					.style("font-family", "Alfa Slab One");
 
-				chart.export({
-					preserveFontStyle: true
-				}, function(dataUrl) {
-					expect(
-						expected.some(pttr => pttr.every(v => dataUrl.indexOf(v) >= 0))
-					).to.be.true;
-
-					chart.$.chart
-						.style("margin-left", null)
-						.style("padding-top", null);
-
-					done(1);
+				const dataUrl = await new Promise<string>(resolve => {
+					chart.export({
+						preserveFontStyle: true
+					}, resolve);
 				});
-			});
-		}));
+
+				expect(dataUrl).to.match(/^data:image\/png;base64,/);
+				expect(renderedTexts.length).to.be.greaterThan(0);
+				expect(
+					renderedTexts.some(({font}) => font.indexOf("Alfa Slab One") >= 0)
+				).to.be.true;
+			} finally {
+				fillText.mockRestore();
+				document.fonts.delete(font);
+
+				chart.$.chart
+					.style("margin-left", null)
+					.style("padding-top", null);
+
+				chart.$.svg
+					.style("font-family", null);
+			}
+		});
 	});
 });

--- a/test/internals/axis-spec.ts
+++ b/test/internals/axis-spec.ts
@@ -3187,10 +3187,45 @@ describe("AXIS", function() {
 
 						expect(domain).to.be.deep.equal(args.axis[id].axes[i].domain);
 						expect(+axis.select(`.tick text`).text()).to.be.equal(domain[0]);
-						expect(+axis.select(`.tick:last-child text`).text()).to.be.equal(domain[1]);
+						// ':last-of-type' rather than ':last-child': the axis renderer
+						// appends <path.domain> after the ticks, as it does for main axes
+						expect(+axis.select(`.tick:last-of-type text`).text())
+							.to.be.equal(domain[1]);
 					});
 			});
 		})
+
+		describe("main axis tick options don't leak into the sub axes", () => {
+			beforeAll(() => {
+				args = {
+					data: {
+						columns: [["data1", 30, 200, 100, 400, 150]]
+					},
+					axis: {
+						x: {
+							tick: {show: false, text: {show: false}},
+							axes: [{tick: {count: 3}}]
+						}
+					}
+				};
+			});
+
+			// the sub axes were rendered by d3-axis, which reads no billboard config, so
+			// `axis.x.tick.show`/`text.show` never applied to them
+			it("sub axis keeps its ticks while the main axis hides them", () => {
+				const main = chart.$.main;
+
+				expect(main.select(`.${$AXIS.axis}-x`).selectAll(".tick line").size())
+					.to.be.equal(0);
+				expect(main.select(`.${$AXIS.axis}-x`).selectAll(".tick text").size())
+					.to.be.equal(0);
+
+				const subAxis = main.select(`.${$AXIS.axis}-x-1`);
+
+				expect(subAxis.selectAll(".tick line").size()).to.be.above(0);
+				expect(subAxis.selectAll(".tick text").size()).to.be.above(0);
+			});
+		});
 	});
 
 	describe("y Axis size", () => {

--- a/test/internals/boost-spec.ts
+++ b/test/internals/boost-spec.ts
@@ -115,6 +115,16 @@ describe("BOOST", () => {
 			expect(config.boost_useWorker).to.be.true;
 		});
 
+		it("should set custom Web Worker URL option", () => {
+			args.boost.useWorker = false;
+			args.boost.workerUrl = "/static/billboard-worker.js";
+
+			chart = util.generate(args);
+			const {config} = chart.internal;
+
+			expect(config.boost_workerUrl).to.be.equal("/static/billboard-worker.js");
+		});
+
 		it("should disable Web Worker option when boost.useWorker is false", () => {
 			args.boost.useWorker = false;
 			chart = util.generate(args);
@@ -342,7 +352,7 @@ describe("BOOST", () => {
 	describe("runWorker function tests", function() {
 		it("check if given function run without WebWorker", () => {
 			return new Promise((resolve) => {
-				runWorker(false, function test_for_worker(p) {
+				runWorker(false, "rows", function test_for_worker(p) {
 						return `${p}_123`;
 					},
 					function(res) {
@@ -353,7 +363,10 @@ describe("BOOST", () => {
 			});
 		});
 
-		it("check if given function run on WebWorker thread", function() {
+		// real worker execution of the registered ops is covered by
+		// test/module/worker-real-spec.ts; this asserts the result is still correct
+		// when the op isn't the one the worker would run
+		it("check if given function returns the correct result with useWorker", function() {
 			// Skip this test in environments where WebWorker is not properly supported
 			if (typeof Worker === 'undefined' || typeof window === 'undefined' || !window.Worker) {
 				this.skip();
@@ -366,7 +379,7 @@ describe("BOOST", () => {
 					reject(new Error("WebWorker test timed out"));
 				}, 3000);
 
-				runWorker(true, function test_for_worker(p) {
+				runWorker(true, "rows", function test_for_worker(p) {
 						return `${p}_123`;
 					},
 					function(res) {
@@ -394,7 +407,7 @@ describe("BOOST", () => {
 
 			// Run multiple times with same function using sync mode
 			["a", "b", "c"].forEach(value => {
-				runWorker(false, reusable_worker_test, function(result) {
+				runWorker(false, "rows", reusable_worker_test, function(result) {
 					results.push(result);
 					callCount++;
 				})(value);

--- a/test/internals/boost-worker-env-spec.ts
+++ b/test/internals/boost-worker-env-spec.ts
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+
+import {cleanupWorkers} from "../../src/module/worker";
+import util from "../assets/util";
+
+/**
+ * Environment matrix for `boost.useWorker`, at chart level.
+ *
+ * boost-spec covers option plumbing and the sync paths; these cases assert the
+ * chart actually renders in each environment the worker can land in:
+ * real worker, static worker script (strict CSP), blocked worker, and a runtime
+ * with no Worker/Blob/URL at all (the SSR-ish shape of this module's guards).
+ *
+ * Every case must end with the same rendered result - that equivalence is what
+ * makes enabling the worker by default safe.
+ */
+describe("BOOST worker environments", () => {
+	const COLUMNS = [
+		["data1", 30, 200, 100, 400, 150, 250],
+		["data2", 50, 150, 150, 150, 50, 150]
+	];
+	const JSON_DATA = [
+		{x: 1, value1: 10, value2: 20},
+		{x: 2, value1: 15, value2: 25},
+		{x: 3, value1: 20, value2: 30}
+	];
+	let chart;
+
+	/**
+	 * Wait until the (possibly worker-driven, async) data conversion landed.
+	 */
+	function waitForData(instance, expectedIds: string[], timeout = 4000) {
+		return new Promise<void>((resolve, reject) => {
+			const start = performance.now();
+			const poll = () => {
+				const ids = instance.data().map(v => v.id);
+
+				if (expectedIds.every(id => ids.includes(id))) {
+					resolve();
+					return;
+				}
+
+				if (performance.now() - start > timeout) {
+					reject(new Error(`data not converted in time, got: ${ids.join()}`));
+					return;
+				}
+
+				setTimeout(poll, 20);
+			};
+
+			poll();
+		});
+	}
+
+	beforeEach(() => {
+		cleanupWorkers();
+	});
+
+	afterEach(() => {
+		cleanupWorkers();
+		chart?.destroy();
+		chart = null;
+	});
+
+	it("renders columns data through a real Worker", async () => {
+		chart = util.generate({
+			boost: {useWorker: true},
+			data: {columns: COLUMNS, type: "line"}
+		});
+
+		await waitForData(chart, ["data1", "data2"]);
+
+		expect(chart.data.values("data1")).to.be.deep.equal([30, 200, 100, 400, 150, 250]);
+		expect(chart.$.line.lines.size()).to.be.equal(2);
+	});
+
+	it("renders json data through a real Worker", async () => {
+		chart = util.generate({
+			boost: {useWorker: true},
+			data: {
+				json: JSON_DATA,
+				keys: {x: "x", value: ["value1", "value2"]},
+				type: "line"
+			}
+		});
+
+		await waitForData(chart, ["value1", "value2"]);
+
+		expect(chart.data.values("value1")).to.be.deep.equal([10, 15, 20]);
+	});
+
+	// exercises dist/billboard.worker.js, the script `boost.workerUrl` is meant to
+	// point at when `blob:` workers are refused
+	it("renders through a static worker script (strict CSP path)", async ctx => {
+		const workerUrl = "/dist/billboard.worker.js";
+		const res = await fetch(workerUrl).catch(() => null);
+
+		if (!res?.ok) {
+			// dist isn't built in this run; the blob cases above still cover execution
+			ctx.skip();
+			return;
+		}
+
+		chart = util.generate({
+			boost: {useWorker: true, workerUrl},
+			data: {columns: COLUMNS, type: "line"}
+		});
+
+		await waitForData(chart, ["data1", "data2"]);
+
+		expect(chart.data.values("data2")).to.be.deep.equal([50, 150, 150, 150, 50, 150]);
+	});
+
+	it("renders when Worker construction is blocked (CSP worker-src 'none')", async () => {
+		const OriginalWorker = window.Worker;
+
+		window.Worker = class {
+			constructor() {
+				throw new Error("Blocked by Content Security Policy");
+			}
+		} as unknown as typeof Worker;
+
+		try {
+			chart = util.generate({
+				boost: {useWorker: true},
+				data: {columns: COLUMNS, type: "line"}
+			});
+
+			await waitForData(chart, ["data1", "data2"]);
+
+			expect(chart.data.values("data1")).to.be.deep.equal([30, 200, 100, 400, 150, 250]);
+		} finally {
+			window.Worker = OriginalWorker;
+		}
+	});
+
+	it("renders when blob URLs are blocked (CSP script-src)", async () => {
+		const originalCreateObjectURL = window.URL.createObjectURL;
+
+		window.URL.createObjectURL = () => {
+			throw new Error("Blocked by Content Security Policy");
+		};
+
+		try {
+			chart = util.generate({
+				boost: {useWorker: true},
+				data: {columns: COLUMNS, type: "line"}
+			});
+
+			await waitForData(chart, ["data1", "data2"]);
+
+			expect(chart.$.line.lines.size()).to.be.equal(2);
+		} finally {
+			window.URL.createObjectURL = originalCreateObjectURL;
+		}
+	});
+
+	describe("useWorker: 'auto'", () => {
+		function trackWorkerUse() {
+			const OriginalWorker = window.Worker;
+			const created: string[] = [];
+
+			window.Worker = class extends OriginalWorker {
+				constructor(...args) {
+					super(...args);
+					created.push(String(args[0]));
+				}
+			};
+
+			return {created, restore: () => (window.Worker = OriginalWorker)};
+		}
+
+		it("stays on the main thread for small data", async () => {
+			const {created, restore} = trackWorkerUse();
+
+			try {
+				chart = util.generate({
+					boost: {useWorker: "auto"},
+					data: {columns: COLUMNS, type: "line"}
+				});
+
+				// small payload: converted synchronously, no worker created
+				expect(chart.data.values("data1")).to.be.deep.equal([30, 200, 100, 400, 150, 250]);
+				expect(created).to.be.deep.equal([]);
+			} finally {
+				restore();
+			}
+		});
+
+		it("offloads data past the threshold", async () => {
+			const {created, restore} = trackWorkerUse();
+
+			try {
+				const big = [
+					["data1", ...Array.from({length: 4000}, (_, i) => i)],
+					["data2", ...Array.from({length: 4000}, (_, i) => i * 2)]
+				];
+
+				chart = util.generate({
+					boost: {useWorker: "auto"},
+					data: {columns: big, type: "line"}
+				});
+
+				await waitForData(chart, ["data1", "data2"]);
+
+				expect(created.length).to.be.equal(1);
+				expect(chart.data.values("data1").length).to.be.equal(4000);
+			} finally {
+				restore();
+			}
+		});
+	});
+
+	it("renders when Worker/Blob APIs are absent", async () => {
+		const {Worker: OriginalWorker, Blob: OriginalBlob} = window;
+
+		// @ts-ignore - emulate a runtime without the worker primitives
+		delete window.Worker;
+		// @ts-ignore
+		delete window.Blob;
+
+		try {
+			chart = util.generate({
+				boost: {useWorker: true},
+				data: {
+					json: JSON_DATA,
+					keys: {x: "x", value: ["value1", "value2"]},
+					type: "line"
+				}
+			});
+
+			await waitForData(chart, ["value1", "value2"]);
+
+			expect(chart.data.values("value2")).to.be.deep.equal([20, 25, 30]);
+		} finally {
+			window.Worker = OriginalWorker;
+			window.Blob = OriginalBlob;
+		}
+	});
+});

--- a/test/internals/text-overlap-batch-spec.ts
+++ b/test/internals/text-overlap-batch-spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+import {select as d3Select} from "d3-selection";
+import {describe, expect, it} from "vitest";
+
+import textModule from "../../src/ChartInternal/internals/text";
+import {$TEXT} from "../../src/config/classes";
+
+describe("TEXT overlap batching", () => {
+	it("batches text length reads before writing overlap classes", () => {
+		const root = document.createElementNS("http://www.w3.org/2000/svg", "g");
+		const ids = ["data1", "data2", "data3"];
+		const readSawWrite: boolean[] = [];
+
+		ids.forEach((id, index) => {
+			const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+
+			text.__data__ = {data: {id}};
+			text.setAttribute("class", "bb-gauge-value");
+			text.setAttribute("transform", `translate(${index === 2 ? 100 : index * 5}, ${index * 5})`);
+			text.style.fontSize = "20px";
+			text.getComputedTextLength = () => {
+				readSawWrite.push(ids.some((_, i) =>
+					root.children[i].classList.contains($TEXT.TextOverlapping)
+				));
+
+				return 50;
+			};
+
+			root.appendChild(text);
+		});
+
+		textModule.markOverlapped("data1", {
+			$el: {
+				arcs: d3Select(root)
+			}
+		}, ".bb-gauge-value");
+
+		expect(readSawWrite).to.be.deep.equal([false, false]);
+		expect(root.children[1].classList.contains($TEXT.TextOverlapping)).to.be.true;
+		expect(root.children[2].classList.contains($TEXT.TextOverlapping)).to.be.false;
+	});
+});

--- a/test/module/module-coverage-spec.ts
+++ b/test/module/module-coverage-spec.ts
@@ -176,7 +176,7 @@ describe("MODULE coverage helpers", () => {
 			window.URL.createObjectURL = () => "blob:worker";
 			window.URL.revokeObjectURL = url => revoked.push(url);
 
-			runWorker(true, value => value * 3, value => {
+			runWorker(true, "rows", value => value * 3, value => {
 				try {
 					expect(value).to.be.equal(12);
 					expect(created).to.be.deep.equal(["blob:worker"]);
@@ -205,7 +205,7 @@ describe("MODULE coverage helpers", () => {
 					throw new Error("CSP blocked");
 				};
 
-				runWorker(true, value => value * 2, value => values.push(value))(5);
+				runWorker(true, "rows", value => value * 2, value => values.push(value))(5);
 
 				expect(values).to.be.deep.equal([10]);
 			} finally {
@@ -229,7 +229,7 @@ describe("MODULE coverage helpers", () => {
 				window.URL.createObjectURL = () => "blob:blocked";
 				window.URL.revokeObjectURL = () => {};
 
-				runWorker(true, value => value + 1, value => values.push(value))(5);
+				runWorker(true, "rows", value => value + 1, value => values.push(value))(5);
 
 				expect(values).to.be.deep.equal([6]);
 			} finally {
@@ -268,7 +268,7 @@ describe("MODULE coverage helpers", () => {
 				window.URL.createObjectURL = () => "blob:post-message";
 				window.URL.revokeObjectURL = url => revoked.push(url);
 
-				runWorker(true, value => value * 4, value => values.push(value))(3);
+				runWorker(true, "rows", value => value * 4, value => values.push(value))(3);
 
 				expect(values).to.be.deep.equal([12]);
 				expect(terminated).to.be.deep.equal(["blob:post-message"]);
@@ -314,7 +314,7 @@ describe("MODULE coverage helpers", () => {
 			window.URL.createObjectURL = () => "blob:error";
 			window.URL.revokeObjectURL = () => {};
 
-			runWorker(true, value => value + 2, value => {
+			runWorker(true, "rows", value => value + 2, value => {
 				try {
 					expect(value).to.be.equal(7);
 				} finally {
@@ -342,7 +342,7 @@ describe("MODULE coverage helpers", () => {
 			window.URL.createObjectURL = () => "blob:timeout";
 			window.URL.revokeObjectURL = () => {};
 
-			runWorker(true, value => value - 1, value => {
+			runWorker(true, "rows", value => value - 1, value => {
 				try {
 					expect(value).to.be.equal(4);
 				} finally {
@@ -352,6 +352,119 @@ describe("MODULE coverage helpers", () => {
 				}
 				done(1);
 			}, undefined, 10)(5);
+		}));
+
+		it("disables worker when the parity self-test result differs", () => new Promise(done => {
+			const OriginalWorker = window.Worker;
+			const originalCreateObjectURL = window.URL.createObjectURL;
+			const originalRevokeObjectURL = window.URL.revokeObjectURL;
+			const terminated: string[] = [];
+
+			class MockWorker {
+				src;
+				listeners = {error: [], message: []};
+
+				constructor(src) {
+					this.src = src;
+				}
+
+				addEventListener(type, fn) {
+					this.listeners[type].push(fn);
+				}
+
+				removeEventListener(type, fn) {
+					this.listeners[type] = this.listeners[type].filter(f => f !== fn);
+				}
+
+				postMessage(data) {
+					setTimeout(() => {
+						this.listeners.message.slice().forEach(fn => fn({
+							data: {id: data.id, result: "wrong"}
+						}));
+					});
+				}
+
+				terminate() {
+					terminated.push(this.src);
+				}
+			}
+
+			window.Worker = MockWorker;
+			window.URL.createObjectURL = () => "blob:parity";
+			window.URL.revokeObjectURL = () => {};
+
+			runWorker(true, "rows", value => value * 2, value => {
+				try {
+					expect(value).to.be.equal(10);
+					expect(terminated).to.be.deep.equal(["blob:parity"]);
+				} finally {
+					window.Worker = OriginalWorker;
+					window.URL.createObjectURL = originalCreateObjectURL;
+					window.URL.revokeObjectURL = originalRevokeObjectURL;
+				}
+				done(1);
+			})(5);
+		}));
+
+		it("uses a custom static worker URL without creating a Blob URL", () => new Promise(done => {
+			const OriginalWorker = window.Worker;
+			const originalCreateObjectURL = window.URL.createObjectURL;
+			const originalRevokeObjectURL = window.URL.revokeObjectURL;
+			const created: string[] = [];
+			let posted;
+
+			class MockWorker {
+				listeners = {error: [], message: []};
+
+				constructor(src) {
+					created.push(src);
+				}
+
+				addEventListener(type, fn) {
+					this.listeners[type].push(fn);
+				}
+
+				removeEventListener(type, fn) {
+					this.listeners[type] = this.listeners[type].filter(f => f !== fn);
+				}
+
+				postMessage(data) {
+					posted = data;
+
+					setTimeout(() => {
+						this.listeners.message.slice().forEach(fn => fn({
+							data: {id: data.id, result: data.args[0] + 3}
+						}));
+					});
+				}
+
+				terminate() {}
+			}
+
+			window.Worker = MockWorker;
+			window.URL.createObjectURL = () => {
+				throw new Error("Blob URL should not be created");
+			};
+			window.URL.revokeObjectURL = () => {};
+
+			runWorker(true, "rows", value => value + 3, value => {
+				try {
+					expect(value).to.be.equal(8);
+					expect(created).to.be.deep.equal(["/static/billboard-worker.js"]);
+					// op-name protocol: no function source is transferred
+					expect(posted.op).to.be.equal("rows");
+					expect(posted.args).to.be.deep.equal([5]);
+					expect(posted.fn).to.be.undefined;
+					expect(posted.deps).to.be.undefined;
+				} finally {
+					window.Worker = OriginalWorker;
+					window.URL.createObjectURL = originalCreateObjectURL;
+					window.URL.revokeObjectURL = originalRevokeObjectURL;
+				}
+				done(1);
+			}, {
+				workerUrl: "/static/billboard-worker.js"
+			})(5);
 		}));
 
 	});

--- a/test/module/module-coverage-spec.ts
+++ b/test/module/module-coverage-spec.ts
@@ -406,6 +406,72 @@ describe("MODULE coverage helpers", () => {
 			})(5);
 		}));
 
+		it("self-tests on a sampled payload, not the full one", () => new Promise(done => {
+			const OriginalWorker = window.Worker;
+			const originalCreateObjectURL = window.URL.createObjectURL;
+			const originalRevokeObjectURL = window.URL.revokeObjectURL;
+			const posted: any[][] = [];
+			const converted: any[][] = [];
+
+			class MockWorker {
+				listeners = {error: [], message: []};
+
+				addEventListener(type, fn) {
+					this.listeners[type].push(fn);
+				}
+
+				removeEventListener(type, fn) {
+					this.listeners[type] = this.listeners[type].filter(f => f !== fn);
+				}
+
+				postMessage(data) {
+					posted.push(data.args[0]);
+
+					setTimeout(() => {
+						this.listeners.message.slice().forEach(fn => fn({
+							data: {id: data.id, result: convert(data.args[0])}
+						}));
+					});
+				}
+
+				terminate() {}
+			}
+
+			// stands in for a conversion: the worker and the main thread run the same one
+			const convert = cols => cols.map(([name, ...values]) => ({name, len: values.length}));
+			const columns = Array.from({length: 8}, (_, i) => [
+				`data${i}`,
+				...Array.from({length: 500}, (_, j) => j)
+			]);
+
+			window.Worker = MockWorker;
+			window.URL.createObjectURL = () => "blob:sampled";
+			window.URL.revokeObjectURL = () => {};
+
+			runWorker(true, "columns", cols => {
+				converted.push(cols);
+
+				return convert(cols);
+			}, result => {
+				try {
+					// the worker got the real payload, and its result is what came back
+					expect(posted[posted.length - 1]).to.be.deep.equal(columns);
+					expect(result).to.be.deep.equal(convert(columns));
+
+					// the main thread converted only the sample: 3 series of 3 values.
+					// Re-parsing the full payload here would undo the offload.
+					expect(converted.length).to.be.equal(1);
+					expect(converted[0].length).to.be.equal(3);
+					converted[0].forEach(col => expect(col.length).to.be.equal(4));
+				} finally {
+					window.Worker = OriginalWorker;
+					window.URL.createObjectURL = originalCreateObjectURL;
+					window.URL.revokeObjectURL = originalRevokeObjectURL;
+				}
+				done(1);
+			})(columns);
+		}));
+
 		it("uses a custom static worker URL without creating a Blob URL", () => new Promise(done => {
 			const OriginalWorker = window.Worker;
 			const originalCreateObjectURL = window.URL.createObjectURL;

--- a/test/module/module-spec.ts
+++ b/test/module/module-spec.ts
@@ -128,6 +128,7 @@ describe("MODULE", function() {
 
             runWorker(
                 false,
+                "rows",
                 function(val: number) { return val * 2; },
                 function(res: number) { result = res; }
             )(5);
@@ -135,19 +136,15 @@ describe("MODULE", function() {
             expect(result).to.be.equal(10);
         });
 
-        it("check with dependency function", () => new Promise(done => {
-            function depsFn() {
-                return 1234;
-            }
-
+        it("check unknown op falls back to the main thread", () => new Promise(done => {
             runWorker(
                 true,
-                function() { return depsFn(); },
+                "__unknown_op__",
+                function() { return 1234; },
                 function(res: number) {
                     expect(res).to.be.equal(1234);
                     done(1);
-                },
-                [depsFn]
+                }
             )();
 
             setTimeout(() => done(1), 2000);

--- a/test/module/voronoi-parity-spec.ts
+++ b/test/module/voronoi-parity-spec.ts
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+import {Delaunay} from "d3-delaunay";
+import {describe, expect, it} from "vitest";
+
+import {polygonArea, polygonCentroid} from "../../src/module/polygon";
+import {voronoiCells} from "../../src/module/voronoi";
+
+/**
+ * Golden parity suite: the in-tree half-plane Voronoi must agree with
+ * d3-delaunay on the cells the textoverlap plugin consumes. d3-delaunay is kept
+ * as a devDependency for exactly this comparison.
+ */
+
+type Point = [number, number];
+
+// deterministic LCG so failures are reproducible
+function seeded(seed: number) {
+	let state = seed;
+
+	return () => {
+		state = (state * 1103515245 + 12345) % 2147483648;
+
+		return state / 2147483648;
+	};
+}
+
+function randomPoints(count: number, seed: number, bounds: number[]): Point[] {
+	const rand = seeded(seed);
+	const [x0, y0, x1, y1] = bounds;
+
+	return Array.from({length: count}, () => [
+		x0 + rand() * (x1 - x0),
+		y0 + rand() * (y1 - y0)
+	] as Point);
+}
+
+// d3-delaunay reaches the cells through circumcenters, so its rings carry two
+// artifacts this comparison must see past: float noise on the order of 1e-5,
+// and redundant vertices sitting mid-edge on a bisector. Neither changes the
+// polygon, and neither is visible to the plugin, which only reads centroid and
+// area.
+const TOLERANCE = 1e-4;
+
+/**
+ * Normalize a cell to an open ring: consistent winding, no near-duplicate and
+ * no collinear vertices.
+ */
+function simplify(cell: Point[] | null): Point[] | null {
+	if (!cell) {
+		return null;
+	}
+
+	const ring: Point[] = [];
+
+	// the ring is closed; drop the repeated vertex and any near-duplicates
+	cell.slice(0, -1).forEach(p => {
+		const last = ring[ring.length - 1];
+
+		if (!last || Math.hypot(p[0] - last[0], p[1] - last[1]) > TOLERANCE) {
+			ring.push(p);
+		}
+	});
+
+	while (
+		ring.length > 1 &&
+		Math.hypot(ring[0][0] - ring[ring.length - 1][0], ring[0][1] - ring[ring.length - 1][1]) <=
+			TOLERANCE
+	) {
+		ring.pop();
+	}
+
+	// drop vertices that lie on the segment between their neighbors
+	const pruned: Point[] = [];
+
+	ring.forEach((b, i) => {
+		const a = ring[(i - 1 + ring.length) % ring.length];
+		const c = ring[(i + 1) % ring.length];
+		const cross = (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]);
+
+		// twice the triangle area: a mid-edge vertex contributes none
+		if (Math.abs(cross) > TOLERANCE) {
+			pruned.push(b);
+		}
+	});
+
+	if (pruned.length < 3) {
+		return null;
+	}
+
+	if (polygonArea(pruned) < 0) {
+		pruned.reverse();
+	}
+
+	return pruned;
+}
+
+/**
+ * Compare two normalized rings, which may start at any vertex.
+ */
+function expectSameRing(own: Point[] | null, d3: Point[] | null, label: string) {
+	expect(!!own, `${label}: cell presence`).to.be.equal(!!d3);
+
+	if (!own || !d3) {
+		return;
+	}
+
+	expect(own.length, `${label}: vertex count (${JSON.stringify(own)} vs ${JSON.stringify(d3)})`)
+		.to.be.equal(d3.length);
+
+	// align on the d3 vertex nearest our first one
+	let offset = 0;
+	let best = Infinity;
+
+	d3.forEach((p, i) => {
+		const d = Math.hypot(p[0] - own[0][0], p[1] - own[0][1]);
+
+		if (d < best) {
+			best = d;
+			offset = i;
+		}
+	});
+
+	own.forEach((p, i) => {
+		const q = d3[(offset + i) % d3.length];
+
+		expect(p[0], `${label}: vertex ${i} x`).to.be.closeTo(q[0], TOLERANCE);
+		expect(p[1], `${label}: vertex ${i} y`).to.be.closeTo(q[1], TOLERANCE);
+	});
+}
+
+function d3Cells(points: Point[], bounds: number[]): (Point[] | null)[] {
+	const voronoi = Delaunay.from(points).voronoi(bounds as [number, number, number, number]);
+
+	return points.map((_, i) => voronoi.cellPolygon(i) as Point[] | null);
+}
+
+function compareCells(points: Point[], bounds: number[], label: string) {
+	const own = voronoiCells(points, bounds);
+	const d3 = d3Cells(points, bounds);
+
+	expect(own.length, `${label}: cell count`).to.be.equal(d3.length);
+
+	own.forEach((cell, i) => {
+		expectSameRing(
+			simplify(cell),
+			simplify(d3[i]),
+			`${label}: cell ${i} of ${JSON.stringify(points[i])}`
+		);
+	});
+}
+
+describe("VORONOI parity with d3-delaunay", () => {
+	const BOUNDS = [0, 0, 960, 500];
+
+	describe("random point sets", () => {
+		[3, 4, 8, 25, 60].forEach(count => {
+			[1, 7, 4242].forEach(seed => {
+				it(`${count} points, seed ${seed}`, () => {
+					compareCells(
+						randomPoints(count, seed, BOUNDS),
+						BOUNDS,
+						`${count}/${seed}`
+					);
+				});
+			});
+		});
+	});
+
+	describe("degenerate layouts", () => {
+		it("two points", () => {
+			compareCells([[100, 100], [800, 400]], BOUNDS, "two points");
+		});
+
+		it("collinear points (a Delaunay triangulation degenerate case)", () => {
+			compareCells(
+				[[100, 250], [300, 250], [500, 250], [700, 250], [900, 250]],
+				BOUNDS,
+				"collinear"
+			);
+		});
+
+		it("grid points (many cocircular quadruples)", () => {
+			const points: Point[] = [];
+
+			for (let x = 100; x <= 700; x += 200) {
+				for (let y = 100; y <= 400; y += 100) {
+					points.push([x, y]);
+				}
+			}
+
+			compareCells(points, BOUNDS, "grid");
+		});
+
+		it("points on the bounds edge", () => {
+			compareCells(
+				[[0, 0], [960, 0], [0, 500], [960, 500], [480, 250]],
+				BOUNDS,
+				"edges"
+			);
+		});
+	});
+
+	describe("the shape the textoverlap plugin builds", () => {
+		// [index, value] pairs clipped to the x/y scale domains
+		it("index/value points over a data domain", () => {
+			const bounds = [0, 0, 9, 400];
+			const points: Point[] = [
+				[0, 130], [1, 340], [2, 200], [3, 500], [4, 250],
+				[5, 350], [6, 90], [7, 380], [8, 120], [9, 300]
+			];
+
+			compareCells(points, bounds, "textoverlap");
+		});
+	});
+
+	describe("cells the plugin actually reads", () => {
+		it("centroid and area match d3-delaunay", () => {
+			const points = randomPoints(40, 99, BOUNDS);
+			const own = voronoiCells(points, BOUNDS);
+			const d3 = d3Cells(points, BOUNDS);
+
+			own.forEach((cell, i) => {
+				const other = d3[i];
+
+				expect(!!cell, `cell ${i} presence`).to.be.equal(!!other);
+
+				if (cell && other) {
+					const [cx, cy] = polygonCentroid(cell);
+					const [dx, dy] = polygonCentroid(other);
+
+					expect(cx, `cell ${i} centroid x`).to.be.closeTo(dx, 1e-3);
+					expect(cy, `cell ${i} centroid y`).to.be.closeTo(dy, 1e-3);
+					expect(Math.abs(polygonArea(cell)), `cell ${i} area`)
+						.to.be.closeTo(Math.abs(polygonArea(other)), 1e-3);
+				}
+			});
+		});
+
+		it("returns null for duplicated sites, as d3-delaunay does", () => {
+			const points: Point[] = [[100, 100], [500, 300], [100, 100]];
+			const own = voronoiCells(points, BOUNDS);
+			const d3 = d3Cells(points, BOUNDS);
+
+			expect(own.map(c => !!c)).to.be.deep.equal(d3.map(c => !!c));
+		});
+	});
+});

--- a/test/module/worker-real-spec.ts
+++ b/test/module/worker-real-spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+
+import {columns, json, rows} from "../../src/ChartInternal/data/convert.helper";
+import {cleanupWorkers, runWorker} from "../../src/module/worker";
+import {ops} from "../../src/module/worker.entry";
+
+/**
+ * End-to-end checks against a REAL browser Worker (no mocks).
+ *
+ * The mocked suites in module-coverage-spec verify the fallback chain; these
+ * verify that the pre-bundled worker source actually executes, which is what
+ * decides whether `boost.useWorker` can ever be enabled by default.
+ *
+ * Regression guard: while the worker source was produced by
+ * `Function.prototype.toString()`, this suite failed with
+ * "cov_xxx is not defined" under coverage instrumentation - the same class of
+ * failure reported for React/webpack setups.
+ */
+
+/**
+ * These tests assert the worker path specifically, so the fallback timer must
+ * never win the race: `runWorker`'s 5s default sits below vitest's 10s
+ * `testTimeout`, so a worker that starts slowly under parallel browser load
+ * silently falls back, delivers the correct main-thread result, and fails here
+ * as "expected +0 to equal 1" on the reply count. Raising it past `testTimeout`
+ * turns that into an honest test timeout.
+ */
+const WORKER_OPTIONS = {timeout: 30_000};
+describe("WORKER real execution", () => {
+	let OriginalWorker;
+	let instances: {worker: Worker, errors: string[], replies: any[]}[] = [];
+
+	function trackWorkers() {
+		OriginalWorker = window.Worker;
+		instances = [];
+
+		window.Worker = class TrackedWorker extends OriginalWorker {
+			constructor(...args) {
+				super(...args);
+
+				const entry = {
+					worker: this as unknown as Worker,
+					errors: [] as string[],
+					replies: [] as any[]
+				};
+
+				// a broken worker source surfaces either as an 'error' event (parse /
+				// top-level ReferenceError) or as an {error} reply (throw inside onmessage)
+				this.addEventListener("error", (e: ErrorEvent) => entry.errors.push(e.message));
+				this.addEventListener("message", (e: MessageEvent) => entry.replies.push(e.data));
+				instances.push(entry);
+			}
+		};
+	}
+
+	function expectWorkerHandled(expected) {
+		expect(instances.length, "a Worker was constructed").to.be.equal(1);
+
+		const [{errors, replies}] = instances;
+
+		expect(errors, "Worker error events").to.be.deep.equal([]);
+		expect(replies.length, "the Worker replied (not a fallback)").to.be.equal(1);
+		expect(replies[0].error).to.be.undefined;
+		expect(replies[0].result).to.be.deep.equal(expected);
+	}
+
+	// the worker cache is module state shared across spec files in the same browser
+	// page: a mocked worker left cached elsewhere would be reused here and time out
+	beforeEach(() => {
+		cleanupWorkers();
+	});
+
+	afterEach(() => {
+		cleanupWorkers();
+
+		if (OriginalWorker) {
+			window.Worker = OriginalWorker;
+			OriginalWorker = null;
+		}
+	});
+
+	it("runs the 'json' op in a real Worker", () => new Promise((resolve, reject) => {
+		trackWorkers();
+
+		const data = [
+			{name: "a", value: 10},
+			{name: "b", value: 20}
+		];
+		const keys = {value: ["value"], x: "name"};
+		const expected = json(data, keys);
+
+		runWorker(true, "json", json, result => {
+			try {
+				expect(result).to.be.deep.equal(expected);
+				expectWorkerHandled(expected);
+				resolve(1);
+			} catch (e) {
+				reject(e);
+			}
+		}, WORKER_OPTIONS)(data, keys);
+	}));
+
+	it("runs the 'rows' op in a real Worker", () => new Promise((resolve, reject) => {
+		trackWorkers();
+
+		const data = [["x", "data1"], [1, 30], [2, 200]];
+		const expected = rows(data);
+
+		runWorker(true, "rows", rows, result => {
+			try {
+				expect(result).to.be.deep.equal(expected);
+				expectWorkerHandled(expected);
+				resolve(1);
+			} catch (e) {
+				reject(e);
+			}
+		}, WORKER_OPTIONS)(data);
+	}));
+
+	it("runs the 'columns' op in a real Worker", () => new Promise((resolve, reject) => {
+		trackWorkers();
+
+		const data = [["data1", 30, 200], ["data2", 130, 100]];
+		const expected = columns(data);
+
+		runWorker(true, "columns", columns, result => {
+			try {
+				expect(result).to.be.deep.equal(expected);
+				expectWorkerHandled(expected);
+				resolve(1);
+			} catch (e) {
+				reject(e);
+			}
+		}, WORKER_OPTIONS)(data);
+	}));
+
+	it("registers every op name used by convertData", () => {
+		// convert.ts addresses the worker by these names; a rename on either side
+		// would otherwise only surface as a silent main-thread fallback
+		expect(Object.keys(ops).sort()).to.be.deep.equal(["columns", "json", "rows"]);
+	});
+
+	it("falls back to the main thread for an unknown op", () => new Promise((resolve, reject) => {
+		trackWorkers();
+
+		const data = [["data1", 30, 200]];
+
+		runWorker(true, "__nope__", columns, result => {
+			try {
+				// the worker rejects the op, and the main thread produces the result
+				expect(result).to.be.deep.equal(columns(data));
+				expect(instances.length).to.be.equal(1);
+				expect(instances[0].replies[0].error).to.be.equal("Unknown worker op: __nope__");
+				resolve(1);
+			} catch (e) {
+				reject(e);
+			}
+		}, WORKER_OPTIONS)(data);
+	}));
+});

--- a/test/module/worker-real-spec.ts
+++ b/test/module/worker-real-spec.ts
@@ -64,9 +64,12 @@ describe("WORKER real execution", () => {
 		const [{errors, replies}] = instances;
 
 		expect(errors, "Worker error events").to.be.deep.equal([]);
-		expect(replies.length, "the Worker replied (not a fallback)").to.be.equal(1);
-		expect(replies[0].error).to.be.undefined;
-		expect(replies[0].result).to.be.deep.equal(expected);
+		// Two replies on a cold worker: the sampled parity self-test, then the real
+		// payload. The sample is posted first and the worker answers in order, so the
+		// real result is the last reply.
+		expect(replies.length, "the Worker replied (not a fallback)").to.be.equal(2);
+		replies.forEach(reply => expect(reply.error).to.be.undefined);
+		expect(replies[replies.length - 1].result).to.be.deep.equal(expected);
 	}
 
 	// the worker cache is module state shared across spec files in the same browser

--- a/test/shape/treemap-spec.ts
+++ b/test/shape/treemap-spec.ts
@@ -191,6 +191,32 @@ describe("TREEMAP", () => {
 			treemap.destroy();
 		});
 
+		it("should render all tile variants with finite rect dimensions", () => {
+			["binary", "dice", "slice", "sliceDice", "squarify", "resquarify"].forEach(tile => {
+				const treemap = util.generate({
+					data: {
+						columns: [
+							["data1", 1000],
+							["data2", 200],
+							["data3", 500],
+							["data4", 50]
+						],
+						type: "treemap"
+					},
+					treemap: {
+						tile
+					}
+				});
+
+				treemap.internal.$el.treemap.selectAll("rect").each(function() {
+					expect(Number.isFinite(+this.getAttribute("width"))).to.be.true;
+					expect(Number.isFinite(+this.getAttribute("height"))).to.be.true;
+				});
+
+				treemap.destroy();
+			});
+		});
+
 		it("should generate w/o error", () => {
 			const param = {
 				data: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
 	},
 	"include": [
 		"src/**/index*.ts",
+		"config/globals.d.ts",
 	],
 	"exclude": [
 		"test/**/*.ts"

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -111,12 +111,36 @@ export interface ChartOptions {
 
 		/**
 		 * Use Web Worker as possible for processing.
+		 * - **Available values:**
+		 *   - `false`: never offload.
+		 *   - `true`: always offload when a Worker can be created.
+		 *   - `"auto"`: offload only when the given data exceeds ~5,000 cells, since smaller
+		 *     payloads lose more to structured cloning than they gain.
 		 * - **NOTE:**
 		 *   - For now, only applies for data conversion at the initial time.
 		 *   - As of Web Worker's async nature, handling chart instance synchronously is not recommended.
 		 *   - When Worker isn't available, fails or times out, data conversion falls back to main thread.
 		 */
-		useWorker?: boolean;
+		useWorker?: boolean | "auto";
+
+		/**
+		 * Use a custom static worker script URL instead of an inline Blob worker.
+		 * - **NOTE:**
+		 *   - **Requires `boost.useWorker` to be enabled** — this option only selects where the
+		 *     worker source comes from, it does not turn offloading on by itself.
+		 *   - Useful for strict CSP environments that disallow `blob:` workers. Without it under
+		 *     such a policy, worker creation throws and each conversion waits out the 5s timeout
+		 *     before falling back, so the chart still renders but the initial draw is delayed.
+		 *   - Point it at `dist/billboard.worker.js`, shipped in the package, or any script
+		 *     implementing the same protocol: receive `{id, op, args}` and post back
+		 *     `{id, result}` or `{id, error}`. No `eval()` is involved.
+		 *   - With a bundler, make sure the file is emitted as a **real asset**, not inlined:
+		 *     it is ~1.5KB, and inlining turns it into a `data:` URI, which a strict CSP
+		 *     blocks exactly like `blob:`. Copying it into the static/public directory is the
+		 *     option that works everywhere.
+		 *   - Any failure (load error, unknown op, timeout, result mismatch) falls back to the main thread.
+		 */
+		workerUrl?: string;
 	};
 
 	size?: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,12 +19,13 @@ const utilAliasPlugin = {
     }
 };
 
-export default defineConfig({
+// async because the worker source is bundled on demand (see config/worker-src.js)
+export default defineConfig(async () => ({
     plugins: [utilAliasPlugin],
     define: {
         // same injection the production builds do, so worker specs exercise the
         // real pre-bundled worker source instead of an undefined constant
-        __WORKER_SRC__: JSON.stringify(getWorkerSource())
+        __WORKER_SRC__: JSON.stringify(await getWorkerSource())
     },
     optimizeDeps: {
         include: ["@vitest/coverage-istanbul"]
@@ -87,4 +88,4 @@ export default defineConfig({
         },
         open: !process.env.CI
     }
-});
+}));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,7 @@
 import {resolve} from "node:path";
 import {defineConfig} from "vitest/config";
 import {playwright} from "@vitest/browser-playwright";
+import {getWorkerSource} from "./config/worker-src.js";
 
 const utilAliasPlugin = {
     name: "util-alias-resolver",
@@ -20,6 +21,11 @@ const utilAliasPlugin = {
 
 export default defineConfig({
     plugins: [utilAliasPlugin],
+    define: {
+        // same injection the production builds do, so worker specs exercise the
+        // real pre-bundled worker source instead of an undefined constant
+        __WORKER_SRC__: JSON.stringify(getWorkerSource())
+    },
     optimizeDeps: {
         include: ["@vitest/coverage-istanbul"]
     },

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -76,21 +76,66 @@ const config = {
 	optimization: {
 		usedExports: true
 	},
-	plugins: [
-		new webpack.optimize.ModuleConcatenationPlugin(),
-		new WebpackBar()
-	],
+	plugins: [],
 	node: false,
 	stats: "minimal",
 	mode: "none"
 };
 
-module.exports = () => {
+// modes emitting into `dist/`, where the static worker script sits next to the
+// library bundle that references it. The theme and plugin builds write into their
+// own subdirectory and have no use for it.
+const WORKER_ASSET_MODES = ["development", "production", "packaged"];
+
+// ship the worker source as a static script for strict CSP environments,
+// referenced through the `boost.workerUrl` option
+const workerAssetPlugin = workerSrc => ({
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap("bb-worker-asset", compilation => {
+			compilation.hooks.processAssets.tap({
+				name: "bb-worker-asset",
+				stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+			}, () => {
+				// BannerPlugin only reaches chunk assets, and this is emitted
+				// standalone: carry the same header every other dist file has
+				const banner = `/*!\n * ${
+					require("./config/template/banner.cjs").production.split("\r\n").join("\n * ")
+				}\n */\n`;
+
+				compilation.emitAsset(
+					"billboard.worker.js",
+					new webpack.sources.RawSource(banner + workerSrc)
+				);
+			});
+		});
+	}
+});
+
+module.exports = async () => {
 	let mode = "development";
 
 	if (env.NODE_ENV) {
 		mode = env.NODE_ENV;
 	}
+
+	// worker source is bundled separately (ESM helper), so the worker never depends on
+	// Function.prototype.toString() of transformed application code
+	const {getWorkerSource} = await import("./config/worker-src.js");
+	const workerSrc = getWorkerSource();
+
+	// assigned, not appended: the factory may run more than once in a process, and
+	// pushing onto the shared config would stack up duplicate plugins
+	config.plugins = [
+		new webpack.optimize.ModuleConcatenationPlugin(),
+		new WebpackBar(),
+		new webpack.DefinePlugin({
+			__WORKER_SRC__: JSON.stringify(workerSrc)
+		})
+	];
+
+	WORKER_ASSET_MODES.includes(mode) && config.plugins.push(
+		workerAssetPlugin(workerSrc)
+	);
 
 	env.ANALYZER && config.plugins.push(
 		new BundleAnalyzerPlugin()

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -121,7 +121,7 @@ module.exports = async () => {
 	// worker source is bundled separately (ESM helper), so the worker never depends on
 	// Function.prototype.toString() of transformed application code
 	const {getWorkerSource} = await import("./config/worker-src.js");
-	const workerSrc = getWorkerSource();
+	const workerSrc = await getWorkerSource();
 
 	// assigned, not appended: the factory may run more than once in a process, and
 	// pushing onto the shared config would stack up duplicate plugins


### PR DESCRIPTION
## Summary

- **Worker source is pre-bundled** (`src/module/worker.entry.ts` → minified IIFE → injected as a string), never derived from `Function.prototype.toString()`. Work is addressed by op name, so no application function is stringified — this was failing under coverage instrumentation with `cov_xxx is not defined`. Bundled with **rolldown**, which the ESM build already uses, so this adds no bundler dependency.
- **`boost.workerUrl`** points at a static script for strict CSP, shipped as `dist/billboard.worker.js`. **`boost.useWorker: "auto"`** offloads only past ~5,000 cells.
- **TextOverlap drops `d3-delaunay`** — `src/module/voronoi.ts` computes cells by half-plane clipping. The plugin's dynamic `import()` goes with it, so label positioning is synchronous again.
- **`axis.{x,y,y2}.axes` sub-axes render through `AxisRenderer`** instead of `d3-axis`.
- Text overlap measurements are batched before applying overlap classes.
- **The worker parity self-test runs on a sampled payload.** It posts a truncated copy of the arguments and compares that against the main thread, so the check costs a fixed amount instead of one full conversion. Re-parsing the real payload would hand back the very work the offload exists to avoid — and since `useWorker` only covers the initial conversion, a single-chart page paid it every time.

## Usage

Default — the worker source is inlined in the bundle and run through a `blob:` URL, so there is nothing extra to serve:

```js
bb.generate({
    boost: {useWorker: true},   // or "auto": offload only past ~5,000 cells
    data: {columns: [["data1", 30, 200, 100]], type: "line"}
});
```

Under a strict CSP that blocks `blob:` workers, serve the shipped script and point at it. **`useWorker` must stay on** — `workerUrl` only selects where the source comes from:

```js
// UMD
bb.generate({
    boost: {useWorker: true, workerUrl: "$YOUR_PATH/dist/billboard.worker.js"},
    data: {columns: [["data1", 30, 200, 100]]}
});
```

```js
// ESM — reachable as a package subpath
import bb, {bar} from "billboard.js";
import workerUrl from "billboard.js/dist/billboard.worker.js?url";

bb.generate({
    boost: {useWorker: true, workerUrl},
    data: {columns: [["data1", 30, 200, 100]], type: bar()}
});
```

The file is ~1.5KB, so Vite inlines it as a `data:` URI — which a strict CSP rejects the same way as `blob:`. Opt it out, or copy it into the served directory instead:

```js
// vite.config.js
export default {
    build: {
        assetsInlineLimit: path => /billboard\.worker\.js$/.test(path) ? false : undefined
    }
};
```

```sh
# bundler-agnostic alternative
cp node_modules/billboard.js/dist/billboard.worker.js public/
```

Any failure — load error, unknown op, timeout, result mismatch — falls back to the main thread.

## Fixes

`feat(subchart)` (37ec4b7c8) left two per-data-point costs in the main-chart render path:

- `getTargetValueMinMax()` called the subchart projection with `isSub` hardcoded `true`, defeating its `!isSub` early return — now resolved once per target.
- `getShapeYMin()` ran per point from the area `y0` accessor, resolving a scale and slicing its domain each time — now memoized per series, as `generateGetAreaPoints()` already did.

## Benchmarks

Measured against this PR's base, `b4fe41a54`, so these cover every commit in it. Release-over-release figures (4.0.3 → HEAD) are in [PERFORMANCE.md](https://github.com/naver/billboard.js/blob/c7a94cf1263bcb6b56aa697edd2b7d852bced6e4/PERFORMANCE.md) instead.

### Runtime

`generate()` on `dist/billboard.pkgd.min.js` in headless Chromium, deterministic seeded data, a fresh page per measurement. Builds are interleaved round-robin so machine drift hits both equally; n=30 per cell, median.

| scenario | `b4fe41a54` | this PR | delta |
|---|---:|---:|---:|
| Canvas 5x5000 area | 47.9 ms | 41.2 ms | **−14.0%** |
| Canvas 5x1000 area | 13.7 ms | 12.3 ms | **−10.2%** |
| SVG 5x1000 area | 39.5 ms | 36.3 ms | −7.9% |
| Canvas 5x5000 line | 32.9 ms | 31.9 ms | −3.0% |

This is the `feat(subchart)` regression above being paid back. The area scenarios gain most because both fixes sit in the area path.

### Delivered bytes

`gzip -9 -n`, since that is what a consumer downloads. The `-n` matters: `gzip -9 <file>` stores the filename and mtime in the header, so the figure moves with the filename.

| | `b4fe41a54` | this PR | delta |
|---|---:|---:|---:|
| `billboard.min.js` | 155,877 | 156,826 | **+949** |
| `billboard.pkgd.min.js` | 270,796 | 270,413 | **−383** |
| `billboard.worker.js` (new) | — | 834 | +834 |
| `billboardjs-plugin-textoverlap.js` (raw) | 14,216 | 10,729 | −3,487 |

The pre-bundled worker source is a string literal reachable from `convert.ts`, so it is **not tree-shakable** — the +949 is paid even with the default `useWorker: false`. `pkgd` comes out ahead because dropping `d3-axis` from core more than covers it.

### Voronoi trade-off

`voronoiCells()` is O(n²) where `d3-delaunay` is O(n log n), and it now runs synchronously on every redraw. Measured per call, bounds `[0, 0, 960, 500]`:

| sites | in-tree | `d3-delaunay` | ratio |
|---:|---:|---:|---:|
| 20 | 0.07 ms | 0.16 ms | 0.4× |
| 100 | 0.41 ms | 0.15 ms | 2.8× |
| 500 | 7.92 ms | 0.33 ms | 24× |
| 2000 | 120.87 ms | 1.23 ms | 99× |

Crossover is around 60 sites. That is the right trade for label placement, which runs on tens to hundreds of points, but a TextOverlap chart with many labels will block during zoom/pan where it previously did not. Parity with `d3-delaunay` is asserted by `test/module/voronoi-parity-spec.ts` across 15 random point sets plus collinear, cocircular-grid, bounds-edge and duplicate-site cases.

### Parity self-test cost

What the sampled check avoids doing on the main thread, per initial conversion at 100k cells:

| | time |
|---|---:|
| full `columns()` conversion | 2.08 ms |
| 2× `JSON.stringify` to compare | 4.62 ms |
| **total avoided** | **6.70 ms** |

Now a fixed 3 series × 3 values regardless of payload size, and the sample is posted before the real request so the check overlaps the real conversion rather than following it.

## Verification

- Full suite **2569 passed / 0 failed**; `lint` and `tsc --noEmit` clean.
- All build pipelines succeed: webpack `production` / `packaged` / `plugin` / `theme`, and the rolldown ESM build with `__WORKER_SRC__` fully substituted.
- The worker bundling was verified with `node_modules` synced to the lockfile, so `node_modules/esbuild` is absent — a lingering direct import would have failed rather than silently resolving a transitive copy.
- Worker environment matrix covered by `test/internals/boost-worker-env-spec.ts`: real worker, static `workerUrl`, blocked `Worker` constructor, blocked `blob:` URL, absent `Worker`/`Blob`, and both `"auto"` branches — every row ending in the same rendered chart.
- `test/module/module-coverage-spec.ts` asserts the main-thread converter sees 3×3 cells while the worker gets the whole payload.

