### PR TITLE
fix(util): Correctly detect empty objects with polluted prototype

### DIFF
--- a/src/module/util/type-checks.ts
+++ b/src/module/util/type-checks.ts
@@ -18,7 +18,9 @@ const isObjectType = (v: unknown): v is Record<string | number, any> => typeof v
 
 const isEmptyObject = (obj: object): boolean => {
 	for (const x in obj) {
-		return false;
+		if (Object.prototype.hasOwnProperty.call(obj, x)) {
+			return false;
+		}
 	}
 	return true;
 };

--- a/test/internals/util-spec.ts
+++ b/test/internals/util-spec.ts
@@ -4,11 +4,11 @@
  */
 /* eslint-disable */
 /* global describe, beforeEach, it, expect */
-import {describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it} from "vitest";
 import sinon from "sinon";
 import {timeParse as d3TimeParse} from "d3-time-format";
 import {window} from "../../src/module/browser";
-import {toArray, getBoundingRect, getCssRules, getPathBox, getPointer, getUnique, isArray, isNumber, sortValue, parseDate} from "../assets/module/util";
+import {toArray, getBoundingRect, getCssRules, getPathBox, getPointer, getUnique, isArray, isEmpty, isNumber, sortValue, parseDate} from "../assets/module/util";
 
 describe("UTIL", function() {
 	describe("toArray", () => {
@@ -207,6 +207,23 @@ describe("UTIL", function() {
 
 			// rollback
 			window.console = console;
+		});
+	});
+
+	describe("isEmpty", () => {
+		const polluteKey = "__bb_polluted__";
+
+		afterEach(() => {
+			delete Object.prototype[polluteKey];
+			delete Array.prototype[polluteKey];
+		});
+
+		it("should detect empty objects when their prototype is polluted", () => {
+			Object.prototype[polluteKey] = "polluted";
+			Array.prototype[polluteKey] = "polluted";
+
+			expect(isEmpty({})).to.be.true;
+			expect(isEmpty([])).to.be.true;
 		});
 	});
 });


### PR DESCRIPTION
I am integrating bollboard.js into a project using the SmartClient Framework, and after upgrade from 3.16.0 to 4.0.3 my charts broke with: 
```
TypeError: can't access property "create", point is undefined
      generatePoint billboard.pkgd.js:54562
      append billboard.pkgd.js:23715
      selection_select billboard.pkgd.js:23116
      append billboard.pkgd.js:23714
      updateCircle billboard.pkgd.js:54898
      redraw billboard.pkgd.js:42952
      initWithData billboard.pkgd.js:47024
      initToRender billboard.pkgd.js:46847
      runFn billboard.pkgd.js:37343
      convertData billboard.pkgd.js:37686
      initToRender billboard.pkgd.js:46846
      init billboard.pkgd.js:46821
      Chart billboard.pkgd.js:50635
      generate billboard.pkgd.js:65233
```
The above issue is caused by additional properties on `Array.prototype`, which cause the optimized `isEmptyObject` from 3.17.2 (added by commit a2e0f6e640688a56cbd3c632fcbfb741f2555915) to treat empty arrays as non-empty.

This PR adds an additional check to `isEmptyObject` to ensure that it works correctly in this situation.
