### PR TITLE
feat(resize): add resize.live to follow the container while resizing

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -151,6 +151,70 @@ interleaved before acting on it.
   collect all `getBBox()`, `getBoundingClientRect()`, `offsetWidth`, and
   `getComputedTextLength()` reads before changing attributes, styles, or classes.
 
+## Resize Cost
+
+`resize.auto` runs a full redraw, delayed by `resize.timer` so a drag produces one
+redraw instead of one per event. Until that delayed call runs, the rendered surface
+keeps its previous pixel size. `resize.live` decides what happens in between.
+
+- `false` (default): nothing. The size changes only when the delayed redraw runs.
+- `true`: the chart follows the container on every animation frame. Only one frame is
+  ever pending, so events coalesce instead of queueing up.
+
+Which strategy `live: true` uses is measured, not configured. The first frame of a resize
+redraws and times itself; the duration decides the rest of that resize.
+
+- Within `RESIZE_FRAME_BUDGET` (16ms): every frame redraws, giving an exact rendering at
+  every size.
+- Over it: the rendering is stretched instead. The SVG `viewBox` is set to the drawn size
+  and the width/height attributes to the new size (canvas: the CSS box only, the backing
+  store untouched), so the browser scales the existing rendering. That costs a handful of
+  attribute writes per frame and no redraw. Pointer coordinates stay correct, as the
+  `hasViewBox()` branches map them back through the element CTM.
+
+The decision is taken once per resize, not per frame: alternating exact and stretched
+frames jitters. The measurement is kept in `state.resizeRedrawTime` across resizes, so a
+chart already known to be expensive stretches from the very first frame.
+
+Resize redraws are much cheaper than a data redraw: `flush()` skips the `dirty.data` flag
+so shape data joins don't run, and `getMaxTickSize()` returns the cached size while
+`state.resizing` is set, skipping the dummy axis and text measurement. Measured on a
+900x500 line chart:
+
+| data | SVG | canvas |
+|---|---|---|
+| 5 x 1,000 | 6.0ms | 2.8ms |
+| 5 x 5,000 | 31.4ms | 11.4ms |
+| 10 x 10,000 | 77.6ms | 53.4ms |
+
+So an ordinary chart redraws live and only the large ones fall back to stretching.
+
+The budget is measured per chart, and charts don't know about each other. On a page with
+several of them the per-frame total is what the browser pays, while each chart only sees
+its own share:
+
+| charts (2,000 points each) | per frame | measured per chart |
+|---|---|---|
+| 1 | 11.6ms | 11.6ms |
+| 4 | 40.1ms | 10.0ms |
+| 8 | 74.9ms | 9.4ms |
+
+Every one of those charts concludes it fits in a frame and keeps redrawing. That is why
+`live` stays opt-in and off by default: a dense dashboard should enable it on the charts
+the user actually watches while resizing. Closing this would mean accumulating the time
+all live-resizing charts spend in a frame and deciding against that total.
+
+`onresize` and `onresized` still fire once per resize, but `onrendered` is called on every
+redrawn frame while resizing.
+
+`resize.timer` keeps its role of deciding when the resize is finished, not when the size is
+reflected. With every frame redrawn it changes nothing on screen, as the last frame already
+drew the final size. While the rendering is stretched it decides how long that stretched
+rendering stays up after the resize stops, so a long delay is felt exactly on the charts
+large enough to be stretched. Measured over a 6 frame resize of a 10x10,000 chart: the
+exact rendering came back 346ms after the last event with `timer: 200`, and 1,148ms with
+`timer: 1000`.
+
 ## Worker Safety
 
 - **The worker source is pre-bundled at build time, never derived from

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -6660,6 +6660,20 @@ d3.select(".chart_area")
 				];
 			},
 		},
