### PR TITLE
fix(grid): guard optional grid focus handlers

### DIFF
--- a/src/ChartInternal/interactions/eventrect.ts
+++ b/src/ChartInternal/interactions/eventrect.ts
@@ -646,7 +646,7 @@ export default {
 						}
 					}
 
-					$$.showAxisGridFocus();
+					$$.showAxisGridFocus?.();
 
 					const eventOnSameIdx = config.tooltip_grouped &&
 						index === eventReceiver.currentIdx;
@@ -692,7 +692,7 @@ export default {
 						return;
 					}
 
-					$$.hideAxisGridFocus();
+					$$.hideAxisGridFocus?.();
 
 					$$.unselectRect();
 					$$.setOverOut(false, eventReceiver.currentIdx);

--- a/test/esm/esm-spec.ts
+++ b/test/esm/esm-spec.ts
@@ -105,6 +105,31 @@ describe("ESM build", function() {
     });
 
     describe("Optional API modules", function() {
+        it("should handle hover without the optional grid module", () => {
+            chart = bb.bb.generate({
+                data: {
+                    columns: [["data1", 10, 20, 30]],
+                    type: bb.line()
+                }
+            });
+
+            const {eventRect} = chart.internal.$el;
+            const eventRectNode = eventRect.node();
+
+            chart.internal.getDataIndexFromEvent = () => 0;
+
+            expect(chart.internal.showAxisGridFocus).to.be.undefined;
+            expect(chart.internal.hideAxisGridFocus).to.be.undefined;
+            expect(() => eventRect.on("mousemove").call(
+                eventRectNode,
+                new MouseEvent("mousemove", {clientX: 100, clientY: 100})
+            )).to.not.throw();
+            expect(() => eventRect.on("mouseout").call(
+                eventRectNode,
+                new MouseEvent("mouseout")
+            )).to.not.throw();
+        });
+
         it("should export optional resolvers as functions", () => {
             expect(typeof bb.exportApi).to.equal("function");
             expect(typeof bb.flow).to.equal("function");


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4205

## Details
<!-- Detailed description of the change/feature -->
Guard axis grid focus handlers when the optional grid module is absent. 
Prevent ESM and React hover interactions from throwing at runtime. 
Preserve existing focus behavior when grid() is registered. 
Keep normal tooltip and event handling active without grid(). 
Add mousemove and mouseout regression coverage without grid().