+		resizeLive: {
+			description: "Follow the container size while resizing. Redraws per frame when the chart draws within a frame, stretches the rendering when it doesn't.",
+			options: {
+				data: {
+					columns: [
+						["sample", 30, 200, 120, 400, 230, 250]
+					],
+					type: "line"
+				},
+				resize: {
+					live: true
+				}
+			}
+		},
 		resizeViewBox: [
 			{
 				options: {

--- a/src/Chart/api/chart.ts
+++ b/src/Chart/api/chart.ts
@@ -148,6 +148,7 @@ export default {
 			$$.canvasRenderer?.destroy();
 			$$.canvasEngine?.destroy();
 			$$.resizeFunction?.clear();
+			$$.resizeFunction?.clearLive?.();
 
 			$$.resizeFunction?.resizeObserver?.disconnect();
 			$$.resizeFunction && window.removeEventListener("resize", $$.resizeFunction);

--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -12,6 +12,7 @@ import {
 } from "d3-time-format";
 import type {d3Selection, d3Transition} from "../../types/types";
 import {$CIRCLE, $COMMON, $TEXT} from "../config/classes";
+import {RESIZE_FRAME_BUDGET} from "../config/const";
 import Options from "../config/Options/Options";
 import Store from "../config/Store/Store";
 import {document, window} from "../module/browser";
@@ -59,6 +60,15 @@ import tooltip from "./internals/tooltip";
 import transform from "./internals/transform";
 import typeInternals from "./internals/type";
 import shape from "./shape/shape";
+
+/**
+ * Get the current time in ms.
+ * @returns {number} Timestamp
+ * @private
+ */
+function getTime(): number {
+	return window.performance?.now?.() ?? Date.now();
+}
 
 /**
  * Get SVG-only chart type reason for canvas render fallback.
@@ -876,42 +886,79 @@ export default class ChartInternal {
 	bindResize(): void {
 		const $$ = <any>this;
 		const {$el, config, state} = $$;
-		const resizeFunction = generateResize(config.resize_timer);
-		const {resize_auto} = config;
+		const {resize_auto, resize_live} = config;
+		const isAutoResize = /^(true|parent)$/.test(resize_auto);
 		const list: (() => void)[] = [];
+
+		const redrawOnResize = (): boolean => {
+			// Skip resize if dimensions haven't changed
+			const prevWidth = state.current.width;
+			const prevHeight = state.current.height;
+
+			$$.setContainerSize();
+
+			if (
+				!state.resizePreview &&
+				prevWidth === state.current.width &&
+				prevHeight === state.current.height
+			) {
+				return false;
+			}
+
+			state.resizing = true;
+			state.dirty.size = true;
+
+			// https://github.com/naver/billboard.js/issues/2650
+			if (config.legend_show) {
+				$$.updateSizes();
+				state.isCanvasMode ? $$.updateHtmlLegend?.() : $$.updateLegend();
+			}
+
+			$$.api.flush(false);
+
+			return true;
+		};
+
+		// Called on every animation frame while resizing, before the delayed call.
+		// Redraws when the chart draws within a frame, and stretches the rendering
+		// when it doesn't: the size follows the container either way.
+		const liveResize = () => {
+			// Decided once per resize and kept until it settles, as alternating exact
+			// and stretched frames jitters. The measured time outlives the resize, so a
+			// chart already known to be expensive stretches from the very first frame.
+			if (state.resizeLiveScale === null) {
+				state.resizeLiveScale = state.resizeRedrawTime > RESIZE_FRAME_BUDGET;
+			}
+
+			if (state.resizeLiveScale) {
+				$$.previewResize();
+				return;
+			}
+
+			const start = getTime();
+
+			if (redrawOnResize()) {
+				state.resizeRedrawTime = getTime() - start;
+
+				// A redraw that missed the frame stretches the rest of this resize. The
+				// switch only goes this way, so frames can't alternate exact/stretched.
+				state.resizeLiveScale = state.resizeRedrawTime > RESIZE_FRAME_BUDGET;
+			}
+		};
+
+		const resizeFunction = generateResize(
+			config.resize_timer,
+			isAutoResize && resize_live ? liveResize : undefined
+		);
 
 		list.push(() => callFn(config.onresize, $$.api));
 
-		if (/^(true|parent)$/.test(resize_auto)) {
-			list.push(() => {
-				// Skip resize if dimensions haven't changed
-				const prevWidth = state.current.width;
-				const prevHeight = state.current.height;
-
-				$$.setContainerSize();
-
-				if (
-					prevWidth === state.current.width &&
-					prevHeight === state.current.height
-				) {
-					return;
-				}
-
-				state.resizing = true;
-
-				// https://github.com/naver/billboard.js/issues/2650
-				if (config.legend_show) {
-					$$.updateSizes();
-					state.isCanvasMode ? $$.updateHtmlLegend?.() : $$.updateLegend();
-				}
-
-				$$.api.flush(false);
-			});
-		}
+		isAutoResize && list.push(redrawOnResize);
 
 		list.push(() => {
 			callFn(config.onresized, $$.api);
 			state.resizing = false;
+			state.resizeLiveScale = null;
 		});
 
 		// add resize functions

--- a/src/ChartInternal/internals/size.ts
+++ b/src/ChartInternal/internals/size.ts
@@ -36,8 +36,30 @@ export default {
 
 	getCurrentHeight(): number {
 		const $$ = this;
-		const {config} = $$;
-		const h = config.size_height || $$.getParentHeight();
+		const {config, state, $el} = $$;
+		let h = config.size_height;
+
+		if (!h) {
+			// The min-height reserved for the canvas surface is this element's own
+			// output. Measuring with it in place makes it the floor of every later
+			// measurement, so the chart could never shrink vertically.
+			const chartNode = state.isCanvasMode ? $el.chart?.node() : null;
+			const minHeight = chartNode?.style.minHeight;
+
+			minHeight && (chartNode.style.minHeight = "");
+			h = $$.getParentHeight();
+			minHeight && (chartNode.style.minHeight = minHeight);
+
+			// Without a height of its own, the container collapses onto the canvas,
+			// which is drawn shorter than the chart by the bottom legend's room. The
+			// legend is positioned absolutely, so it adds nothing back: keep that room.
+			const surface = chartNode ? parseFloat($$.canvasEngine?.canvas.style.height) || 0 : 0;
+			const reserve = state.current.height - surface;
+
+			if (reserve > 0 && Math.round(h) === Math.round(surface)) {
+				h += reserve;
+			}
+		}
 
 		return h > 0 ? h : 320 / ($$.hasType("gauge") && !config.gauge_fullCircle ? 2 : 1);
 	},
@@ -135,6 +157,78 @@ export default {
 		return result;
 	},
 
+	/**
+	 * Stretch the rendered surface to the container's current size, without redrawing.
+	 * Gives an immediate size feedback while the delayed resize is pending.
+	 * The drawn content keeps its previous geometry until the redraw takes place.
+	 * @private
+	 */
+	previewResize(): void {
+		const $$ = this;
+		const {state, $el} = $$;
+		const {current} = state;
+		const width = $$.getCurrentWidth();
+		const height = $$.getCurrentHeight();
+
+		if (
+			!width || !height || !current.width || !current.height ||
+			(width === current.width && height === current.height)
+		) {
+			return;
+		}
+
+		if (state.isCanvasMode) {
+			const canvas = $$.canvasEngine?.canvas;
+
+			if (!canvas) {
+				return;
+			}
+
+			// Bottom legend is a DOM node keeping its own height, so only the
+			// remaining surface stretches.
+			$el.chart.style("min-height", `${height}px`);
+			canvas.style.width = `${width}px`;
+			canvas.style.height = `${
+				Math.max(0, height - ($$.getCanvasBottomLegendHeight?.() ?? 0))
+			}px`;
+		} else if ($el.svg) {
+			// viewBox of the drawn size + the new size as the layout box stretches the
+			// rendering exactly to the container. Pointer coordinates stay correct, as
+			// the viewBox branches(hasViewBox) map them back through the CTM.
+			$el.svg
+				.attr("viewBox", `0 0 ${current.width} ${current.height}`)
+				.attr("preserveAspectRatio", "none")
+				.attr("width", width)
+				.attr("height", height);
+		} else {
+			return;
+		}
+
+		state.resizePreview = true;
+	},
+
+	/**
+	 * Drop the stretched state set by previewResize(), to render on exact pixels again.
+	 * @private
+	 */
+	clearResizePreview(): void {
+		const $$ = this;
+		const {config, state, $el} = $$;
+
+		if (!state.resizePreview) {
+			return;
+		}
+
+		state.resizePreview = false;
+
+		// canvas surfaces are restored by resizeCanvas()
+		if (!state.isCanvasMode && $el.svg && config.resize_auto !== "viewBox") {
+			$el.svg
+				.attr("viewBox", null)
+				.attr("preserveAspectRatio", null);
+		}
+	},
+
 	updateDimension(withoutAxis?: boolean): void {
 		const $$ = this;
 		const {config, state: {hasAxis, isCanvasMode}, $el} = $$;
@@ -163,6 +257,9 @@ export default {
 			$$.resizeCanvas?.();
 			return;
 		}
+
+		// about to draw on exact pixels: drop any stretched state
+		$$.clearResizePreview();
 
 		if (config.resize_auto === "viewBox") {
 			svg

--- a/src/config/Options/common/main.ts
+++ b/src/config/Options/common/main.ts
@@ -168,12 +168,50 @@ export default {
 	 *   - false: Disables automatic resize.
 	 *   - "parent": Enables automatic resize when the parent node is resized.
 	 *   - "viewBox": Enables automatic resize, and size will be fixed based on the viewbox.
+	 * - **NOTE:** `true` listens to the window's resize event, so a container resized by anything
+	 *   else(a splitter drag, a sibling element growing, a CSS resize handle) is not detected.
+	 *   Use `"parent"`, which observes the parent node itself, for those.
 	 * @property {boolean|number} [resize.timer=true] Set resize timer option.
 	 * - **NOTE:** Available options
 	 *   - The resize function will be called using:
 	 *     - true: `setTimeout()`
 	 *     - false: `requestIdleCallback()`
 	 *   - Given number(delay in ms) value, resize function will be triggered using `setTimeout()` with given delay.
+	 * - **NOTE:** With `resize.live`, this no longer decides when the size is reflected(every
+	 *   animation frame does), but when the resize is treated as finished:
+	 *   - `onresize`/`onresized` are called then, as they are without it.
+	 *   - When the rendering is being stretched, this is also when it's redrawn to the exact
+	 *     size. The stretched rendering stays on screen for this long after the resize stops,
+	 *     so keep the delay short for charts large enough to be stretched.
+	 *   - When every frame is redrawn, the last frame already drew the final size, so the
+	 *     delayed call changes nothing on screen.
+	 * @property {boolean} [resize.live=false] Follow the container size while resizing, instead of
+	 * only when the delayed resize(`resize.timer`) runs.
+	 * - **NOTE:** Applies only when `resize.auto` is `true` or `"parent"`.
+	 * - **Strategy:** How the size is followed is measured, not configured. Two of them are used:
+	 *   - **Redraw**: while a resize redraw fits in one animation frame(16ms), the chart is
+	 *     redrawn on every frame, giving an exact rendering at every size.
+	 *   - **Stretch**: once a redraw misses that budget, the rendering is stretched to the new
+	 *     size for the rest of the resize, and redrawn when the resize settles. Stretching runs
+	 *     no redraw at all: for SVG the `viewBox` is set to the drawn size and the width/height
+	 *     attributes to the new one, and for canvas only the element's CSS box is resized, with
+	 *     the backing store left as is. The size keeps following the container at any data amount.
+	 * - **Switching:** within a resize the strategy only goes from redraw to stretch, never back,
+	 *   so frames can't alternate between an exact and a stretched rendering. The measured time
+	 *   outlives the resize, so a chart already known to be expensive stretches from the first
+	 *   frame of the next one.
+	 * - **While stretched:** text and stroke width are scaled with the box(SVG) and the drawn
+	 *   bitmap is upscaled(canvas). Interaction is unaffected, as pointer coordinates are mapped
+	 *   back through the element's transform. The redraw on settle restores the exact rendering.
+	 * - **Cost:** resize redraws skip the shape data join and the axis tick measurement, so they
+	 *   are far cheaper than an initial render. A 5x1,000 line chart redraws in about 6ms(SVG)
+	 *   and 3ms(canvas), a 10x10,000 one in about 78ms and 53ms. Ordinary charts therefore redraw
+	 *   on every frame, and only the large ones fall back to stretching.
+	 * - **Several charts on a page:** the budget is measured per chart, and charts don't know
+	 *   about each other. Eight charts of 2,000 points each spend about 75ms per frame together
+	 *   while each one measures about 9ms and keeps redrawing. Turn it on for the charts the user
+	 *   actually watches while resizing, rather than for every chart on a dense page.
+	 * - `onrendered` is called on every redrawn frame while resizing, not once per resize.
 	 * @see [Demo: resize "parent"](https://naver.github.io/billboard.js/demo/#ChartOptions.resizeParent)
 	 * @see [Demo: resize "viewBox"](https://naver.github.io/billboard.js/demo/#ChartOptions.resizeViewBox)
 	 * @example
@@ -193,11 +231,15 @@ export default {
 	 *      timer: false,
 	 *
 	 *      // set resize function will be triggered using `setTimeout()` with a delay of `100ms`.
-	 *      timer: 100
+	 *      timer: 100,
+	 *
+	 *      // follow the container size while resizing
+	 *      live: true
 	 *  }
 	 */
 	resize_auto: <boolean | "parent" | "viewBox">true,
 	resize_timer: true,
+	resize_live: false,
 
 	/**
 	 * Set a callback to execute when the chart is clicked.

--- a/src/config/Store/State.ts
+++ b/src/config/Store/State.ts
@@ -162,6 +162,10 @@ export default class State {
 			transiting: false,
 			redrawing: false, // if redraw() is on process
 			resizing: false, // resize event called
+			resizePreview: false, // rendered surface is stretched, pending an exact redraw
+			resizeRedrawTime: 0, // ms the last resize redraw took, decides resize.live strategy
+			// stretch instead of redrawing for the rest of this resize; null until decided
+			resizeLiveScale: <boolean | null>null,
 			toggling: false, // legend toggle
 			zooming: false,
 			hasNegativeValue: false,

--- a/src/config/const.ts
+++ b/src/config/const.ts
@@ -49,6 +49,10 @@ export const API_MODULE_NEEDED = {
  * Axis rendering constants shared by SVG and canvas renderers.
  * @private
  */
+// A resize redraw costing more than one frame makes the whole drag stretch the
+// rendering instead of redrawing it. 16ms is the budget of a 60fps frame.
+export const RESIZE_FRAME_BUDGET = 16;
+
 export const AXIS_DEFAULT_TICK_COUNT = 10;
 export const AXIS_TICK_SIZE = 6;
 export const AXIS_TICK_PADDING = 3;

--- a/src/config/resolver/canvas.ts
+++ b/src/config/resolver/canvas.ts
@@ -3208,6 +3208,9 @@ const canvasInternal = {
 		const {config, state, $el} = $$;
 		const container = $el.chart.node();
 
+		// about to draw on exact pixels: drop any stretched state
+		$$.clearResizePreview();
+
 		$el.chart.style("min-height", `${state.current.height}px`);
 		$$.canvasEngine?.resize(state.current.width, $$.getCanvasSurfaceHeight());
 		$$.canvasTheme?.reload(container, config.canvas_theme);

--- a/src/module/generator.ts
+++ b/src/module/generator.ts
@@ -3,7 +3,13 @@
  * billboard.js project is licensed under the MIT license
  */
 import type {d3Transition} from "../../types/types";
-import {cancelIdleCallback, requestIdleCallback, window} from "./browser";
+import {
+	cancelAnimationFrame,
+	cancelIdleCallback,
+	requestAnimationFrame,
+	requestIdleCallback,
+	window
+} from "./browser";
 import {isArray, isNumber, isTabVisible, runUntil} from "./util";
 
 const {setTimeout, clearTimeout} = window;
@@ -11,16 +17,28 @@ const {setTimeout, clearTimeout} = window;
 /**
  * Generate resize queue function
  * @param {boolean|number} option Resize option
+ * @param {()=>void} live Called on every resize event, throttled by animation frame.
+ *  Used to reflect the size change before the delayed call takes place.
  * @returns {Fucntion}
  * @private
  */
-export function generateResize(option: boolean | number) {
+export function generateResize(option: boolean | number, live?: Function) {
 	const fn: Function[] = [];
 	let timeout;
+	let rafId: number | null = null;
 
 	const callResizeFn = function() {
 		// Delay all resize functions call, to prevent unintended excessive call from resize event
 		callResizeFn.clear();
+
+		// One pending frame at most: when the live call takes longer than a frame,
+		// events coalesce instead of piling up.
+		if (live && rafId === null) {
+			rafId = requestAnimationFrame(() => {
+				rafId = null;
+				live();
+			});
+		}
 
 		if (option === false) {
 			timeout = requestIdleCallback(() => {
@@ -39,6 +57,13 @@ export function generateResize(option: boolean | number) {
 		if (timeout) {
 			(option === false ? cancelIdleCallback : clearTimeout)(timeout);
 			timeout = null;
+		}
+	};
+
+	callResizeFn.clearLive = () => {
+		if (rafId !== null) {
+			cancelAnimationFrame(rafId);
+			rafId = null;
 		}
 	};
 

--- a/test/internals/resize-live-canvas-spec.ts
+++ b/test/internals/resize-live-canvas-spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+import {afterEach, beforeAll, describe, expect, it} from "vitest";
+import bb, {canvas, line} from "../../src/index.canvas";
+import {RESIZE_FRAME_BUDGET} from "../../src/config/const";
+
+describe("resize.live - canvas", () => {
+	let chart;
+	let container;
+
+	const INITIAL_WIDTH = 360;
+	const RESIZED_WIDTH = 240;
+	const TIMER = 500;
+
+	beforeAll(() => {
+		canvas();
+	});
+
+	afterEach(() => {
+		chart?.destroy();
+		container?.remove();
+		chart = null;
+		container = null;
+	});
+
+	function nextFrame(): Promise<void> {
+		return new Promise(resolve => {
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+		});
+	}
+
+	function generate(live) {
+		container = document.createElement("div");
+		container.style.cssText =
+			`position:absolute;top:0;left:0;width:${INITIAL_WIDTH}px;height:260px;`;
+		document.body.appendChild(container);
+
+		return (chart = bb.generate({
+			bindto: container,
+			render: {
+				mode: canvas()
+			},
+			transition: {
+				duration: 0
+			},
+			resize: {
+				live,
+				timer: TIMER
+			},
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40]
+				],
+				type: line()
+			}
+		}));
+	}
+
+	function shrink() {
+		container.style.width = `${RESIZED_WIDTH}px`;
+		chart.internal.resizeFunction();
+	}
+
+	it("should stretch the surface without resizing the backing store when too slow", async () => {
+		generate(true);
+
+		const {internal} = chart;
+		const canvasEl = internal.canvasEngine.canvas;
+		const backingWidth = canvasEl.width;
+
+		// as if the previous redraw had been too expensive to run per frame
+		internal.state.resizeRedrawTime = RESIZE_FRAME_BUDGET + 1;
+
+		shrink();
+		await nextFrame();
+
+		// CSS box follows the container, drawn bitmap is left as is
+		expect(canvasEl.style.width).to.be.equal(`${RESIZED_WIDTH}px`);
+		expect(canvasEl.width).to.be.equal(backingWidth);
+		expect(internal.state.current.width).to.be.equal(INITIAL_WIDTH);
+		expect(internal.state.resizePreview).to.be.true;
+
+		await new Promise(resolve => setTimeout(resolve, TIMER + 300));
+
+		expect(canvasEl.style.width).to.be.equal(`${RESIZED_WIDTH}px`);
+		expect(canvasEl.width).to.be.below(backingWidth);
+		expect(internal.state.current.width).to.be.equal(RESIZED_WIDTH);
+		expect(internal.state.resizePreview).to.be.false;
+	});
+
+	it("should resize the backing store on the animation frame when fast enough", async () => {
+		generate(true);
+
+		const {internal} = chart;
+		const canvasEl = internal.canvasEngine.canvas;
+		const backingWidth = canvasEl.width;
+
+		shrink();
+		await nextFrame();
+
+		expect(canvasEl.width).to.be.below(backingWidth);
+		expect(internal.state.current.width).to.be.equal(RESIZED_WIDTH);
+		expect(internal.state.resizePreview).to.be.false;
+	});
+
+	it("should follow the container's height when it shrinks", async () => {
+		generate(false);
+
+		const {internal} = chart;
+
+		expect(Math.round(internal.state.current.height)).to.be.equal(260);
+
+		container.style.height = "180px";
+		chart.internal.resizeFunction();
+
+		await new Promise(resolve => setTimeout(resolve, TIMER + 300));
+
+		// the min-height reserved for the surface must not become the floor here
+		expect(Math.round(internal.state.current.height)).to.be.equal(180);
+		expect(+internal.canvasEngine.canvas.style.height.replace("px", ""))
+			.to.be.below(180 + 1);
+	});
+
+	it("should keep the height of a container sized by its content", async () => {
+		container = document.createElement("div");
+		container.style.cssText = `position:absolute;top:0;left:0;width:${INITIAL_WIDTH}px;`;
+		document.body.appendChild(container);
+
+		chart = bb.generate({
+			bindto: container,
+			render: {mode: canvas()},
+			transition: {duration: 0},
+			resize: {timer: TIMER},
+			legend: {position: "bottom"},
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40]
+				],
+				type: line()
+			}
+		});
+
+		const {internal} = chart;
+		const height = internal.state.current.height;
+
+		expect(height).to.be.above(0);
+
+		// the container has no height of its own: repeated resizes must not drift
+		for (let i = 0; i < 3; i++) {
+			container.style.width = `${INITIAL_WIDTH - (i + 1) * 40}px`;
+			chart.internal.resizeFunction();
+
+			await new Promise(resolve => setTimeout(resolve, TIMER + 200));
+
+			expect(internal.state.current.height).to.be.equal(height);
+		}
+	});
+
+	it("shouldn't touch the surface before the delayed resize on default", async () => {
+		generate(false);
+
+		const {internal} = chart;
+		const canvasEl = internal.canvasEngine.canvas;
+		const backingWidth = canvasEl.width;
+
+		shrink();
+		await nextFrame();
+
+		expect(canvasEl.width).to.be.equal(backingWidth);
+		expect(internal.state.current.width).to.be.equal(INITIAL_WIDTH);
+	});
+});

--- a/test/internals/resize-live-spec.ts
+++ b/test/internals/resize-live-spec.ts
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/* eslint-disable */
+import {afterEach, describe, expect, it} from "vitest";
+import bb from "../../src/index";
+import {RESIZE_FRAME_BUDGET} from "../../src/config/const";
+
+describe("resize.live", () => {
+	let chart;
+	let container;
+
+	const INITIAL_WIDTH = 360;
+	const RESIZED_WIDTH = 240;
+	const TIMER = 500;
+
+	afterEach(() => {
+		chart?.destroy();
+		container?.remove();
+		chart = null;
+		container = null;
+	});
+
+	/**
+	 * Wait for the animation frame the live call is scheduled on.
+	 */
+	function nextFrame(): Promise<void> {
+		return new Promise(resolve => {
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+		});
+	}
+
+	function settle(): Promise<void> {
+		return new Promise(resolve => setTimeout(resolve, TIMER + 300));
+	}
+
+	function generate(live) {
+		container = document.createElement("div");
+		container.style.cssText =
+			`position:absolute;top:0;left:0;width:${INITIAL_WIDTH}px;height:260px;`;
+		document.body.appendChild(container);
+
+		return (chart = bb.generate({
+			bindto: container,
+			transition: {
+				duration: 0
+			},
+			resize: {
+				live,
+				timer: TIMER
+			},
+			data: {
+				columns: [
+					["data1", 30, 200, 100, 400],
+					["data2", 50, 20, 10, 40]
+				],
+				type: "line"
+			}
+		}));
+	}
+
+	function shrink() {
+		container.style.width = `${RESIZED_WIDTH}px`;
+		chart.internal.resizeFunction();
+	}
+
+	describe("default(false)", () => {
+		it("shouldn't reflect the size before the delayed resize runs", async () => {
+			generate(false);
+
+			const {svg} = chart.internal.$el;
+
+			shrink();
+			await nextFrame();
+
+			expect(+svg.attr("width")).to.be.equal(INITIAL_WIDTH);
+			expect(svg.attr("viewBox")).to.be.null;
+
+			await settle();
+
+			expect(+svg.attr("width")).to.be.equal(RESIZED_WIDTH);
+		});
+	});
+
+	describe("true", () => {
+		it("should redraw on the animation frame when it draws within a frame", async () => {
+			generate(true);
+
+			const {internal} = chart;
+			const {svg} = internal.$el;
+
+			shrink();
+			await nextFrame();
+
+			expect(+svg.attr("width")).to.be.equal(RESIZED_WIDTH);
+			expect(internal.state.current.width).to.be.equal(RESIZED_WIDTH);
+
+			// exact rendering: no stretching involved
+			expect(svg.attr("viewBox")).to.be.null;
+			expect(internal.state.resizePreview).to.be.false;
+		});
+
+		it("should measure the redraw to decide the strategy", async () => {
+			generate(true);
+
+			const {internal} = chart;
+
+			expect(internal.state.resizeRedrawTime).to.be.equal(0);
+
+			shrink();
+			await nextFrame();
+
+			// a chart this small draws well within a frame
+			expect(internal.state.resizeRedrawTime).to.be.above(0);
+			expect(internal.state.resizeRedrawTime).to.be.below(RESIZE_FRAME_BUDGET);
+			expect(internal.state.resizeLiveScale).to.be.false;
+		});
+
+		it("should stretch instead when the redraw doesn't fit in a frame", async () => {
+			generate(true);
+
+			const {internal} = chart;
+			const {svg} = internal.$el;
+
+			// as if the previous redraw had been too expensive
+			internal.state.resizeRedrawTime = RESIZE_FRAME_BUDGET + 1;
+
+			shrink();
+			await nextFrame();
+
+			// stretched: layout box is the new size, drawn size kept as viewBox
+			expect(+svg.attr("width")).to.be.equal(RESIZED_WIDTH);
+			expect(svg.attr("viewBox")).to.be.equal(`0 0 ${INITIAL_WIDTH} 260`);
+			expect(svg.attr("preserveAspectRatio")).to.be.equal("none");
+			expect(internal.state.resizePreview).to.be.true;
+			expect(internal.state.resizeLiveScale).to.be.true;
+
+			// drawn geometry isn't touched until the resize settles
+			expect(internal.state.current.width).to.be.equal(INITIAL_WIDTH);
+
+			await settle();
+
+			expect(svg.attr("viewBox")).to.be.null;
+			expect(svg.attr("preserveAspectRatio")).to.be.null;
+			expect(internal.state.current.width).to.be.equal(RESIZED_WIDTH);
+			expect(internal.state.resizePreview).to.be.false;
+			expect(internal.state.resizeLiveScale).to.be.null;
+		});
+
+		it("should switch to stretching once a redraw misses the frame", async () => {
+			generate(true);
+
+			const {internal} = chart;
+			const {svg} = internal.$el;
+			const redraw = internal.redraw;
+
+			// make the redraw miss the frame budget
+			internal.redraw = function(...args) {
+				const end = Date.now() + RESIZE_FRAME_BUDGET + 5;
+
+				while (Date.now() < end) {
+					// busy wait
+				}
+
+				return redraw.apply(this, args);
+			};
+
+			shrink();
+			await nextFrame();
+
+			// the first frame still redraws: that's what measures the cost
+			expect(internal.state.current.width).to.be.equal(RESIZED_WIDTH);
+			expect(internal.state.resizeRedrawTime).to.be.above(RESIZE_FRAME_BUDGET);
+			expect(internal.state.resizeLiveScale).to.be.true;
+
+			// from here on the rendering is stretched instead
+			container.style.width = "300px";
+			chart.internal.resizeFunction();
+			await nextFrame();
+
+			expect(+svg.attr("width")).to.be.equal(300);
+			expect(svg.attr("viewBox")).to.be.equal(`0 0 ${RESIZED_WIDTH} 260`);
+			expect(internal.state.current.width).to.be.equal(RESIZED_WIDTH);
+
+			internal.redraw = redraw;
+		});
+
+		it("should keep the strategy for the whole resize", async () => {
+			generate(true);
+
+			const {internal} = chart;
+
+			internal.state.resizeRedrawTime = RESIZE_FRAME_BUDGET + 1;
+
+			shrink();
+			await nextFrame();
+
+			expect(internal.state.resizeLiveScale).to.be.true;
+
+			// a cheap measurement arriving mid resize must not flip the strategy
+			internal.state.resizeRedrawTime = 0;
+
+			container.style.width = "300px";
+			chart.internal.resizeFunction();
+			await nextFrame();
+
+			expect(internal.state.resizeLiveScale).to.be.true;
+			expect(internal.state.current.width).to.be.equal(INITIAL_WIDTH);
+		});
+
+		it("should redraw on settle even when the size returns to the drawn one", async () => {
+			generate(true);
+
+			const {internal} = chart;
+			const {svg} = internal.$el;
+
+			internal.state.resizeRedrawTime = RESIZE_FRAME_BUDGET + 1;
+
+			shrink();
+			await nextFrame();
+
+			expect(internal.state.resizePreview).to.be.true;
+
+			// back to the drawn size before the delayed resize runs
+			container.style.width = `${INITIAL_WIDTH}px`;
+			chart.internal.resizeFunction();
+
+			await settle();
+
+			expect(svg.attr("viewBox")).to.be.null;
+			expect(+svg.attr("width")).to.be.equal(INITIAL_WIDTH);
+			expect(internal.state.resizePreview).to.be.false;
+		});
+
+		it("should drop the stretched state on an explicit redraw", async () => {
+			generate(true);
+
+			const {internal} = chart;
+			const {svg} = internal.$el;
+
+			internal.state.resizeRedrawTime = RESIZE_FRAME_BUDGET + 1;
+
+			shrink();
+			await nextFrame();
+
+			expect(internal.state.resizePreview).to.be.true;
+
+			chart.flush();
+
+			expect(svg.attr("viewBox")).to.be.null;
+			expect(svg.attr("preserveAspectRatio")).to.be.null;
+			expect(internal.state.resizePreview).to.be.false;
+		});
+	});
+});

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -209,6 +209,9 @@ export interface ChartOptions {
 		 *   - false: Disables automatic resize.
 		 *   - "parent": Enables automatic resize when the parent node is resized.
 		 *   - "viewBox": Enables automatic resize, and size will be fixed based on the viewbox.
+		 * - **NOTE:** `true` listens to the window's resize event, so a container resized by anything else(a splitter drag,
+		 *   a sibling element growing, a CSS resize handle) is not detected. Use `"parent"`, which observes the parent node
+		 *   itself, for those.
 		 */
 		auto?: boolean | "parent" | "viewBox";
 
@@ -217,8 +220,43 @@ export interface ChartOptions {
 		 * - **NOTE:**
 		 *   - The resize function will be called using: true - `setTimeout()`, false - `requestIdleCallback()`.
 		 *   - Given number(delay in ms) value, resize function will be triggered using `setTimer()` with given delay.
+		 * - **NOTE:** With `resize.live`, this no longer decides when the size is reflected(every animation frame does), but
+		 *   when the resize is treated as finished:
+		 *   - `onresize`/`onresized` are called then, as they are without it.
+		 *   - When the rendering is being stretched, this is also when it's redrawn to the exact size. The stretched
+		 *     rendering stays on screen for this long after the resize stops, so keep the delay short for charts large
+		 *     enough to be stretched.
+		 *   - When every frame is redrawn, the last frame already drew the final size, so the delayed call changes nothing
+		 *     on screen.
 		 */
 		timer?: boolean | number;
+
+		/**
+		 * Follow the container size while resizing, instead of only when the delayed resize(`resize.timer`) runs.
+		 * - **NOTE:** Applies only when `resize.auto` is `true` or `"parent"`.
+		 * - **Strategy:** How the size is followed is measured, not configured. Two of them are used:
+		 *   - **Redraw**: while a resize redraw fits in one animation frame(16ms), the chart is redrawn on every frame,
+		 *     giving an exact rendering at every size.
+		 *   - **Stretch**: once a redraw misses that budget, the rendering is stretched to the new size for the rest of
+		 *     the resize, and redrawn when the resize settles. Stretching runs no redraw at all: for SVG the `viewBox` is
+		 *     set to the drawn size and the width/height attributes to the new one, and for canvas only the element's CSS
+		 *     box is resized, with the backing store left as is.
+		 * - **Switching:** within a resize the strategy only goes from redraw to stretch, never back, so frames can't
+		 *   alternate between an exact and a stretched rendering. The measured time outlives the resize, so a chart already
+		 *   known to be expensive stretches from the first frame of the next one.
+		 * - **While stretched:** text and stroke width are scaled with the box(SVG) and the drawn bitmap is
+		 *   upscaled(canvas). Interaction is unaffected, as pointer coordinates are mapped back through the element's
+		 *   transform. The redraw on settle restores the exact rendering.
+		 * - **Cost:** resize redraws skip the shape data join and the axis tick measurement, so they are far cheaper than an
+		 *   initial render. A 5x1,000 line chart redraws in about 6ms(SVG) and 3ms(canvas), a 10x10,000 one in about 78ms
+		 *   and 53ms. Ordinary charts therefore redraw on every frame, and only the large ones fall back to stretching.
+		 * - **Several charts on a page:** the budget is measured per chart, and charts don't know about each other. Eight
+		 *   charts of 2,000 points each spend about 75ms per frame together while each one measures about 9ms and keeps
+		 *   redrawing. Turn it on for the charts the user actually watches while resizing, rather than for every chart on a
+		 *   dense page.
+		 * - `onrendered` is called on every redrawn frame while resizing, not once per resize.
+		 */
+		live?: boolean;
 	};
 
 	color?: {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#4219


## Details
<!-- Detailed description of the change/feature -->
resize.timer delays the redraw, so the chart kept its previous pixel size while the container was being dragged. resize.live follows it in between.

How the size is followed is measured, not configured. While a resize redraw fits in one animation frame(16ms) the chart is redrawn every frame; once a redraw misses that budget the rendering is stretched to the new size for the rest of the resize and redrawn when it settles. The switch only goes one way within a resize, so frames can't alternate between exact and stretched, and the measured time outlives the resize so an expensive chart stretches from the first frame of the next one.

Stretching writes the viewBox and the width/height attributes for SVG, and the CSS box alone for canvas, leaving the backing store as is. Pointer coordinates keep working through the existing hasViewBox() branches.

```js
resize: {
    live: true
}
```

<img width="1012" height="618" alt="Sep-11-2026 15-24-12" src="https://github.com/user-attachments/assets/42db6280-0f7e-4f3f-96dc-80b9fe996dc4" />
